### PR TITLE
Claude GitHub Agent #47 - Add WorkOrder Instructions - Claude 3.7 Sonnet

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
@@ -1,0 +1,168 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using Microsoft.Playwright;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+[TestFixture]
+public class WorkOrderInstructionsTests : AcceptanceTestBase
+{
+    [Test]
+    public async Task ShouldCreateWorkOrderWith4000CharacterInstructions()
+    {
+        await LoginAsCurrentUser();
+
+        var order = Faker<WorkOrder>();
+        order.Title = "from automation";
+        order.Number = null;
+        var testTitle = order.Title;
+        var testDescription = order.Description;
+        var testInstructions = new string('x', 4000);
+        var testRoomNumber = order.RoomNumber;
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Click(nameof(NavMenu.Elements.NewWorkOrder));
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+        await TakeScreenshotAsync(1, "NewWorkOrderPage");
+
+        ILocator woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await Expect(woNumberLocator).ToBeVisibleAsync();
+        var newWorkOrderNumber = await woNumberLocator.InnerTextAsync();
+        order.Number = newWorkOrderNumber;
+
+        await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
+        await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
+        await TakeScreenshotAsync(2, "FormFilledWithInstructions");
+
+        var saveButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name;
+        await Click(saveButtonTestId);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        WorkOrder? rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
+        if (rehydratedOrder == null)
+        {
+            await Task.Delay(1000);
+            rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
+        }
+        rehydratedOrder.ShouldNotBeNull();
+        rehydratedOrder.Instructions.ShouldNotBeNull();
+        rehydratedOrder.Instructions!.Length.ShouldBe(4000);
+    }
+
+    [Test]
+    public async Task ShouldCreateWorkOrderWithEmptyInstructions()
+    {
+        await LoginAsCurrentUser();
+
+        var order = Faker<WorkOrder>();
+        order.Title = "from automation";
+        order.Number = null;
+        var testTitle = order.Title;
+        var testDescription = order.Description;
+        var testRoomNumber = order.RoomNumber;
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Click(nameof(NavMenu.Elements.NewWorkOrder));
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+        ILocator woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await Expect(woNumberLocator).ToBeVisibleAsync();
+        var newWorkOrderNumber = await woNumberLocator.InnerTextAsync();
+        order.Number = newWorkOrderNumber;
+
+        await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
+        await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        // Leave Instructions empty
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
+
+        var saveButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name;
+        await Click(saveButtonTestId);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        WorkOrder? rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
+        if (rehydratedOrder == null)
+        {
+            await Task.Delay(1000);
+            rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
+        }
+        rehydratedOrder.ShouldNotBeNull();
+        rehydratedOrder.Instructions.ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public async Task ShouldUpdateInstructionsOnExistingWorkOrder()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await woNumberLocator.WaitForAsync();
+        await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+        var newInstructions = "Updated instructions for this work order";
+        await Input(nameof(WorkOrderManage.Elements.Instructions), newInstructions);
+        
+        var saveButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name;
+        await Click(saveButtonTestId);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        WorkOrder? rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!));
+        rehydratedOrder.ShouldNotBeNull();
+        rehydratedOrder.Instructions.ShouldBe(newInstructions);
+    }
+
+    [Test]
+    public async Task ShouldAssignWorkOrderWithInstructions()
+    {
+        await LoginAsCurrentUser();
+
+        var order = Faker<WorkOrder>();
+        order.Title = "from automation";
+        order.Number = null;
+        var testTitle = order.Title;
+        var testDescription = order.Description;
+        var testInstructions = "Follow these steps carefully";
+        var testRoomNumber = order.RoomNumber;
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Click(nameof(NavMenu.Elements.NewWorkOrder));
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+        ILocator woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await Expect(woNumberLocator).ToBeVisibleAsync();
+        var newWorkOrderNumber = await woNumberLocator.InnerTextAsync();
+        order.Number = newWorkOrderNumber;
+
+        await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
+        await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
+
+        var saveButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name;
+        await Click(saveButtonTestId);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Now assign the work order
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
+        var assignButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name;
+        await Click(assignButtonTestId);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        WorkOrder? rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
+        rehydratedOrder.ShouldNotBeNull();
+        rehydratedOrder.Instructions.ShouldBe(testInstructions);
+        rehydratedOrder.Status.ShouldBe(WorkOrderStatus.Assigned);
+    }
+}

--- a/src/AcceptanceTests/appsettings.acceptancetests.json
+++ b/src/AcceptanceTests/appsettings.acceptancetests.json
@@ -1,9 +1,9 @@
 {
-    "ConnectionStrings":  {
-                              "SqlConnectionString":  "server=(LocalDb)\\MSSQLLocalDB;database=ChurchBulletin;Integrated Security=true;"
-                          },
-    "ApplicationBaseUrl":  "https://localhost:7174",
-    "StartLocalServer":  "true",
-    "SkipScreenshotsForSpeed":  "true",
-    "SlowMo":  "100"
+  "ConnectionStrings": {
+    "SqlConnectionString": "server=(LocalDb)\\MSSQLLocalDB;database=ChurchBulletin;Integrated Security=true;"
+  },
+  "ApplicationBaseUrl": "https://localhost:7174",
+  "StartLocalServer": "true",
+  "SkipScreenshotsForSpeed": "true",
+  "SlowMo": "100"
 }

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,24 @@
+/*
+   Tuesday, November 4, 2025
+   GitHub Issue 47 - Add Instructions field to WorkOrder
+   Claude Agent - claude-3-7-sonnet
+*/
+
+/* To prevent any potential data loss issues, you should review this script in detail before running it outside the context of the database designer.*/
+BEGIN TRANSACTION
+SET QUOTED_IDENTIFIER ON
+SET ARITHABORT ON
+SET NUMERIC_ROUNDABORT OFF
+SET CONCAT_NULL_YIELDS_NULL ON
+SET ANSI_NULLS ON
+SET ANSI_PADDING ON
+SET ANSI_WARNINGS ON
+COMMIT
+BEGIN TRANSACTION
+GO
+ALTER TABLE dbo.WorkOrder ADD
+	Instructions nvarchar(4000) NULL
+GO
+ALTER TABLE dbo.WorkOrder SET (LOCK_ESCALATION = TABLE)
+GO
+COMMIT

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -288,4 +288,107 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Assignee.FirstName.ShouldBe("Jane");
         rehydratedWorkOrder.Assignee.LastName.ShouldBe("Smith");
     }
+
+    [Test]
+    public async Task ShouldMapInstructionsFieldCorrectly()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = new Employee("creator1", "John", "Doe", "john@example.com");
+        var workOrder = new WorkOrder
+        {
+            Number = "WO-07",
+            Title = "Test Instructions",
+            Description = "Testing Instructions field",
+            Instructions = "These are the instructions for completing this work order",
+            RoomNumber = "CR-102",
+            Status = WorkOrderStatus.Draft,
+            Creator = creator
+        };
+
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(workOrder);
+            await context.SaveChangesAsync();
+        }
+
+        WorkOrder rehydratedWorkOrder;
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            rehydratedWorkOrder = context.Set<WorkOrder>()
+                .Single(wo => wo.Id == workOrder.Id);
+        }
+
+        rehydratedWorkOrder.Instructions.ShouldBe("These are the instructions for completing this work order");
+    }
+
+    [Test]
+    public async Task ShouldHandleEmptyInstructions()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = new Employee("creator1", "John", "Doe", "john@example.com");
+        var workOrder = new WorkOrder
+        {
+            Number = "WO-08",
+            Title = "Test Empty Instructions",
+            Description = "Testing empty Instructions field",
+            Instructions = null,
+            RoomNumber = "CR-103",
+            Status = WorkOrderStatus.Draft,
+            Creator = creator
+        };
+
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(workOrder);
+            await context.SaveChangesAsync();
+        }
+
+        WorkOrder rehydratedWorkOrder;
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            rehydratedWorkOrder = context.Set<WorkOrder>()
+                .Single(wo => wo.Id == workOrder.Id);
+        }
+
+        rehydratedWorkOrder.Instructions.ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public async Task ShouldTruncateInstructionsTo4000Characters()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = new Employee("creator1", "John", "Doe", "john@example.com");
+        var longInstructions = new string('x', 4001);
+        var workOrder = new WorkOrder
+        {
+            Number = "WO-09",
+            Title = "Test Long Instructions",
+            Description = "Testing Instructions truncation",
+            Instructions = longInstructions,
+            RoomNumber = "CR-104",
+            Status = WorkOrderStatus.Draft,
+            Creator = creator
+        };
+
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(workOrder);
+            await context.SaveChangesAsync();
+        }
+
+        WorkOrder rehydratedWorkOrder;
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            rehydratedWorkOrder = context.Set<WorkOrder>()
+                .Single(wo => wo.Id == workOrder.Id);
+        }
+
+        rehydratedWorkOrder.Instructions!.Length.ShouldBe(4000);
+    }
 }

--- a/src/IntegrationTests/appsettings.test.json
+++ b/src/IntegrationTests/appsettings.test.json
@@ -1,17 +1,17 @@
 {
-    "ConnectionStrings":  {
-                              "SqlConnectionString":  "server=(LocalDb)\\MSSQLLocalDB;database=ChurchBulletin;Integrated Security=true;"
-                          },
-    "Logging":  {
-                    "LogLevel":  {
-                                     "Default":  "Information",
-                                     "Microsoft.AspNetCore":  "Information",
-                                     "Microsoft.EntityFrameworkCore":  "Information"
-                                 },
-                    "Console":  {
-                                    "LogLevel":  {
-                                                     "Default":  "Information"
-                                                 }
-                                }
-                }
+  "ConnectionStrings": {
+    "SqlConnectionString": "server=(LocalDb)\\MSSQLLocalDB;database=ChurchBulletin;Integrated Security=true;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Information",
+      "Microsoft.EntityFrameworkCore": "Information"
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Information"
+      }
+    }
+  }
 }

--- a/src/LlmGateway/WorkOrderChatHandler.cs
+++ b/src/LlmGateway/WorkOrderChatHandler.cs
@@ -23,6 +23,7 @@ public class WorkOrderChatHandler(ChatClientFactory factory, WorkOrderTool workO
             new(ChatRole.System, $"Work Order number is {request.CurrentWorkOrder.Number}"),
             new(ChatRole.System, $"Work Order title is {request.CurrentWorkOrder.Title}"),
             new(ChatRole.System, $"Work Order description is {request.CurrentWorkOrder.Description}"),
+            new(ChatRole.System, $"Work Order instructions is {request.CurrentWorkOrder.Instructions}"),
             new(ChatRole.System, $"Work Order room is {request.CurrentWorkOrder.RoomNumber}"),
             new(ChatRole.System, $"Work Order creator is {request.CurrentWorkOrder.Creator?.GetFullName()}"),
             new(ChatRole.System, $"Limit answer to 3 sentences. Be brief"),

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -56,6 +56,13 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -114,6 +121,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -81,6 +81,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate.ToString(),
             AssignedDate = workOrder.AssignedDate?.ToString(),
@@ -120,6 +121,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UI/Server/WorkOrderEvaluationAgent.cs
+++ b/src/UI/Server/WorkOrderEvaluationAgent.cs
@@ -41,6 +41,7 @@ public class WorkOrderEvaluationAgent(
                                  Work Order: {workOrder.Number}
                                  Title: {workOrder.Title}
                                  Description: {workOrder.Description}
+                                 Instructions: {workOrder.Instructions}
                                  Room Number: {workOrder.RoomNumber}
                                  Assigned Date: {workOrder.AssignedDate}
                                  Creator: {workOrder.Creator?.GetFullName()}

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -70,6 +71,15 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('x', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions.Length, Is.EqualTo(4000));
     }
 
     [Test]

--- a/src/UnitTests/Core/Services/WorkOrderBuilderTests.cs
+++ b/src/UnitTests/Core/Services/WorkOrderBuilderTests.cs
@@ -21,6 +21,7 @@ public class WorkOrderBuilderTests
         Assert.That(workOrder.Assignee, Is.Null);
         Assert.That(workOrder.Title, Is.Empty);
         Assert.That(workOrder.Description, Is.Empty);
+        Assert.That(workOrder.Instructions, Is.Empty);
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.RoomNumber, Is.Null);
     }


### PR DESCRIPTION
## Issue #47: Add Instructions field to WorkOrder

**AI Model:** Claude 3.7 Sonnet
**Agent:** Claude GitHub Agent

### Implementation Details

This PR implements the Instructions field for work orders as specified in issue #47.

### Changes Made

#### Domain Layer
- ✅ Added Instructions property to WorkOrder entity with 4000 character truncation
- ✅ Applied truncation logic in setter using existing getTruncatedString method

#### Data Access Layer
- ✅ Updated WorkOrderMap to include Instructions with max length 4000
- ✅ Created database migration script 