### PR TITLE
[Work Item #484] Fix spelling mistakes

### DIFF
--- a/src/Core/Model/Employee.cs
+++ b/src/Core/Model/Employee.cs
@@ -64,7 +64,7 @@ public class Employee : EntityBase<Employee>, IComparable<Employee>
         return false;
     }
 
-    public bool CanFulfilWorkOrder()
+    public bool CanFulfillWorkOrder()
     {
         foreach (var role in Roles)
         {

--- a/src/DataAccess/Handlers/EmployeeQueryHandler.cs
+++ b/src/DataAccess/Handlers/EmployeeQueryHandler.cs
@@ -28,7 +28,7 @@ public class EmployeeQueryHandler(DataContext context)
         var employees = await query.ToListAsync();
         if (EmployeeSpecification.All.CanFulfill)
         {
-            employees = employees.Where(e => e.CanFulfilWorkOrder()).ToList();
+            employees = employees.Where(e => e.CanFulfillWorkOrder()).ToList();
         }
 
         return employees.OrderBy(e => e.LastName).ThenBy(e => e.FirstName).ToArray();

--- a/src/UnitTests/Core/Model/EmployeeTests.cs
+++ b/src/UnitTests/Core/Model/EmployeeTests.cs
@@ -116,7 +116,7 @@ public class EmployeeTests
     {
         var employee1 = new Employee("", "1", "1", "");
         employee1.AddRole(new Role("", false, true));
-        Assert.That(employee1.CanFulfilWorkOrder(), Is.EqualTo(true));
+        Assert.That(employee1.CanFulfillWorkOrder(), Is.EqualTo(true));
     }
 
     [Test]


### PR DESCRIPTION
Closes #484

Fix any spelling mistakes in the UI and backend code.

## User Experience Design

**User Flow:**
N/A - No user-facing UI changes required. This is a code quality task focused on correcting spelling errors in source code, comments, and documentation.

**UI Components:**
- New: N/A
- Modified: N/A - Spelling corrections will not change UI component structure or behavior

**Error States:**
N/A - Spelling corrections do not introduce or modify error states

**Accessibility:**
N/A - Spelling corrections do not affect keyboard navigation, screen readers, or accessibility features

## Technical Design

**Affected Components:**

| Layer | File | Action |
|-------|------|--------|
| Core | `src/Core/Model/Employee.cs` | Modify |
| DataAccess | `src/DataAccess/Handlers/EmployeeQueryHandler.cs` | Modify |
| UnitTests | `src/UnitTests/Core/EmployeeTests.cs` | Modify |

**Implementation Steps:**
1. Rename method `CanFulfilWorkOrder()` to `CanFulfillWorkOrder()` in `src/Core/Model/Employee.cs` line 67
2. Update method call from `e.CanFulfilWorkOrder()` to `e.CanFulfillWorkOrder()` in `src/DataAccess/Handlers/EmployeeQueryHandler.cs` line 31
3. Update method call from `CanFulfilWorkOrder()` to `CanFulfillWorkOrder()` in `src/UnitTests/Core/EmployeeTests.cs` line 119

**Dependencies:** None

**Database Migrations:** None

**Tests:**

| Type | Location | Coverage |
|------|----------|----------|
| Unit | `src/UnitTests/Core/EmployeeTests.cs` | Existing test validates method behavior; no new tests required |
| Integration | N/A | Spelling correction does not require new integration tests |
| Acceptance | N/A | Spelling correction does not require new acceptance tests |

## Test Design

**Acceptance Tests:** None required

**Rationale:** Backend-only change - Spelling correction in method names does not change user-facing behavior or require new acceptance test scenarios. Existing unit test in `src/UnitTests/Core/EmployeeTests.cs` (line 119) validates the method behavior and will be updated to reflect the corrected spelling.