### PR TITLE
Add acceptance tests for shelve and cancel work order commands

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderCancelTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderCancelTests.cs
@@ -1,0 +1,29 @@
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderCancelTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldAssignThenCancelWorkOrder()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order.Title = "Title from automation";
+        order.Description = "Description";
+        await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
+        await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToCancelledCommand.Name);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Title))).ToHaveValueAsync(order.Title!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToHaveValueAsync(order.Description!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status))).ToHaveTextAsync(WorkOrderStatus.Cancelled.FriendlyName);
+    }
+}

--- a/src/AcceptanceTests/WorkOrders/WorkOrderShelvedTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderShelvedTests.cs
@@ -1,0 +1,32 @@
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderShelvedTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldShelveInProgressWorkOrder()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await BeginExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order.Title = "Title from automation";
+        order.Description = "Description";
+        await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
+        await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToAssignedCommand.Name);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Title))).ToHaveValueAsync(order.Title!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToHaveValueAsync(order.Description!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee))).ToHaveValueAsync(CurrentUser.UserName);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status))).ToHaveTextAsync(WorkOrderStatus.Assigned.FriendlyName);
+    }
+}


### PR DESCRIPTION
## Changes

Add WorkOrderShelvedTests with test for shelving in-progress work orders (InProgressToAssignedCommand).
Add WorkOrderCancelTests with test for cancelling assigned work orders (AssignedToCancelledCommand).
Both tests follow the established pattern from WorkOrderBeginTests and WorkOrderAssignTests.