### PR TITLE
Development environment setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -281,6 +281,11 @@ jobs:
           $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           $jobStatus = "${{ job.status }}"
 
+          if ($jobStatus -eq "cancelled") {
+            Write-Host "Job was cancelled (superseded by a newer deployment). Leaving status as pending."
+            exit 0
+          }
+
           if ($jobStatus -eq "success") {
             $state = "success"
             $description = "TDD deployment and acceptance tests passed"


### PR DESCRIPTION
Submitter checklist
- [ ] Issue is clearly tagged
- [x] Narrate status of the branch: Incremental change to CI workflow behavior.
- [x] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

This PR addresses the issue where GitHub Actions `deploy-to-tdd` jobs, when cancelled due to concurrency, incorrectly reported a `failure` status.

**Why this change?**
Previously, a cancelled workflow run (e.g., superseded by a newer run) would result in a red 'failed' status on the commit. This change aims to provide a more accurate visual indication in GitHub by preventing a 'failure' status for expected cancellations, instead leaving the status as 'pending' (yellow/inconclusive).

**What does this change do?**
It modifies `.github/workflows/deploy.yml` to add an early exit condition in the "Report TDD status to commit" step. If the job status is `cancelled`, the step now exits without updating the commit status, effectively leaving it in a `pending` state.

---
<p><a href="https://cursor.com/agents/bc-e4a9ec69-02ed-4f2c-aecf-fcba84baa73e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4a9ec69-02ed-4f2c-aecf-fcba84baa73e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

