### PR TITLE
Fix Playwright cache cross-contamination between x86 and ARM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -608,9 +608,9 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('src/AcceptanceTests/AcceptanceTests.csproj') }}
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/AcceptanceTests/AcceptanceTests.csproj') }}
           restore-keys: |
-            playwright-${{ runner.os }}-
+            playwright-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Set Version
         run: |
@@ -673,9 +673,9 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-arm-${{ hashFiles('src/AcceptanceTests/AcceptanceTests.csproj') }}
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/AcceptanceTests/AcceptanceTests.csproj') }}
           restore-keys: |
-            playwright-${{ runner.os }}-arm-
+            playwright-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Set Version
         run: |


### PR DESCRIPTION
## Summary
- Add `runner.arch` to Playwright browser cache keys to prevent ARM Chromium binaries from being restored on x86 runners
- x86 key changes from `playwright-Linux-<hash>` to `playwright-Linux-X64-<hash>`
- ARM key changes from `playwright-Linux-arm-<hash>` to `playwright-Linux-ARM64-<hash>`

## Problem
PR #552 modifies `AcceptanceTests.csproj`, causing the Playwright cache exact key to miss. The x86 `restore-keys` prefix `playwright-Linux-` matched the ARM cache `playwright-Linux-arm-...`, restoring ARM Chromium binaries on x86 runners. The ARM binary fails with `Syntax error: "&" unexpected` when executed on x86. Since the x86 tests fail, the correct cache is never saved, creating a self-perpetuating failure across all 5 builds (#79-#83).

## Test plan
- [ ] Verify x86 Acceptance Tests pass on this branch (currently failing on PR #552)
- [ ] Verify ARM Acceptance Tests continue to pass
- [ ] Merge into PR #552 branch and confirm it unblocks that PR

https://claude.ai/code/session_017CoYJUxvXieM194PivCgm4