### PR TITLE
Remove ClearMeasureLabs NuGet feed credentials from workflows

### DIFF
--- a/.github/workflows/IssueProcessor.yml
+++ b/.github/workflows/IssueProcessor.yml
@@ -37,18 +37,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # Configure NuGet authentication for ClearMeasureLabs feed
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        run: |
-          # Remove existing source to avoid encryption issues
-          dotnet nuget remove source ClearMeasureLabs 2>/dev/null || true
-          # Add source with credentials and clear-text password storage
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json \
-            --name ClearMeasureLabs \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} \
-            --store-password-in-clear-text
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -83,18 +71,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # Configure NuGet authentication for ClearMeasureLabs feed
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        run: |
-          # Remove existing source to avoid encryption issues
-          dotnet nuget remove source ClearMeasureLabs 2>/dev/null || true
-          # Add source with credentials and clear-text password storage
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json \
-            --name ClearMeasureLabs \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} \
-            --store-password-in-clear-text
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -128,18 +104,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-
-      # Configure NuGet authentication for ClearMeasureLabs feed
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        run: |
-          # Remove existing source to avoid encryption issues
-          dotnet nuget remove source ClearMeasureLabs 2>/dev/null || true
-          # Add source with credentials and clear-text password storage
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json \
-            --name ClearMeasureLabs \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} \
-            --store-password-in-clear-text
 
       - name: Run IssueAssigner
         env:

--- a/.github/workflows/PullRequestWatcher.yml
+++ b/.github/workflows/PullRequestWatcher.yml
@@ -32,18 +32,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # Configure NuGet authentication for ClearMeasureLabs feed
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        run: |
-          # Remove existing source to avoid encryption issues
-          dotnet nuget remove source ClearMeasureLabs 2>/dev/null || true
-          # Add source with credentials and clear-text password storage
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json \
-            --name ClearMeasureLabs \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} \
-            --store-password-in-clear-text
-
       - name: Run PullRequestWatcher
         id: watcher
         env:

--- a/.github/workflows/deploy-tdd.yml
+++ b/.github/workflows/deploy-tdd.yml
@@ -50,21 +50,6 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
-      # Configure NuGet authentication for ClearMeasureLabs feed
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        shell: pwsh
-        run: |
-          # Remove existing source to avoid encryption issues
-          dotnet nuget remove source ClearMeasureLabs 2>$null
-          if ($LASTEXITCODE -ne 0) { $LASTEXITCODE = 0 }
-          # Add source with credentials and clear-text password storage
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json `
-            --name ClearMeasureLabs `
-            --username ${{ github.actor }} `
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} `
-            --store-password-in-clear-text
-
-
       - name: Set Version
         shell: pwsh
         run: |

--- a/.github/workflows/integration-build-feature-branches.yml
+++ b/.github/workflows/integration-build-feature-branches.yml
@@ -37,19 +37,6 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
-      # Configure NuGet authentication for ClearMeasureLabs feed
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        run: |
-          # Remove existing source to avoid encryption issues
-          dotnet nuget remove source ClearMeasureLabs 2>/dev/null || true
-          # Add source with credentials and clear-text password storage
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json \
-            --name ClearMeasureLabs \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} \
-            --store-password-in-clear-text
-
-
       # Set version environment variable
       - name: Set Version
         run: |
@@ -311,15 +298,6 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        run: |
-          dotnet nuget remove source ClearMeasureLabs 2>/dev/null || true
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json \
-            --name ClearMeasureLabs \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} \
-            --store-password-in-clear-text
-
       - name: Set Version
         run: |
           version="${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ github.run_number }}"
@@ -373,15 +351,6 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        run: |
-          dotnet nuget remove source ClearMeasureLabs 2>/dev/null || true
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json \
-            --name ClearMeasureLabs \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} \
-            --store-password-in-clear-text
-
       - name: Restore solution
         run: dotnet restore src/ChurchBulletin.sln
 
@@ -421,17 +390,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
-
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        shell: pwsh
-        run: |
-          dotnet nuget remove source ClearMeasureLabs 2>$null
-          if ($LASTEXITCODE -ne 0) { $LASTEXITCODE = 0 }
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json `
-            --name ClearMeasureLabs `
-            --username ${{ github.actor }} `
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} `
-            --store-password-in-clear-text
 
       - name: Set Version
         shell: pwsh
@@ -628,15 +586,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
-
-      - name: Authenticate to ClearMeasureLabs NuGet feed
-        run: |
-          dotnet nuget remove source ClearMeasureLabs 2>/dev/null || true
-          dotnet nuget add source https://nuget.pkg.github.com/ClearMeasureLabs/index.json \
-            --name ClearMeasureLabs \
-            --username ${{ github.actor }} \
-            --password ${{ secrets.CLEARMEASURELABS_NUGET_PAT }} \
-            --store-password-in-clear-text
 
       - name: Set Version
         run: |


### PR DESCRIPTION
## Summary
- Removed the "Authenticate to ClearMeasureLabs NuGet feed" step from all GitHub Actions workflows
- Removed all references to the `CLEARMEASURELABS_NUGET_PAT` secret
- Affected workflows: `integration-build-feature-branches.yml` (5 jobs), `deploy-tdd.yml`, `IssueProcessor.yml` (3 jobs), `PullRequestWatcher.yml`

## Test plan
- [ ] Verify workflows still run successfully without the ClearMeasureLabs feed authentication
- [ ] Confirm no packages in the solution depend on the ClearMeasureLabs private feed

https://claude.ai/code/session_01D2NewdHkMNDxE1edRtZ4oK