### PR TITLE
Add Instructions field to WorkOrder

### DIFF
--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,4 @@
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'dbo.WorkOrder') AND name = 'Instructions')
+BEGIN
+	ALTER TABLE dbo.WorkOrder ADD Instructions NVARCHAR(4000) NULL;
+END

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -56,6 +56,13 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -114,6 +121,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -82,6 +82,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate?.ToString("G", CultureInfo.CurrentCulture),
             AssignedDate = workOrder.AssignedDate?.ToString("G", CultureInfo.CurrentCulture),
@@ -121,6 +122,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -70,6 +71,15 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('x', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions.Length, Is.EqualTo(4000));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Added `Instructions` property to WorkOrder entity with 4000 character truncation
- Created database migration script to add Instructions column to WorkOrder table
- Updated WorkOrderManage UI to include Instructions textarea between Description and Room Number fields
- Added unit test for Instructions truncation logic

## Changes
- `src/Core/Model/WorkOrder.cs` - Added Instructions property with truncation
- `src/DataAccess/Mappings/WorkOrderMap.cs` - Added EF Core mapping
- `src/Database/scripts/Update/022_AddInstructionsToWorkOrder.sql` - Migration script
- `src/UI.Shared/Models/WorkOrderManageModel.cs` - Added Instructions to view model
- `src/UI.Shared/Pages/WorkOrderManage.razor` - Added Instructions textarea
- `src/UI.Shared/Pages/WorkOrderManage.razor.cs` - Added Instructions mapping in load/save

## Test plan
- [ ] Verify Instructions field appears on work order create/edit screen
- [ ] Verify empty Instructions saves successfully
- [ ] Verify 4000 character Instructions saves successfully
- [ ] Verify Instructions can be edited after initial save

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)