### PR TITLE
Force work order title to uppercase on save draft

### DIFF
--- a/src/Core/Model/StateCommands/SaveDraftCommand.cs
+++ b/src/Core/Model/StateCommands/SaveDraftCommand.cs
@@ -33,6 +33,8 @@ StateCommandBase(WorkOrder, CurrentUser)
             WorkOrder.CreatedDate = context.CurrentDateTime;
         }
 
+        WorkOrder.Title = WorkOrder.Title?.ToUpperInvariant();
+
         base.Execute(context);
     }
 }

--- a/src/UnitTests/Core/Model/StateCommands/SaveDraftCommandTests.cs
+++ b/src/UnitTests/Core/Model/StateCommands/SaveDraftCommandTests.cs
@@ -1,6 +1,7 @@
 using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.Core.Model.StateCommands;
 using ClearMeasure.Bootcamp.Core.Services;
+using Shouldly;
 
 namespace ClearMeasure.Bootcamp.UnitTests.Core.Model.StateCommands;
 
@@ -41,6 +42,38 @@ public class SaveDraftCommandTests : StateCommandBaseTests
 
         var command = new SaveDraftCommand(order, employee);
         Assert.That(command.IsValid(), Is.True);
+    }
+
+    [Test]
+    public void ShouldConvertTitleToUpperCase()
+    {
+        var order = new WorkOrder();
+        order.Number = "456";
+        order.Title = "Fix the Leaky Faucet";
+        order.Status = WorkOrderStatus.Draft;
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var command = new SaveDraftCommand(order, employee);
+        command.Execute(new StateCommandContext());
+
+        order.Title.ShouldBe("FIX THE LEAKY FAUCET");
+    }
+
+    [Test]
+    public void ShouldHandleNullTitle()
+    {
+        var order = new WorkOrder();
+        order.Number = "789";
+        order.Title = null;
+        order.Status = WorkOrderStatus.Draft;
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var command = new SaveDraftCommand(order, employee);
+        command.Execute(new StateCommandContext());
+
+        order.Title.ShouldBeNull();
     }
 
     [Test]


### PR DESCRIPTION
Closes #754

When saving a work order as a draft, the Title field is automatically converted to all uppercase letters before persisting.

**Changes:**
- Added `WorkOrder.Title = WorkOrder.Title?.ToUpperInvariant()` in `SaveDraftCommand.Execute()`
- Added unit tests for uppercase conversion and null title handling