### PR TITLE
Fix integration test assertion for Draft status code (DFT -> DRT)

### DIFF
--- a/src/IntegrationTests/McpServer/McpReferenceResourceTests.cs
+++ b/src/IntegrationTests/McpServer/McpReferenceResourceTests.cs
@@ -15,7 +15,7 @@ public class McpReferenceResourceTests
         result.ShouldContain("Assigned");
         result.ShouldContain("InProgress");
         result.ShouldContain("Complete");
-        result.ShouldContain("DFT");
+        result.ShouldContain("DRT");
         result.ShouldContain("ASD");
         result.ShouldContain("IPG");
         result.ShouldContain("CMP");


### PR DESCRIPTION
## Summary

- Updates the `ShouldReturnAllWorkOrderStatuses` integration test assertion from `"DFT"` to `"DRT"` to match the current Draft status code introduced in commit `c9f7f99`.
- Also applies database migration `026_AddPreferredLanguageToEmployee.sql` which adds the `PreferredLanguage` column to `[dbo].[Employee]`, resolving the previously failing `PreferredLanguage` integration tests.