### PR TITLE
Host Worker NServiceBus endpoint in-process with UI.Server

### DIFF
--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -32,7 +32,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
 		<PackageReference Include="microsoft.playwright.nunit" Version="1.54.0" />
 		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.7.1-preview.1.25365.4" />

--- a/src/AcceptanceTests/appsettings.acceptancetests.json
+++ b/src/AcceptanceTests/appsettings.acceptancetests.json
@@ -4,7 +4,6 @@
   },
   "ApplicationBaseUrl": "https://localhost:7174",
   "StartLocalServer": "true",
-  "StartWorker": "true",
   "SkipScreenshotsForSpeed": "true",
   "SlowMo": "100",
   "HeadlessTestBrowser": "true"

--- a/src/IntegrationTests/IntegrationTests.csproj
+++ b/src/IntegrationTests/IntegrationTests.csproj
@@ -37,7 +37,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -55,6 +55,9 @@ endpointConfiguration.Conventions().Add(conventions);
 
 builder.Host.UseNServiceBus(_ => endpointConfiguration);
 
+// Host the Worker's NServiceBus "WorkOrderProcessing" endpoint in-process
+builder.Services.AddHostedService<Worker.WorkOrderEndpoint>();
+
 // Build application
 var app = builder.Build();
 

--- a/src/UI/Server/UI.Server.csproj
+++ b/src/UI/Server/UI.Server.csproj
@@ -36,6 +36,7 @@
 		<ProjectReference Include="..\..\McpServer\McpServer.csproj" />
 		<ProjectReference Include="..\Client\UI.Client.csproj" />
 		<ProjectReference Include="..\Api\UI.Api.csproj" />
+		<ProjectReference Include="..\..\Worker\Worker.csproj" />
 	</ItemGroup>
 
 

--- a/src/UI/Server/appsettings.Development.json
+++ b/src/UI/Server/appsettings.Development.json
@@ -20,5 +20,8 @@
   },
   "ConnectionStrings": {
     "SqlConnectionString": "server=(LocalDb)\\MSSQLLocalDB;database=ChurchBulletin;Integrated Security=true;TrustServerCertificate=true;"
+  },
+  "RemotableBus": {
+    "ApiUrl": "https://localhost:7174/api/blazor-wasm-single-api"
   }
 }

--- a/src/UI/Server/appsettings.json
+++ b/src/UI/Server/appsettings.json
@@ -12,5 +12,8 @@
   "AI_OpenAI_ApiKey": "",
   "AI_OpenAI_Url": "",
   "AI_OpenAI_Model": "",
-  "DISABLE_AUTO_REFORMAT_AGENT": "true"
+  "DISABLE_AUTO_REFORMAT_AGENT": "true",
+  "RemotableBus": {
+    "ApiUrl": "http://localhost:8080/api/blazor-wasm-single-api"
+  }
 }


### PR DESCRIPTION
## Summary
- Register the Worker's `WorkOrderEndpoint` as an `IHostedService` in UI.Server so the NServiceBus "WorkOrderProcessing" endpoint runs alongside the web server in the same container
- Configure `RemotableBus:ApiUrl` for localhost callback (port 8080 in container, 7174 in dev)
- Remove separate Worker process management from acceptance test `ServerFixture`; set `WorkerStarted` based on SqlServerTransport availability

## Test plan
- [x] Solution builds with zero warnings/errors
- [x] All 102 unit tests pass
- [ ] Integration tests pass (requires SQL Server)
- [ ] Acceptance tests pass with TracerBulletTests no longer skipped when using SQL Server transport
- [ ] Verify Worker DLLs appear in `dotnet publish` output for UI.Server

https://claude.ai/code/session_01Bq4nUoKx7JPGXNvAZjaXmB