### PR TITLE
Claude.AI code issue 49 Set up GitHub repository access

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -153,6 +153,7 @@ public abstract class AcceptanceTestBase : PageTest
         order.Number = null;
         var testTitle = order.Title;
         var testDescription = order.Description;
+        var testInstructions = order.Instructions;
         var testRoomNumber = order.RoomNumber;
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -166,6 +167,7 @@ public abstract class AcceptanceTestBase : PageTest
         order.Number = newWorkOrderNumber;
         await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
         await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
         await TakeScreenshotAsync(2, "FormFilled");
 

--- a/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
@@ -1,0 +1,113 @@
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderInstructionsTests : AcceptanceTestBase
+{
+	[Test]
+	public async Task ShouldCreateWorkOrderWith4000CharacterInstructions()
+	{
+		await LoginAsCurrentUser();
+
+		var longInstructions = new string('x', 4000);
+
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Click(nameof(NavMenu.Elements.NewWorkOrder));
+		await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+		ILocator woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+		await Expect(woNumberLocator).ToBeVisibleAsync();
+		var newWorkOrderNumber = await woNumberLocator.InnerTextAsync();
+
+		await Input(nameof(WorkOrderManage.Elements.Title), "Test 4000 char instructions");
+		await Input(nameof(WorkOrderManage.Elements.Description), "Testing maximum length instructions");
+		await Input(nameof(WorkOrderManage.Elements.Instructions), longInstructions);
+
+		var saveButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name;
+		await Click(saveButtonTestId);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		WorkOrder? savedOrder = await Bus.Send(new WorkOrderByNumberQuery(newWorkOrderNumber));
+		if (savedOrder == null)
+		{
+			await Task.Delay(1000);
+			savedOrder = await Bus.Send(new WorkOrderByNumberQuery(newWorkOrderNumber));
+		}
+
+		savedOrder.ShouldNotBeNull();
+		savedOrder.Instructions.ShouldNotBeNull();
+		savedOrder.Instructions.Length.ShouldBe(4000);
+	}
+
+	[Test]
+	public async Task ShouldCreateWorkOrderWithEmptyInstructions()
+	{
+		await LoginAsCurrentUser();
+
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Click(nameof(NavMenu.Elements.NewWorkOrder));
+		await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+		ILocator woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+		await Expect(woNumberLocator).ToBeVisibleAsync();
+		var newWorkOrderNumber = await woNumberLocator.InnerTextAsync();
+
+		await Input(nameof(WorkOrderManage.Elements.Title), "Test empty instructions");
+		await Input(nameof(WorkOrderManage.Elements.Description), "Testing empty instructions field");
+
+		var saveButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name;
+		await Click(saveButtonTestId);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		WorkOrder? savedOrder = await Bus.Send(new WorkOrderByNumberQuery(newWorkOrderNumber));
+		if (savedOrder == null)
+		{
+			await Task.Delay(1000);
+			savedOrder = await Bus.Send(new WorkOrderByNumberQuery(newWorkOrderNumber));
+		}
+
+		savedOrder.ShouldNotBeNull();
+		savedOrder.Title.ShouldBe("Test empty instructions");
+		savedOrder.Description.ShouldBe("Testing empty instructions field");
+	}
+
+	[Test]
+	public async Task ShouldSaveWorkOrderReturnLaterAddInstructionsAssignAndVerifyPersistence()
+	{
+		await LoginAsCurrentUser();
+
+		var order = await CreateAndSaveNewWorkOrder();
+
+		await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+		await woNumberLocator.WaitForAsync();
+		await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+		await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
+		await Input(nameof(WorkOrderManage.Elements.Instructions), "New instructions added later");
+		await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+		await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+		await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+		await woNumberLocator.WaitForAsync();
+		await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+		var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+		await Expect(instructionsField).ToHaveValueAsync("New instructions added later");
+
+		var assigneeField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee));
+		await Expect(assigneeField).ToHaveValueAsync(CurrentUser.UserName);
+
+		WorkOrder rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ?? throw new InvalidOperationException();
+		rehydratedOrder.Instructions.ShouldBe("New instructions added later");
+		rehydratedOrder.Assignee.ShouldNotBeNull();
+		rehydratedOrder.Assignee!.UserName.ShouldBe(CurrentUser.UserName);
+	}
+}

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -45,6 +45,9 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         var descriptionField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Description));
         await Expect(descriptionField).ToHaveValueAsync(order.Description!);
 
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions!);
+
         var roomNumberField = Page.GetByTestId(nameof(WorkOrderManage.Elements.RoomNumber));
         await Expect(roomNumberField).ToHaveValueAsync(order.RoomNumber!);
 

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,12 @@
+BEGIN TRANSACTION
+GO
+PRINT N'Adding [dbo].[WorkOrder] Instructions column'
+GO
+ALTER TABLE [dbo].[WorkOrder] ADD
+	[Instructions] NVARCHAR(4000) NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -19,6 +19,7 @@ public class WorkOrderMappingTests
             Number = "WO-01",
             Title = "Fix lighting",
             Description = "Replace broken light bulbs in conference room",
+            Instructions = "Turn off power before replacing bulbs",
             RoomNumber = "CR-101",
             Status = WorkOrderStatus.Draft,
             Creator = creator
@@ -43,6 +44,7 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Number.ShouldBe("WO-01");
         rehydratedWorkOrder.Title.ShouldBe("Fix lighting");
         rehydratedWorkOrder.Description.ShouldBe("Replace broken light bulbs in conference room");
+        rehydratedWorkOrder.Instructions.ShouldBe("Turn off power before replacing bulbs");
         rehydratedWorkOrder.RoomNumber.ShouldBe("CR-101");
         rehydratedWorkOrder.Status.ShouldBe(WorkOrderStatus.Draft);
         rehydratedWorkOrder.Creator.ShouldNotBeNull();
@@ -62,6 +64,7 @@ public class WorkOrderMappingTests
             Assignee = assignee,
             Title = "foo",
             Description = "bar",
+            Instructions = "baz",
             RoomNumber = "123 a"
         };
         order.ChangeStatus(WorkOrderStatus.InProgress);
@@ -89,6 +92,7 @@ public class WorkOrderMappingTests
             rehydratedWorkOrder.Assignee!.Id.ShouldBe(order.Assignee.Id);
             rehydratedWorkOrder.Title.ShouldBe(order.Title);
             rehydratedWorkOrder.Description.ShouldBe(order.Description);
+            rehydratedWorkOrder.Instructions.ShouldBe(order.Instructions);
             rehydratedWorkOrder.Status.ShouldBe(order.Status);
             rehydratedWorkOrder.RoomNumber.ShouldBe(order.RoomNumber);
             rehydratedWorkOrder.Number.ShouldBe(order.Number);

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -56,6 +56,13 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -114,6 +121,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -81,6 +81,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate.ToString(),
             AssignedDate = workOrder.AssignedDate?.ToString(),
@@ -120,6 +121,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -40,6 +41,7 @@ public class WorkOrderTests
         workOrder.Id = guid;
         workOrder.Title = "Title";
         workOrder.Description = "Description";
+        workOrder.Instructions = "Instructions";
         workOrder.Status = WorkOrderStatus.Complete;
         workOrder.Number = "Number";
         workOrder.Creator = creator;
@@ -48,6 +50,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(guid));
         Assert.That(workOrder.Title, Is.EqualTo("Title"));
         Assert.That(workOrder.Description, Is.EqualTo("Description"));
+        Assert.That(workOrder.Instructions, Is.EqualTo("Instructions"));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Complete));
         Assert.That(workOrder.Number, Is.EqualTo("Number"));
         Assert.That(workOrder.Creator, Is.EqualTo(creator));
@@ -70,6 +73,15 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('x', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions.Length, Is.EqualTo(4000));
     }
 
     [Test]


### PR DESCRIPTION
Implemented new optional Instructions field (up to 4000 characters) for Work Orders:

- Domain: Added Instructions property to WorkOrder entity with 4000-character truncation
- Data Access: Updated WorkOrderMap EF mapping with 4000-character max length constraint
- Database: Created migration script 022_AddInstructionsToWorkOrder.sql
- View Model: Added Instructions to WorkOrderManageModel
- UI: Added Instructions textarea between Description and Room Number fields
- Tests: Added comprehensive unit, integration, and acceptance tests covering:
  - Property initialization and truncation
  - Persistence and retrieval
  - 4000-character instructions scenario
  - Empty instructions scenario
  - Add instructions later scenario

All changes follow Onion Architecture principles with proper dependency flow.

Submitter checklist
- [ ] Issue is clearly tagged
- [ ] Narrate status of the branch (feature complete, incremental build, etc)
- [ ] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item