### PR TITLE
Add Instructions field to WorkOrder

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -146,13 +146,14 @@ public abstract class AcceptanceTestBase : PageTest
         await locator.SelectOptionAsync(value ?? "");
     }
 
-    protected async Task<WorkOrder> CreateAndSaveNewWorkOrder()
+    protected async Task<WorkOrder> CreateAndSaveNewWorkOrder(string? instructions = null)
     {
         var order = Faker<WorkOrder>();
         order.Title = "from automation";
         order.Number = null;
         var testTitle = order.Title;
         var testDescription = order.Description;
+        var testInstructions = instructions ?? order.Instructions;
         var testRoomNumber = order.RoomNumber;
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -166,6 +167,7 @@ public abstract class AcceptanceTestBase : PageTest
         order.Number = newWorkOrderNumber;
         await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
         await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
         await TakeScreenshotAsync(2, "FormFilled");
 
@@ -176,7 +178,7 @@ public abstract class AcceptanceTestBase : PageTest
         WorkOrder? rehyratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
         if (rehyratedOrder == null)
         {
-            await Task.Delay(1000); 
+            await Task.Delay(1000);
             rehyratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
         }
         rehyratedOrder.ShouldNotBeNull();

--- a/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
@@ -1,0 +1,73 @@
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderInstructionsTests : AcceptanceTestBase
+{
+	[Test]
+	public async Task ShouldCreateWorkOrderWith4000CharacterInstructions()
+	{
+		await LoginAsCurrentUser();
+
+		var longInstructions = new string('x', 4000);
+		var order = await CreateAndSaveNewWorkOrder(instructions: longInstructions);
+
+		await Page.WaitForURLAsync("**/workorder/search");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+		var actualValue = await instructionsField.InputValueAsync();
+		Assert.That(actualValue, Is.EqualTo(longInstructions));
+		Assert.That(actualValue.Length, Is.EqualTo(4000));
+	}
+
+	[Test]
+	public async Task ShouldCreateWorkOrderWithEmptyInstructions()
+	{
+		await LoginAsCurrentUser();
+
+		var order = await CreateAndSaveNewWorkOrder(instructions: "");
+
+		await Page.WaitForURLAsync("**/workorder/search");
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+		await Expect(instructionsField).ToHaveValueAsync("");
+	}
+
+	[Test]
+	public async Task ShouldAddInstructionsAfterCreatingWorkOrder()
+	{
+		await LoginAsCurrentUser();
+
+		var order = await CreateAndSaveNewWorkOrder(instructions: "");
+
+		await Page.WaitForURLAsync("**/workorder/search");
+		await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+		await Expect(instructionsField).ToHaveValueAsync("");
+
+		await Input(nameof(WorkOrderManage.Elements.Instructions), "Added instructions later");
+		await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
+		await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignCommand.Name);
+
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await Expect(instructionsField).ToHaveValueAsync("Added instructions later");
+
+		var rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!));
+		Assert.That(rehydratedOrder!.Instructions, Is.EqualTo("Added instructions later"));
+	}
+}

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,4 @@
+-- Add Instructions column to WorkOrder table
+ALTER TABLE [dbo].[WorkOrder]
+	ADD [Instructions] NVARCHAR(4000) NULL;
+GO

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -19,6 +19,7 @@ public class WorkOrderMappingTests
             Number = "WO-01",
             Title = "Fix lighting",
             Description = "Replace broken light bulbs in conference room",
+            Instructions = "Turn off power before replacing bulbs",
             RoomNumber = "CR-101",
             Status = WorkOrderStatus.Draft,
             Creator = creator
@@ -43,6 +44,7 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Number.ShouldBe("WO-01");
         rehydratedWorkOrder.Title.ShouldBe("Fix lighting");
         rehydratedWorkOrder.Description.ShouldBe("Replace broken light bulbs in conference room");
+        rehydratedWorkOrder.Instructions.ShouldBe("Turn off power before replacing bulbs");
         rehydratedWorkOrder.RoomNumber.ShouldBe("CR-101");
         rehydratedWorkOrder.Status.ShouldBe(WorkOrderStatus.Draft);
         rehydratedWorkOrder.Creator.ShouldNotBeNull();
@@ -62,6 +64,7 @@ public class WorkOrderMappingTests
             Assignee = assignee,
             Title = "foo",
             Description = "bar",
+            Instructions = "baz",
             RoomNumber = "123 a"
         };
         order.ChangeStatus(WorkOrderStatus.InProgress);
@@ -89,6 +92,7 @@ public class WorkOrderMappingTests
             rehydratedWorkOrder.Assignee!.Id.ShouldBe(order.Assignee.Id);
             rehydratedWorkOrder.Title.ShouldBe(order.Title);
             rehydratedWorkOrder.Description.ShouldBe(order.Description);
+            rehydratedWorkOrder.Instructions.ShouldBe(order.Instructions);
             rehydratedWorkOrder.Status.ShouldBe(order.Status);
             rehydratedWorkOrder.RoomNumber.ShouldBe(order.RoomNumber);
             rehydratedWorkOrder.Number.ShouldBe(order.Number);
@@ -287,5 +291,40 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Assignee!.Id.ShouldBe(assignee.Id);
         rehydratedWorkOrder.Assignee.FirstName.ShouldBe("Jane");
         rehydratedWorkOrder.Assignee.LastName.ShouldBe("Smith");
+    }
+
+    [Test]
+    public void ShouldPersistInstructionsUpTo4000Characters()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = new Employee("creator1", "John", "Doe", "john@example.com");
+        var longInstructions = new string('x', 4000);
+        var workOrder = new WorkOrder
+        {
+            Number = "WO-07",
+            Title = "Test Instructions",
+            Description = "Testing instructions persistence",
+            Instructions = longInstructions,
+            Creator = creator,
+            Status = WorkOrderStatus.Draft
+        };
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(workOrder);
+            context.SaveChanges();
+        }
+
+        WorkOrder rehydratedWorkOrder;
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            rehydratedWorkOrder = context.Set<WorkOrder>()
+                .Single(wo => wo.Id == workOrder.Id);
+        }
+
+        rehydratedWorkOrder.Instructions.ShouldBe(longInstructions);
+        rehydratedWorkOrder.Instructions!.Length.ShouldBe(4000);
     }
 }

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -56,6 +56,13 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -114,6 +121,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -81,6 +81,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate.ToString(),
             AssignedDate = workOrder.AssignedDate?.ToString(),
@@ -120,6 +121,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -40,6 +41,7 @@ public class WorkOrderTests
         workOrder.Id = guid;
         workOrder.Title = "Title";
         workOrder.Description = "Description";
+        workOrder.Instructions = "Instructions";
         workOrder.Status = WorkOrderStatus.Complete;
         workOrder.Number = "Number";
         workOrder.Creator = creator;
@@ -48,6 +50,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(guid));
         Assert.That(workOrder.Title, Is.EqualTo("Title"));
         Assert.That(workOrder.Description, Is.EqualTo("Description"));
+        Assert.That(workOrder.Instructions, Is.EqualTo("Instructions"));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Complete));
         Assert.That(workOrder.Number, Is.EqualTo("Number"));
         Assert.That(workOrder.Creator, Is.EqualTo(creator));
@@ -70,6 +73,15 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('x', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions.Length, Is.EqualTo(4000));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
Implements comprehensive Instructions field support for Work Orders as specified in #53.

## Changes
- Domain: Added Instructions property to WorkOrder entity with 4000 char truncation
- Data Access: Updated WorkOrderMap with 4000 char max length constraint
- Database: Created migration script 022_AddInstructionsToWorkOrder.sql
- View Model: Added Instructions to WorkOrderManageModel
- UI: Added Instructions textarea between Description and Room Number fields
- Unit Tests: Added truncation and initialization tests
- Integration Tests: Added persistence tests for Instructions field
- Acceptance Tests: Added WorkOrderInstructionsTests with 3 scenarios

Resolves #53

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new 4000-character "Instructions" field to WorkOrder with full persistence, UI binding, and tests.
> 
> - **Domain**
>   - Add `Instructions` property to `WorkOrder` with 4000-char truncation.
> - **Data/DB**
>   - Map `Instructions` in `WorkOrderMap` with `HasMaxLength(4000)`.
>   - Migration `scripts/Update/022_AddInstructionsToWorkOrder.sql` adds `Instructions NVARCHAR(4000)`.
> - **UI**
>   - Add `Instructions` to `WorkOrderManageModel`.
>   - Add `Instructions` textarea and test id in `WorkOrderManage.razor`; bind/save in code-behind.
> - **Tests**
>   - Unit: defaults and 4000-char truncation for `Instructions` in `WorkOrderTests`.
>   - Integration: mapping and persistence assertions for `Instructions` in `WorkOrderMappingTests`.
>   - Acceptance: new `WorkOrderInstructionsTests` (4000 chars, empty, post-create add); update helper to input `Instructions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de08f79b1f5071abf4cd6bb10c6ec809c67a7b5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->