### PR TITLE
Add AssignedToCancelledCommand support to MCP WorkOrderTools

### DIFF
--- a/src/ChurchBulletin.sln
+++ b/src/ChurchBulletin.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FBE145BD-737C-47A5-BA88-A50ABAA81729}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.mcp.json = .mcp.json
 		..\AcceptanceTests.ps1 = ..\AcceptanceTests.ps1
 		..\build.bat = ..\build.bat
 		..\build.ps1 = ..\build.ps1

--- a/src/IntegrationTests/McpServer/McpWorkOrderToolTests.cs
+++ b/src/IntegrationTests/McpServer/McpWorkOrderToolTests.cs
@@ -126,6 +126,30 @@ public class McpWorkOrderToolTests
     }
 
     [Test]
+    public async Task ShouldCancelAssignedWorkOrder()
+    {
+        var employee = new Employee("user1", "John", "Doe", "john@test.com");
+        var order = new WorkOrder { Creator = employee, Number = "WO-300", Title = "Test", Assignee = employee, Status = WorkOrderStatus.Assigned };
+
+        await using(var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(employee);
+            context.Add(order);
+            await context.SaveChangesAsync();
+        }
+
+        var bus = TestHost.GetRequiredService<IBus>();
+        await WorkOrderTools.ExecuteWorkOrderCommand(bus, order.Number, nameof(AssignedToCancelledCommand), employee.UserName);
+
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            var updatedOrder = await context.Set<WorkOrder>().FirstOrDefaultAsync(o => o.Number == order.Number);
+            updatedOrder.ShouldNotBeNull();
+            updatedOrder.Status.ShouldBe(WorkOrderStatus.Cancelled);
+        }
+    }
+
+    [Test]
     public async Task ShouldReturnErrorForUnknownCommand()
     {
         var employee = new Employee("user1", "John", "Doe", "john@test.com");

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -124,6 +124,7 @@ public class WorkOrderTools
             "DraftToAssignedCommand" => new DraftToAssignedCommand(workOrder, user),
             "AssignedToInProgressCommand" => new AssignedToInProgressCommand(workOrder, user),
             "InProgressToCompleteCommand" => new InProgressToCompleteCommand(workOrder, user),
+            "AssignedToCancelledCommand" => new AssignedToCancelledCommand(workOrder, user),
             _ => null
         };
 


### PR DESCRIPTION
Adds cancel command support (AssignedToCancelledCommand) to the MCP WorkOrderTools, along with an integration test for cancelling an assigned work order.