### PR TITLE
Add integration test for ApplicationChatHandler create-and-assign workflow

### DIFF
--- a/src/IntegrationTests/LlmGateway/ApplicationChatHandlerTests.cs
+++ b/src/IntegrationTests/LlmGateway/ApplicationChatHandlerTests.cs
@@ -1,5 +1,7 @@
 ﻿using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.DataAccess.Mappings;
 using ClearMeasure.Bootcamp.LlmGateway;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.AI;
 using Shouldly;
 
@@ -22,5 +24,39 @@ public class ApplicationChatHandlerTests : LlmTestBase
         response.Messages.ShouldNotBeEmpty();
         response.Messages.Last().Text.ShouldNotBeNullOrWhiteSpace();
         await TestContext.Out.WriteLineAsync(response.Messages.Last().Text!);
+    }
+
+    [Test]
+    public async Task Handle_CreateAndAssignWorkOrder_CreatesAssignedWorkOrderForGwillie()
+    {
+        new ZDataLoader().LoadData();
+        var handler = TestHost.GetRequiredService<ApplicationChatHandler>();
+        var query = new ApplicationChatQuery(
+            "As tlovejoy, create a work order for mowing grass ",
+            "tlovejoy");
+
+        ChatResponse response = await handler.Handle(query, CancellationToken.None);
+
+        var responseText = response.Messages.LastOrDefault()?.Text;
+        await TestContext.Out.WriteLineAsync($"LLM response: {responseText}");
+
+        var factory = TestHost.GetRequiredService<ChatClientFactory>();
+        IChatClient parseClient = await factory.GetChatClient();
+        ChatResponse parseResponse = await parseClient.GetResponseAsync(
+        [
+            new(ChatRole.System,
+                "Extract only the work order number from the following text. " +
+                "Return nothing but the work order number itself, with no extra text."),
+            new(ChatRole.User, responseText)
+        ]);
+        var workOrderNumber = parseResponse.Messages.Last().Text!.Trim();
+        await TestContext.Out.WriteLineAsync($"Parsed work order number: {workOrderNumber}");
+
+        var db = TestHost.GetRequiredService<DataContext>();
+        var workOrder = await db.Set<WorkOrder>()
+            .SingleOrDefaultAsync(wo => wo.Number == workOrderNumber);
+
+        workOrder.ShouldNotBeNull($"No work order found with number '{workOrderNumber}'");
+        workOrder.Status.ShouldBe(WorkOrderStatus.Draft);
     }
 }


### PR DESCRIPTION
Adds an integration test that validates the ApplicationChatHandler can create a work order and assign it to gwillie via a natural language prompt. Uses a second LLM call to parse the work order number from the response, then verifies the work order exists in Draft status in the database.