### PR TITLE
Restrict deploy workflow to master branch only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Build"]
     types: [completed]
+    branches: [master]
   workflow_dispatch:
     inputs:
       release_number:


### PR DESCRIPTION
## Summary
- Add `branches: [master]` filter to the `workflow_run` trigger in the deploy workflow
- Prevents the deploy pipeline from firing on feature branch builds
- Manual `workflow_dispatch` triggering remains unaffected

## Test plan
- [ ] Verify the deploy workflow no longer triggers when a feature branch build completes
- [ ] Verify the deploy workflow still triggers when a master branch build completes
- [ ] Verify manual workflow_dispatch still works from any branch

https://claude.ai/code/session_01LzruK39tjoBqdSS42KJN4t