### PR TITLE
Fix ShouldRespondToChat flaky test by improving retry logic

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -319,11 +319,12 @@ public abstract class AcceptanceTestBase
         await Click(saveButtonTestId);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-        WorkOrder? rehyratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
-        if (rehyratedOrder == null)
+        WorkOrder? rehyratedOrder = null;
+        for (var attempt = 0; attempt < 10; attempt++)
         {
-            await Task.Delay(1000); 
             rehyratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number));
+            if (rehyratedOrder != null) break;
+            await Task.Delay(1000);
         }
         rehyratedOrder.ShouldNotBeNull();
 


### PR DESCRIPTION
## Summary
- The `ShouldRespondToChat` acceptance test was failing on the TDD deploy (`1.4.153`) with `rehyratedOrder should not be null` because `CreateAndSaveNewWorkOrder()` had insufficient retry logic when querying the database for a just-saved work order.
- Replaced the single 1-second retry with a polling loop (up to 10 attempts, 1-second intervals) to handle asynchronous persistence latency in the deployed Azure SQL environment.
- The other chat tests (`ShouldSendChatMessageAndReceiveResponse`, `ShouldListEmployees`) passed in the same run, confirming this is a timing/race condition rather than a functional bug.