### PR TITLE
Add branch naming convention: branches must use username folder

### DIFF
--- a/.cursor/rules/cloud-agent-instructions.mdc
+++ b/.cursor/rules/cloud-agent-instructions.mdc
@@ -62,7 +62,10 @@ New or updated behavior requires:
 ## Workflow
 
 ### Branching
-- Create branch: `issues/[issue-number]/[issue-title]`
+- Create branch inside a folder matching the username of the account creating the branch: `{username}/{branch-description}`
+- Example for user `jeffreypalermo`: `jeffreypalermo/fix-work-order-status`
+- Example for user `johnsmith`: `johnsmith/add-employee-search`
+- For AI agents (Cursor, Copilot, Claude), use the username of the account that initiated the session
 - If branch exists, use it (do not create new)
 
 ### Database Migrations

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,6 +121,14 @@ If either script fails:
 
 1. **Run `gh pr ready`** - Mark PR as ready for review immediately
 
+## Branch Naming Convention
+
+All branches must be created inside a folder matching the username of the account creating the branch. The format is `{username}/{branch-description}`.
+
+- For user `jeffreypalermo`, branches go under `jeffreypalermo/` (e.g., `jeffreypalermo/fix-work-order-status`)
+- For user `johnsmith`, branches go under `johnsmith/` (e.g., `johnsmith/add-employee-search`)
+- For AI agents (Copilot, Claude, Cursor), use the username of the account that initiated the session
+
 ## Special Project Rules
 
 - **DO NOT** modify files in `.octopus/`, `.octopus_original_from_od/`, or build scripts without explicit approval

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,14 @@ PlantUML diagrams in `arch/`:
 - `arch-c4-component-project-dependencies.puml`: Project dependencies
 - `arch-c4-class-domain-model.puml`: Domain model (WorkOrder, Employee, WorkOrderStatus, Role)
 
+## Branch Naming Convention
+
+All branches must be created inside a folder matching the username of the account creating the branch. The format is `{username}/{branch-description}`.
+
+- For user `jeffreypalermo`, branches go under `jeffreypalermo/` (e.g., `jeffreypalermo/fix-work-order-status`)
+- For user `johnsmith`, branches go under `johnsmith/` (e.g., `johnsmith/add-employee-search`)
+- For AI agents (Claude, Copilot, Cursor), use the username of the account that initiated the session
+
 ## Important Notes
 
 - **No Nuget packages**: Do not add new NuGet packages or change SDK versions without explicit approval


### PR DESCRIPTION
All AI tools (Claude, Copilot, Cursor) now instructed to create branches
under a folder matching the username of the account creating the branch,
e.g. jeffreypalermo/fix-work-order-status or johnsmith/add-employee-search.

https://claude.ai/code/session_01PdjMjBe2mb3awgWmhYvNz1