### PR TITLE
Add Instructions field to WorkOrder (Issue #45)

### DIFF
--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,15 @@
+-- Add Instructions column to WorkOrder table
+IF NOT EXISTS (SELECT * FROM sys.columns 
+               WHERE object_id = OBJECT_ID(N'[dbo].[WorkOrder]') 
+               AND name = 'Instructions')
+BEGIN
+    ALTER TABLE [dbo].[WorkOrder]
+    ADD [Instructions] NVARCHAR(4000) NULL;
+    
+    PRINT 'Instructions column added to WorkOrder table successfully.';
+END
+ELSE
+BEGIN
+    PRINT 'Instructions column already exists in WorkOrder table.';
+END
+GO

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -1,4 +1,4 @@
-﻿using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.DataAccess.Mappings;
 using Microsoft.EntityFrameworkCore;
 using Shouldly;
@@ -19,6 +19,7 @@ public class WorkOrderMappingTests
             Number = "WO-01",
             Title = "Fix lighting",
             Description = "Replace broken light bulbs in conference room",
+            Instructions = "Use ladder, turn off power first",
             RoomNumber = "CR-101",
             Status = WorkOrderStatus.Draft,
             Creator = creator
@@ -43,6 +44,7 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Number.ShouldBe("WO-01");
         rehydratedWorkOrder.Title.ShouldBe("Fix lighting");
         rehydratedWorkOrder.Description.ShouldBe("Replace broken light bulbs in conference room");
+        rehydratedWorkOrder.Instructions.ShouldBe("Use ladder, turn off power first");
         rehydratedWorkOrder.RoomNumber.ShouldBe("CR-101");
         rehydratedWorkOrder.Status.ShouldBe(WorkOrderStatus.Draft);
         rehydratedWorkOrder.Creator.ShouldNotBeNull();

--- a/src/LlmGateway/WorkOrderChatHandler.cs
+++ b/src/LlmGateway/WorkOrderChatHandler.cs
@@ -1,4 +1,4 @@
-﻿using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model;
 using MediatR;
 using Microsoft.Extensions.AI;
 
@@ -23,6 +23,7 @@ public class WorkOrderChatHandler(ChatClientFactory factory, WorkOrderTool workO
             new(ChatRole.System, $"Work Order number is {request.CurrentWorkOrder.Number}"),
             new(ChatRole.System, $"Work Order title is {request.CurrentWorkOrder.Title}"),
             new(ChatRole.System, $"Work Order description is {request.CurrentWorkOrder.Description}"),
+            new(ChatRole.System, $"Work Order instructions are {request.CurrentWorkOrder.Instructions}"),
             new(ChatRole.System, $"Work Order room is {request.CurrentWorkOrder.RoomNumber}"),
             new(ChatRole.System, $"Work Order creator is {request.CurrentWorkOrder.Creator?.GetFullName()}"),
             new(ChatRole.System, $"Limit answer to 3 sentences. Be brief"),

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -56,6 +56,13 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -114,6 +121,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -1,4 +1,4 @@
-﻿using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.Core.Model.StateCommands;
 using ClearMeasure.Bootcamp.Core.Queries;
 using ClearMeasure.Bootcamp.Core.Services;
@@ -81,6 +81,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate.ToString(),
             AssignedDate = workOrder.AssignedDate?.ToString(),
@@ -120,6 +121,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UnitTests/BogusOverrides.cs
+++ b/src/UnitTests/BogusOverrides.cs
@@ -1,4 +1,4 @@
-﻿using AutoBogus;
+using AutoBogus;
 using Bogus.Extensions;
 using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.Core.Queries;
@@ -18,6 +18,7 @@ internal class BogusOverrides : AutoGeneratorOverride
         {
             case WorkOrder order:
                 order.Description = order.Description.ClampLength(1, 2000);
+                order.Instructions = order.Instructions.ClampLength(1, 2000);
                 order.Number = order.Number.ClampLength(1, 5);
                 // order.Status = context.Faker.PickRandom<WorkOrderStatus>(WorkOrderStatus.GetAllItems());
                 break;

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -40,6 +41,7 @@ public class WorkOrderTests
         workOrder.Id = guid;
         workOrder.Title = "Title";
         workOrder.Description = "Description";
+        workOrder.Instructions = "Instructions";
         workOrder.Status = WorkOrderStatus.Complete;
         workOrder.Number = "Number";
         workOrder.Creator = creator;
@@ -48,6 +50,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(guid));
         Assert.That(workOrder.Title, Is.EqualTo("Title"));
         Assert.That(workOrder.Description, Is.EqualTo("Description"));
+        Assert.That(workOrder.Instructions, Is.EqualTo("Instructions"));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Complete));
         Assert.That(workOrder.Number, Is.EqualTo("Number"));
         Assert.That(workOrder.Creator, Is.EqualTo(creator));
@@ -70,6 +73,15 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('x', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions.Length, Is.EqualTo(4000));
     }
 
     [Test]

--- a/src/UnitTests/Core/Services/WorkOrderBuilderTests.cs
+++ b/src/UnitTests/Core/Services/WorkOrderBuilderTests.cs
@@ -21,6 +21,7 @@ public class WorkOrderBuilderTests
         Assert.That(workOrder.Assignee, Is.Null);
         Assert.That(workOrder.Title, Is.Empty);
         Assert.That(workOrder.Description, Is.Empty);
+        Assert.That(workOrder.Instructions, Is.Empty);
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.RoomNumber, Is.Null);
     }


### PR DESCRIPTION
## Overview
This PR implements Issue #45: Add WorkOrder Instructions Field

## Changes Made

### Domain Layer
- Added Instructions property to WorkOrder entity with 4000 character truncation logic (matching Description behavior)

### Data Access Layer
- Updated WorkOrderMap to include Instructions field with max length of 4000
- Created SQL migration script 