### PR TITLE
Claude GitHub Agent - Issue #45 - Sonnet 4.5 - Add WorkOrder Instructions Field

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using ClearMeasure.Bootcamp.Core.Queries;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderInstructionsTests : AcceptanceTestBase
+{
+    [Test]
+    public async Task ShouldCreateWorkOrderWith4000CharacterInstructions()
+    {
+        await LoginAsCurrentUser();
+
+        var longInstructions = new string('X', 4000);
+
+        await Page.GetByTestId(nameof(NavMenu.Elements.NewWorkOrder)).ClickAsync();
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Input(nameof(WorkOrderManage.Elements.Title), "Test 4000 Char Instructions");
+        await Input(nameof(WorkOrderManage.Elements.Description), "Testing long instructions field");
+        await Input(nameof(WorkOrderManage.Elements.Instructions), longInstructions);
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), "101");
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var workOrderNumberMatch = System.Text.RegularExpressions.Regex.Match(
+            await Page.ContentAsync(), 
+            @"WO-\d{5}"
+        );
+        Assert.That(workOrderNumberMatch.Success, Is.True, "Work order number not found");
+        
+        string orderNumber = workOrderNumberMatch.Value;
+
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + orderNumber);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        var instructionsValue = await instructionsField.InputValueAsync();
+        
+        Assert.That(instructionsValue.Length, Is.EqualTo(4000));
+        Assert.That(instructionsValue, Is.EqualTo(longInstructions));
+    }
+
+    [Test]
+    public async Task ShouldCreateWorkOrderWithEmptyInstructions()
+    {
+        await LoginAsCurrentUser();
+
+        await Page.GetByTestId(nameof(NavMenu.Elements.NewWorkOrder)).ClickAsync();
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Input(nameof(WorkOrderManage.Elements.Title), "Test Empty Instructions");
+        await Input(nameof(WorkOrderManage.Elements.Description), "Testing empty instructions field");
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), "102");
+        // Intentionally not setting Instructions field
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var workOrderNumberMatch = System.Text.RegularExpressions.Regex.Match(
+            await Page.ContentAsync(), 
+            @"WO-\d{5}"
+        );
+        Assert.That(workOrderNumberMatch.Success, Is.True, "Work order number not found");
+        
+        string orderNumber = workOrderNumberMatch.Value;
+
+        var rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(orderNumber));
+        Assert.That(rehydratedOrder, Is.Not.Null);
+        Assert.That(rehydratedOrder!.Instructions, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public async Task ShouldSaveWorkOrderReturnLaterAddInstructionsAssignAndVerifyPersistence()
+    {
+        await LoginAsCurrentUser();
+
+        // Step 1: Create and save work order without instructions
+        await Page.GetByTestId(nameof(NavMenu.Elements.NewWorkOrder)).ClickAsync();
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Input(nameof(WorkOrderManage.Elements.Title), "Test Add Instructions Later");
+        await Input(nameof(WorkOrderManage.Elements.Description), "Testing adding instructions after initial save");
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), "103");
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var workOrderNumberMatch = System.Text.RegularExpressions.Regex.Match(
+            await Page.ContentAsync(), 
+            @"WO-\d{5}"
+        );
+        Assert.That(workOrderNumberMatch.Success, Is.True, "Work order number not found");
+        
+        string orderNumber = workOrderNumberMatch.Value;
+
+        // Step 2: Return later and add instructions
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + orderNumber);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Input(nameof(WorkOrderManage.Elements.Instructions), "These instructions were added after initial save");
+        await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Step 3: Verify persistence
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + orderNumber);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync("These instructions were added after initial save");
+
+        var assigneeField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee));
+        await Expect(assigneeField).ToHaveValueAsync(CurrentUser.UserName);
+
+        // Verify via database
+        var rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(orderNumber));
+        Assert.That(rehydratedOrder, Is.Not.Null);
+        Assert.That(rehydratedOrder!.Instructions, Is.EqualTo("These instructions were added after initial save"));
+        Assert.That(rehydratedOrder.Assignee, Is.Not.Null);
+        Assert.That(rehydratedOrder.Assignee!.UserName, Is.EqualTo(CurrentUser.UserName));
+    }
+}

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION
+GO
+PRINT N'Adding Instructions column to [dbo].[WorkOrder]'
+GO
+ALTER TABLE [dbo].[WorkOrder] ADD [Instructions] NVARCHAR(4000) NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -56,6 +56,13 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -114,6 +121,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -1,4 +1,4 @@
-﻿using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.Core.Model.StateCommands;
 using ClearMeasure.Bootcamp.Core.Queries;
 using ClearMeasure.Bootcamp.Core.Services;
@@ -81,6 +81,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate.ToString(),
             AssignedDate = workOrder.AssignedDate?.ToString(),
@@ -120,6 +121,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()


### PR DESCRIPTION
## Summary
This PR implements GitHub Issue #45: Add WorkOrder Instructions Field

## Changes Made
- **Domain Layer**: Added Instructions property to WorkOrder entity with 4000-character truncation
- **Data Access Layer**: Updated EF Core mapping in WorkOrderMap to include Instructions field with max length 4000
- **Database**: Added migration script 