### PR TITLE
Fix TDD: correct AcceptanceTests DLL name in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,9 +181,9 @@ jobs:
           Write-Host "Extracting $($package.Name)..."
           Expand-Archive -Path $package.FullName -DestinationPath ./acceptance-tests -Force
 
-          $testDll = Get-ChildItem -Path ./acceptance-tests -Filter "AcceptanceTests.dll" -Recurse | Select-Object -First 1
+          $testDll = Get-ChildItem -Path ./acceptance-tests -Filter "ClearMeasure.Bootcamp.AcceptanceTests.dll" -Recurse | Select-Object -First 1
           if (-not $testDll) {
-            Write-Error "AcceptanceTests.dll not found in extracted package"
+            Write-Error "ClearMeasure.Bootcamp.AcceptanceTests.dll not found in extracted package"
             exit 1
           }
           Write-Host "Test DLL found at: $($testDll.FullName)"


### PR DESCRIPTION
## Summary
- Fix TDD deployment failure caused by wrong DLL name in the "Extract Acceptance Test Package" step
- The assembly name is `ClearMeasure.Bootcamp.AcceptanceTests.dll` (from the csproj `<AssemblyName>` property), not `AcceptanceTests.dll`

## Test plan
- [ ] Merge and verify TDD deployment passes the Extract step
- [ ] Verify acceptance tests run successfully in TDD

https://claude.ai/code/session_01PRW8jdkfHip2Tmic6uZh2r