### PR TITLE
[Work Item #668] Only the AI agent screen support the enter key

### DIFF
--- a/src/UnitTests/UI.Shared/Pages/ApplicationChatTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/ApplicationChatTests.cs
@@ -5,6 +5,7 @@ using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UI.Shared.Authentication;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
 using MediatR;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Palermo.BlazorMvc;
 using Shouldly;
@@ -67,6 +68,24 @@ public class ApplicationChatTests
         component.Find($"[data-testid='{ApplicationChat.Elements.ChatInput}']").ShouldNotBeNull();
         component.Find($"[data-testid='{ApplicationChat.Elements.SendButton}']").ShouldNotBeNull();
         component.FindAll(".chat-message").Count.ShouldBeGreaterThanOrEqualTo(24);
+    }
+
+    [Test]
+    public void ShouldSendMessageWhenEnterKeyPressed()
+    {
+        using var ctx = CreateContext();
+        var component = ctx.RenderComponent<ApplicationChat>();
+
+        var chatInput = component.Find($"[data-testid='{ApplicationChat.Elements.ChatInput}']");
+        chatInput.Change("test prompt via enter");
+        chatInput.KeyDown(new KeyboardEventArgs { Key = "Enter" });
+
+        component.WaitForAssertion(() =>
+        {
+            component.Find($"[data-testid='{ApplicationChat.Elements.ChatHistory}']").ShouldNotBeNull();
+            component.FindAll(".chat-message").Count.ShouldBeGreaterThanOrEqualTo(1);
+            component.Markup.ShouldContain("test prompt via enter");
+        });
     }
 
     private static TestContext CreateContext()


### PR DESCRIPTION
Closes #668

Currently on the AI agent page I have to type in a prompt and then actually click the send button for the prompt to be sent to the application. If my cursor is in the text box entering a prompt I want to be able to hit the enter key and have the prompt automatically fit. The key should be interpreted as clicking the send button.

The code review reveals that the ApplicationChat component already has Enter key handling implemented at lines 51-55 and 125-131. The `@onkeydown="HandleKeyDown"` is bound to the InputText, and `HandleKeyDown` checks for Enter key and calls `SendMessage()`.

## User Experience Design

**User Flow:**
1. User navigates to the AI Agent page (/ai-agent)
2. User clicks or tabs into the chat input text field
3. User types their prompt/question
4. User presses Enter key (or clicks Send button)
5. System validates input is not empty/whitespace
6. System displays user message in chat history
7. System shows "AI is thinking..." loading indicator
8. System sends query to AI backend
9. System displays AI response in chat history
10. System scrolls chat to bottom to show new messages
11. User can continue conversation by typing another prompt

**UI Components:**
- New: N/A - The Enter key functionality already exists in the ApplicationChat component
- Modified: N/A - The existing implementation at line 55 (`@onkeydown="HandleKeyDown"`) and lines 125-131 already handles Enter key to trigger SendMessage()

**Error States:**
- Empty input: Silently ignores Enter key press when input is empty or whitespace (line 89)
- Loading in progress: Prevents duplicate submissions while AI is processing (line 89 checks `_isLoading`)
- AI service error: Displays error message in chat as AI response (line 115: "Error: {ex.Message}")
- JS disconnect: Gracefully handles scroll failures when component is disposed (lines 79-83)

**Accessibility:**
- Keyboard navigation: Enter key submits the form without requiring mouse click; Tab navigation moves between input field and Send button
- Screen reader considerations: Button has clear "Send" label; loading state announces "AI is thinking..."; messages are semantically structured with class differentiation for user vs AI messages
- Color contrast: Uses Bootstrap btn-primary styling for Send button; distinct visual styling between user-message and ai-message classes

## Technical Design

**Affected Components:**

| Layer | File | Action |
|-------|------|--------|
| Presentation | `src/UI.Shared/Pages/ApplicationChat.razor` | Verify (no changes needed) |
| Unit Tests | `src/UnitTests/UI.Shared/Pages/ApplicationChatTests.cs` | Modify |

**Implementation Steps:**
1. Verify existing Enter key handling in `src/UI.Shared/Pages/ApplicationChat.razor` at lines 55 and 125-131 - the `@onkeydown="HandleKeyDown"` binding and `HandleKeyDown` method already implement Enter key submission
2. Add unit test to `src/UnitTests/UI.Shared/Pages/ApplicationChatTests.cs` to verify Enter key triggers message submission via bUnit keyboard event simulation

**Dependencies:** None

**Database Migrations:** None

**Tests:**

| Type | Location | Coverage |
|------|----------|----------|
| Unit | `src/UnitTests/UI.Shared/Pages/ApplicationChatTests.cs` | Test that pressing Enter key in chat input triggers SendMessage and displays user message in chat history |
| Integration | N/A | N/A |
| Acceptance | N/A | N/A |

Based on analysis of the issue and existing code, the issue explicitly states that acceptance tests are N/A - this is a UI-only change that is covered by unit tests. The feature (Enter key handling) already exists in the ApplicationChat component at lines 125-131, and the issue specifies only adding a unit test.

## Test Design

**Acceptance Tests:** None required

**Rationale:** UI-only change covered by unit tests in `src/UnitTests/UI.Shared/Pages/ApplicationChatTests.cs`. The technical design explicitly states "Acceptance | N/A | N/A" and requires only a bUnit unit test to verify Enter key triggers message submission. The existing unit test infrastructure using bUnit keyboard event simulation provides adequate coverage for this component-level interaction.