### PR TITLE
claude.ai code Work on Issue 49

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
@@ -1,0 +1,112 @@
+using System.Globalization;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderInstructionsTests : AcceptanceTestBase
+{
+    [Test]
+    public async Task ShouldCreateWorkOrderWith4000CharacterInstructions()
+    {
+        await LoginAsCurrentUser();
+
+        await Page.GetByTestId(nameof(NavMenu.Elements.NewWorkOrder)).ClickAsync();
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+        var longInstructions = new string('X', 4000);
+
+        await Input(nameof(WorkOrderManage.Elements.Title), "Test Long Instructions");
+        await Input(nameof(WorkOrderManage.Elements.Description), "Testing 4000 character instructions");
+        await Input(nameof(WorkOrderManage.Elements.Instructions), longInstructions);
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), "101");
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var workOrderLinks = await Page.GetByTestId(new Regex($"{nameof(WorkOrderSearch.Elements.WorkOrderLink)}.*")).AllAsync();
+        var firstLink = workOrderLinks.First();
+        var orderNumber = await firstLink.TextContentAsync();
+
+        await firstLink.ClickAsync();
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        var instructionsValue = await instructionsField.InputValueAsync();
+
+        Assert.That(instructionsValue, Is.EqualTo(longInstructions));
+        Assert.That(instructionsValue!.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public async Task ShouldCreateWorkOrderWithEmptyInstructions()
+    {
+        await LoginAsCurrentUser();
+
+        await Page.GetByTestId(nameof(NavMenu.Elements.NewWorkOrder)).ClickAsync();
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+        await Input(nameof(WorkOrderManage.Elements.Title), "Test Empty Instructions");
+        await Input(nameof(WorkOrderManage.Elements.Description), "Testing empty instructions field");
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), "102");
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var workOrderLinks = await Page.GetByTestId(new Regex($"{nameof(WorkOrderSearch.Elements.WorkOrderLink)}.*")).AllAsync();
+        var firstLink = workOrderLinks.First();
+        var orderNumber = await firstLink.TextContentAsync();
+
+        await firstLink.ClickAsync();
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        var instructionsValue = await instructionsField.InputValueAsync();
+
+        Assert.That(instructionsValue, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public async Task ShouldSaveReturnAddInstructionsAssignAndVerifyPersistence()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await woNumberLocator.WaitForAsync();
+        await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(string.Empty);
+
+        await Input(nameof(WorkOrderManage.Elements.Instructions), "Follow these new instructions carefully");
+        await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await woNumberLocator.WaitForAsync();
+        await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+        await Expect(instructionsField).ToHaveValueAsync("Follow these new instructions carefully");
+
+        var assigneeField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee));
+        await Expect(assigneeField).ToHaveValueAsync(CurrentUser.UserName);
+
+        var rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ?? throw new InvalidOperationException();
+        Assert.That(rehydratedOrder.Instructions, Is.EqualTo("Follow these new instructions carefully"));
+        Assert.That(rehydratedOrder.Assignee!.UserName, Is.EqualTo(CurrentUser.UserName));
+    }
+}

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION
+GO
+PRINT N'Adding [dbo].[WorkOrder] Instructions column'
+GO
+ALTER TABLE [dbo].[WorkOrder] ADD [Instructions] NVARCHAR(4000) NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -19,6 +19,7 @@ public class WorkOrderMappingTests
             Number = "WO-01",
             Title = "Fix lighting",
             Description = "Replace broken light bulbs in conference room",
+            Instructions = "Turn off power before replacing bulbs",
             RoomNumber = "CR-101",
             Status = WorkOrderStatus.Draft,
             Creator = creator
@@ -43,6 +44,7 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Number.ShouldBe("WO-01");
         rehydratedWorkOrder.Title.ShouldBe("Fix lighting");
         rehydratedWorkOrder.Description.ShouldBe("Replace broken light bulbs in conference room");
+        rehydratedWorkOrder.Instructions.ShouldBe("Turn off power before replacing bulbs");
         rehydratedWorkOrder.RoomNumber.ShouldBe("CR-101");
         rehydratedWorkOrder.Status.ShouldBe(WorkOrderStatus.Draft);
         rehydratedWorkOrder.Creator.ShouldNotBeNull();
@@ -62,6 +64,7 @@ public class WorkOrderMappingTests
             Assignee = assignee,
             Title = "foo",
             Description = "bar",
+            Instructions = "test instructions",
             RoomNumber = "123 a"
         };
         order.ChangeStatus(WorkOrderStatus.InProgress);
@@ -89,6 +92,7 @@ public class WorkOrderMappingTests
             rehydratedWorkOrder.Assignee!.Id.ShouldBe(order.Assignee.Id);
             rehydratedWorkOrder.Title.ShouldBe(order.Title);
             rehydratedWorkOrder.Description.ShouldBe(order.Description);
+            rehydratedWorkOrder.Instructions.ShouldBe(order.Instructions);
             rehydratedWorkOrder.Status.ShouldBe(order.Status);
             rehydratedWorkOrder.RoomNumber.ShouldBe(order.RoomNumber);
             rehydratedWorkOrder.Number.ShouldBe(order.Number);
@@ -287,5 +291,105 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Assignee!.Id.ShouldBe(assignee.Id);
         rehydratedWorkOrder.Assignee.FirstName.ShouldBe("Jane");
         rehydratedWorkOrder.Assignee.LastName.ShouldBe("Smith");
+    }
+
+    [Test]
+    public void ShouldPersistInstructionsField()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = new Employee("creator1", "John", "Doe", "john@example.com");
+        var workOrder = new WorkOrder
+        {
+            Number = "WO-07",
+            Title = "Test Instructions",
+            Description = "Testing Instructions field",
+            Instructions = "Follow these specific instructions carefully",
+            Creator = creator,
+            Status = WorkOrderStatus.Draft
+        };
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(workOrder);
+            context.SaveChanges();
+        }
+
+        WorkOrder rehydratedWorkOrder;
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            rehydratedWorkOrder = context.Set<WorkOrder>()
+                .Single(wo => wo.Id == workOrder.Id);
+        }
+
+        rehydratedWorkOrder.Instructions.ShouldBe("Follow these specific instructions carefully");
+    }
+
+    [Test]
+    public void ShouldAllowEmptyInstructions()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = new Employee("creator1", "John", "Doe", "john@example.com");
+        var workOrder = new WorkOrder
+        {
+            Number = "WO-08",
+            Title = "Test Empty Instructions",
+            Description = "Testing empty Instructions field",
+            Creator = creator,
+            Status = WorkOrderStatus.Draft
+        };
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(workOrder);
+            context.SaveChanges();
+        }
+
+        WorkOrder rehydratedWorkOrder;
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            rehydratedWorkOrder = context.Set<WorkOrder>()
+                .Single(wo => wo.Id == workOrder.Id);
+        }
+
+        rehydratedWorkOrder.Instructions.ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public void ShouldPersistInstructionsWithMaxLength()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = new Employee("creator1", "John", "Doe", "john@example.com");
+        var longInstructions = new string('X', 4000);
+        var workOrder = new WorkOrder
+        {
+            Number = "WO-09",
+            Title = "Test Long Instructions",
+            Description = "Testing Instructions field with max length",
+            Instructions = longInstructions,
+            Creator = creator,
+            Status = WorkOrderStatus.Draft
+        };
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(workOrder);
+            context.SaveChanges();
+        }
+
+        WorkOrder rehydratedWorkOrder;
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            rehydratedWorkOrder = context.Set<WorkOrder>()
+                .Single(wo => wo.Id == workOrder.Id);
+        }
+
+        rehydratedWorkOrder.Instructions.ShouldBe(longInstructions);
+        rehydratedWorkOrder.Instructions!.Length.ShouldBe(4000);
     }
 }

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -56,6 +56,13 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -114,6 +121,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -81,6 +81,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate.ToString(),
             AssignedDate = workOrder.AssignedDate?.ToString(),
@@ -120,6 +121,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -40,6 +41,7 @@ public class WorkOrderTests
         workOrder.Id = guid;
         workOrder.Title = "Title";
         workOrder.Description = "Description";
+        workOrder.Instructions = "Instructions";
         workOrder.Status = WorkOrderStatus.Complete;
         workOrder.Number = "Number";
         workOrder.Creator = creator;
@@ -48,6 +50,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(guid));
         Assert.That(workOrder.Title, Is.EqualTo("Title"));
         Assert.That(workOrder.Description, Is.EqualTo("Description"));
+        Assert.That(workOrder.Instructions, Is.EqualTo("Instructions"));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Complete));
         Assert.That(workOrder.Number, Is.EqualTo("Number"));
         Assert.That(workOrder.Creator, Is.EqualTo(creator));
@@ -70,6 +73,15 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('x', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions.Length, Is.EqualTo(4000));
     }
 
     [Test]


### PR DESCRIPTION
Implemented optional Instructions field for work orders as specified in issue #49.

Changes:
- Domain: Added Instructions property to WorkOrder entity with 4000 char truncation
- DataAccess: Updated WorkOrderMap with Instructions column mapping (max 4000 chars)
- Database: Created migration script 022 to add Instructions column
- UI: Added Instructions textarea to WorkOrderManage.razor between Description and Room
- View Model: Added Instructions property to WorkOrderManageModel
- Code-behind: Updated CreateViewModel and HandleSubmit to map Instructions

Tests:
- Unit: Added tests for Instructions initialization, get/set, and truncation
- Integration: Added tests for Instructions persistence, empty values, and max length
- Acceptance: Added Playwright tests for 4000-char input, empty input, and edit scenarios

The Instructions field is optional, supports up to 4000 characters, and appears between Description and Room Number fields in the UI as specified.

Submitter checklist
- [ ] Issue is clearly tagged
- [ ] Narrate status of the branch (feature complete, incremental build, etc)
- [ ] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional 4000-char `Instructions` field to work orders, mapped to DB, surfaced in UI, and fully covered by unit, integration, and acceptance tests.
> 
> - **Domain/Model**:
>   - Add `WorkOrder.Instructions` with 4000-char truncation in `src/Core/Model/WorkOrder.cs`.
> - **Data**:
>   - Map `Instructions` (NVARCHAR(4000)) in `src/DataAccess/Mappings/WorkOrderMap.cs`.
>   - DB script `src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql` adds column to `[dbo].[WorkOrder]`.
> - **UI**:
>   - Surface `Instructions` field in `src/UI.Shared/Pages/WorkOrderManage.razor` and bind via model.
>   - Extend view model and submit handling in `src/UI.Shared/Models/WorkOrderManageModel.cs` and `WorkOrderManage.razor.cs`.
> - **Tests**:
>   - Unit tests for defaults and 4000-char truncation in `WorkOrderTests`.
>   - Integration tests verifying mapping/persistence, empties, and max length in `WorkOrderMappingTests`.
>   - Acceptance tests covering create/edit flows and persistence in `WorkOrderInstructionsTests`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88008412b1954868b0dcc16d2e527c02ec0fbf15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->