### PR TITLE
Enable cancel-in-progress for TDD deployment concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,9 @@ jobs:
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success'
     concurrency:
-      # This will protect deployments - there should be no cancellation.
+      # A newer version deploying to TDD will cancel any previous pending or in-progress run.
       group: deploy-to-tdd-serialized
-      cancel-in-progress: false
+      cancel-in-progress: true
     runs-on: windows-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Changes TDD deployment concurrency from `cancel-in-progress: false` to `cancel-in-progress: true`
- When a newer build starts deploying to TDD, any older pending or in-progress TDD deployment is cancelled since the older version will never be deployed
- Matches the UAT concurrency behavior already configured

## Test plan
- [ ] Verify that when two builds complete in sequence, the newer deploy cancels the older TDD deployment

https://claude.ai/code/session_01NaLL5cnFHq3ont1j2HykWY