### PR TITLE
feat: Add Instructions field to WorkOrder (#45)

### DIFF
--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,23 @@
+/*
+   Add Instructions column to WorkOrder table
+   GitHub Issue #45: Add WorkOrder Instructions Field
+*/
+
+/* To prevent any potential data loss issues, you should review this script in detail before running it outside the context of the database designer.*/
+BEGIN TRANSACTION
+SET QUOTED_IDENTIFIER ON
+SET ARITHABORT ON
+SET NUMERIC_ROUNDABORT OFF
+SET CONCAT_NULL_YIELDS_NULL ON
+SET ANSI_NULLS ON
+SET ANSI_PADDING ON
+SET ANSI_WARNINGS ON
+COMMIT
+BEGIN TRANSACTION
+GO
+ALTER TABLE dbo.WorkOrder ADD
+	Instructions nvarchar(4000) NULL
+GO
+ALTER TABLE dbo.WorkOrder SET (LOCK_ESCALATION = TABLE)
+GO
+COMMIT

--- a/src/DatabaseFlyway/migrations/V003__ADD_Instructions_To_WorkOrder.sql
+++ b/src/DatabaseFlyway/migrations/V003__ADD_Instructions_To_WorkOrder.sql
@@ -1,0 +1,5 @@
+-- Add Instructions column to WorkOrder table
+-- GitHub Issue #45: Add WorkOrder Instructions Field
+
+ALTER TABLE dbo.WorkOrder
+ADD Instructions nvarchar(4000) NULL;

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }


### PR DESCRIPTION
## Summary
This PR implements GitHub issue #45 by adding an Instructions field to the WorkOrder entity.

## Changes Made
- ✅ Added Instructions property to WorkOrder entity with 4000-character truncation logic
- ✅ Updated EF Core WorkOrderMap to include Instructions field (max length 4000)
- ✅ Created database migration scripts:
  - AliaSQL: 