### PR TITLE
[Work Item #676] Final step screenshot for acceptance tests

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -161,6 +161,20 @@ public abstract class AcceptanceTestBase
             // Ignore tracing errors during teardown
         }
 
+        try
+        {
+            var screenshotDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "final-screenshots");
+            Directory.CreateDirectory(screenshotDir);
+            var screenshotFileName = $"{TestContext.CurrentContext.Test.ClassName}-{TestContext.CurrentContext.Test.Name}-final-{TestId}.png";
+            var screenshotPath = Path.Combine(screenshotDir, screenshotFileName);
+            await state.Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath });
+            TestContext.AddTestAttachment(screenshotPath);
+        }
+        catch
+        {
+            // Ignore screenshot errors during teardown to prevent affecting other teardown operations
+        }
+
         try { await state.Page.CloseAsync(); } catch { }
         try { await state.BrowserContext.CloseAsync(); } catch { }
         try { await state.Browser.CloseAsync(); } catch { }


### PR DESCRIPTION
Closes #676

We have a growing number of acceptance tests that use playwright in order to open up a browser and use the application but the browser closes and we have no idea what the final screen looked like before we close the browser we need an automated way to capture a final screenshot before each acceptance test ends if we can find a way to do the screen shot right before closing the browser Then we can get a good picture of what the screen looks like when the test is performing its assertions. This should be automatic across the test suite and should not be an extra line of code that every test has to declare I believe that we can do it right before the code that closes the web browser Each of these screenshots need to be saved in the proper according to the in unit framework and exported so that when in Github Actions we can see the screenshots along with the test reports automatically

The issue is about creating an MCP (Model Context Protocol) server - this is a backend-only, programmatic protocol for AI agents. There is no user-facing UI in this feature.

## User Experience Design

**User Flow:**
N/A - This feature creates an MCP server for programmatic AI agent access via stdio transport. There is no user-facing interface; AI clients (Claude, Copilot, Cursor) connect programmatically to the server process. Users interact with the work order system through their existing AI assistant interfaces, not through any new UI components in this application.

**UI Components:**
- New: N/A - No new UI components; MCP server is a headless backend process
- Modified: N/A - No existing components are modified

**Error States:**
- MCP tool precondition failures (e.g., invalid state transition): Return structured error message in MCP tool response JSON, surfaced by the AI client in its chat interface
- Database connection failure: MCP server process exits with error code; AI client reports tool unavailable
- Invalid parameters (e.g., non-existent work order number): Return descriptive error string in tool response

**Accessibility:**
- N/A - No UI components; accessibility is handled by the AI client applications (Claude, Copilot, Cursor) that consume this MCP server
- N/A - Screen reader and keyboard navigation concerns are delegated to the consuming AI client interfaces

## Technical Design

**Affected Components:**

| Layer | File | Action |
|-------|------|--------|
| Test Infrastructure | `src/AcceptanceTests/AcceptanceTestBase.cs` | Modify |

**Implementation Steps:**
1. Modify `src/AcceptanceTests/AcceptanceTestBase.cs` - Add automatic final screenshot capture in the `TearDownAsync` method before closing the browser. The screenshot should be taken after tracing stops but before `Page.CloseAsync()` is called. The screenshot filename should follow the pattern `{ClassName}-{TestName}-final-{TestId}.png` for uniqueness.
2. Modify `src/AcceptanceTests/AcceptanceTestBase.cs` - Store the final screenshot in a dedicated `final-screenshots` subdirectory under `TestContext.CurrentContext.WorkDirectory` to organize outputs alongside the existing `playwright-traces` folder.
3. Modify `src/AcceptanceTests/AcceptanceTestBase.cs` - Register the final screenshot as a test attachment using `TestContext.AddTestAttachment()` so NUnit includes it in test reports and GitHub Actions can surface it in test result artifacts.
4. Modify `src/AcceptanceTests/AcceptanceTestBase.cs` - Ensure the final screenshot is captured regardless of test outcome (pass, fail, skip) by wrapping the screenshot logic in its own try-catch block to prevent failures from affecting other teardown operations.
5. Modify `src/AcceptanceTests/AcceptanceTestBase.cs` - Ensure directory creation (`Directory.CreateDirectory`) before saving screenshots to handle parallel test execution where the directory may not exist yet.

**Dependencies:** None

**Database Migrations:** None

**Tests:**

| Type | Location | Coverage |
|------|----------|----------|
| Unit | N/A | No unit tests required - this is test infrastructure that will be validated by running the acceptance test suite itself |
| Integration | N/A | No integration tests required |
| Acceptance | `src/AcceptanceTests/` | Validation by running any existing acceptance test and verifying: (1) final screenshot PNG file exists in `final-screenshots` directory, (2) screenshot is attached to NUnit test results |

Based on the issue analysis, this is a test infrastructure change that modifies `AcceptanceTestBase.cs` to automatically capture final screenshots before closing the browser. The technical design explicitly states validation is performed by running existing acceptance tests and verifying screenshot files exist.

## Test Design

**Acceptance Tests:** None required

**Rationale:** Backend-only change - This is test infrastructure code that modifies the `AcceptanceTestBase.cs` teardown logic. Per the technical design, validation is performed by running any existing acceptance test and verifying: (1) final screenshot PNG file exists in `final-screenshots` directory, (2) screenshot is attached to NUnit test results. No new acceptance test scenarios are needed; the existing test suite serves as validation.