### PR TITLE
Set SQLite connection string env var for local ARM builds

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -124,6 +124,10 @@ Function Init {
 			}
 		}
 		"SQLite" {
+			if ([string]::IsNullOrEmpty($env:ConnectionStrings__SqlConnectionString)) {
+				$env:ConnectionStrings__SqlConnectionString = "Data Source=ChurchBulletin.db"
+				Log-Message -Message "Set ConnectionStrings__SqlConnectionString for SQLite: $($env:ConnectionStrings__SqlConnectionString)" -Type "INFO"
+			}
 			Log-Message -Message "SQLite mode enabled - Docker not required" -Type "INFO"
 		}
 	}


### PR DESCRIPTION
## Summary
- set ConnectionStrings__SqlConnectionString when DATABASE_ENGINE is SQLite and env var is unset
- keeps local mac ARM behavior aligned with ARM SQLite CI

## Validation
- ./PrivateBuild.ps1
- ./AcceptanceTests.ps1