### PR TITLE
[Work Item #800] Software Factory - Allow creator to reassign a completed work order (Complete → Assigned)

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderReassignTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderReassignTests.cs
@@ -1,0 +1,167 @@
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderReassignTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldReassignCompletedWorkOrderToSameAssignee()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await BeginExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await CompleteExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.Complete.FriendlyName);
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + CompleteToAssignedCommand.Name);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.Assigned.FriendlyName);
+
+        var rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!))
+            ?? throw new InvalidOperationException();
+        rehydratedOrder.Status.ShouldBe(WorkOrderStatus.Assigned);
+        rehydratedOrder.CompletedDate.ShouldBeNull();
+        rehydratedOrder.AssignedDate.ShouldNotBeNull();
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldReassignCompletedWorkOrderToDifferentAssignee()
+    {
+        await LoginAsCurrentUser();
+
+        var secondEmployee = CreateSecondEmployee();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await BeginExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await CompleteExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.Complete.FriendlyName);
+
+        await Select(nameof(WorkOrderManage.Elements.Assignee), secondEmployee.UserName);
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + CompleteToAssignedCommand.Name);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.Assigned.FriendlyName);
+
+        var rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!))
+            ?? throw new InvalidOperationException();
+        rehydratedOrder.Status.ShouldBe(WorkOrderStatus.Assigned);
+        rehydratedOrder.CompletedDate.ShouldBeNull();
+        rehydratedOrder.AssignedDate.ShouldNotBeNull();
+        rehydratedOrder.Assignee!.UserName.ShouldBe(secondEmployee.UserName);
+    }
+
+    [Test, Retry(2)]
+    public async Task NonCreatorShouldNotSeeReassignButtonOnCompletedWorkOrder()
+    {
+        await LoginAsCurrentUser();
+
+        var secondEmployee = CreateSecondEmployee();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await AssignExistingWorkOrder(order, secondEmployee.UserName);
+
+        CurrentUser = secondEmployee;
+        await Page.GotoAsync("/");
+        await LoginAsCurrentUser();
+
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        await BeginWorkOrderAsAssignee(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        await CompleteWorkOrderAsAssignee(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.Complete.FriendlyName);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.ReadOnlyMessage)))
+            .ToHaveTextAsync("This work order is read-only for you at this time.");
+
+        var reassignButton = Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + CompleteToAssignedCommand.Name);
+        await Expect(reassignButton).Not.ToBeVisibleAsync();
+    }
+
+    [Test, Retry(2)]
+    public async Task ReassignButtonShouldOnlyBeVisibleOnCompleteStatus()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.Draft.FriendlyName);
+        var reassignButton = Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + CompleteToAssignedCommand.Name);
+        await Expect(reassignButton).Not.ToBeVisibleAsync();
+
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.Assigned.FriendlyName);
+        reassignButton = Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + CompleteToAssignedCommand.Name);
+        await Expect(reassignButton).Not.ToBeVisibleAsync();
+
+        order = await BeginExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.InProgress.FriendlyName);
+        reassignButton = Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + CompleteToAssignedCommand.Name);
+        await Expect(reassignButton).Not.ToBeVisibleAsync();
+    }
+
+    private Employee CreateSecondEmployee()
+    {
+        using var context = IntegrationTests.TestHost.NewDbContext();
+        var employee = Faker<Employee>();
+        employee.UserName = $"test_{TestTag}_second_{employee.UserName}";
+        employee.AddRole(new Role("admin", true, true));
+        context.Add(employee);
+        context.SaveChanges();
+        return employee;
+    }
+
+    private async Task BeginWorkOrderAsAssignee(WorkOrder order)
+    {
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await woNumberLocator.WaitForAsync();
+        await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToInProgressCommand.Name);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    private async Task CompleteWorkOrderAsAssignee(WorkOrder order)
+    {
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await woNumberLocator.WaitForAsync();
+        await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToCompleteCommand.Name);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+}

--- a/src/Core/Model/StateCommands/CompleteToAssignedCommand.cs
+++ b/src/Core/Model/StateCommands/CompleteToAssignedCommand.cs
@@ -1,0 +1,35 @@
+using ClearMeasure.Bootcamp.Core.Services;
+
+namespace ClearMeasure.Bootcamp.Core.Model.StateCommands;
+
+public record CompleteToAssignedCommand(WorkOrder WorkOrder, Employee CurrentUser)
+    : StateCommandBase(WorkOrder, CurrentUser)
+{
+    public const string Name = "Reassign";
+
+    public override WorkOrderStatus GetBeginStatus()
+    {
+        return WorkOrderStatus.Complete;
+    }
+
+    public override WorkOrderStatus GetEndStatus()
+    {
+        return WorkOrderStatus.Assigned;
+    }
+
+    public override string TransitionVerbPresentTense => Name;
+
+    public override string TransitionVerbPastTense => "Reassigned";
+
+    protected override bool UserCanExecute(Employee currentUser)
+    {
+        return currentUser == WorkOrder.Creator;
+    }
+
+    public override void Execute(StateCommandContext context)
+    {
+        WorkOrder.CompletedDate = null;
+        WorkOrder.AssignedDate = context.CurrentDateTime;
+        base.Execute(context);
+    }
+}

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -74,5 +74,20 @@ public class WorkOrder : EntityBase<WorkOrder>
         return Status == WorkOrderStatus.Draft;
     }
 
+    public bool CanReassign(Employee currentUser)
+    {
+        if (Status == WorkOrderStatus.Draft)
+        {
+            return true;
+        }
+
+        if (Status == WorkOrderStatus.Complete && currentUser == Creator)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     public ICollection<WorkOrderAttachment> Attachments { get; set; } = new List<WorkOrderAttachment>();
 }

--- a/src/Core/Services/Impl/StateCommandList.cs
+++ b/src/Core/Services/Impl/StateCommandList.cs
@@ -23,6 +23,7 @@ public class StateCommandList
         commands.Add(new InProgressToAssignedCommand(workOrder, currentUser));
         commands.Add(new InProgressToCompleteCommand(workOrder, currentUser));
         commands.Add(new AssignedToCancelledCommand(workOrder, currentUser));
+        commands.Add(new CompleteToAssignedCommand(workOrder, currentUser));
 
         return commands.ToArray();
     }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -26,7 +26,7 @@
                         {
                             <InputSelect data-testid="@Elements.Assignee" id="AssignedToUserName"
                                          @bind-Value="Model.AssignedToUserName"
-                                         disabled="@(Model.WorkOrder != null && !Model.WorkOrder.CanReassign())"
+                                         disabled="@(!CanReassignAssignee())"
                                          class="form-control input-select">
                                 @foreach (var user in UserOptions)
                                 {

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -17,6 +17,7 @@ public partial class WorkOrderManage : AppComponentBase
     private WorkOrder? _workOrder;
     private WorkOrderAttachment[] _attachments = [];
     private string _preferredLanguage = "en-US";
+    private Employee? _currentUser;
     [Inject] public IWorkOrderBuilder? WorkOrderBuilder { get; set; }
     [Inject] public IUserSession? UserSession { get; set; }
     [Inject] private NavigationManager? NavigationManager { get; set; }
@@ -52,6 +53,7 @@ public partial class WorkOrderManage : AppComponentBase
     private async Task LoadWorkOrder()
     {
         var currentUser = (await UserSession!.GetCurrentUserAsync())!;
+        _currentUser = currentUser;
         _preferredLanguage = currentUser.PreferredLanguage;
         WorkOrder workOrder;
 
@@ -183,6 +185,16 @@ public partial class WorkOrderManage : AppComponentBase
         {
             // Speech synthesis may not be available in all environments
         }
+    }
+
+    private bool CanReassignAssignee()
+    {
+        if (Model.WorkOrder == null || _currentUser == null)
+        {
+            return false;
+        }
+
+        return Model.WorkOrder.CanReassign(_currentUser);
     }
 }
 

--- a/src/UnitTests/Core/Model/StateCommands/CompleteToAssignedCommandTests.cs
+++ b/src/UnitTests/Core/Model/StateCommands/CompleteToAssignedCommandTests.cs
@@ -1,0 +1,103 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Services;
+
+namespace ClearMeasure.Bootcamp.UnitTests.Core.Model.StateCommands;
+
+[TestFixture]
+public class CompleteToAssignedCommandTests : StateCommandBaseTests
+{
+    [Test]
+    public void ShouldNotBeValidInWrongStatus()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Draft;
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var command = new CompleteToAssignedCommand(order, employee);
+        Assert.That(command.IsValid(), Is.False);
+    }
+
+    [Test]
+    public void ShouldNotBeValidWithWrongEmployee()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Complete;
+        var creator = new Employee();
+        var differentEmployee = new Employee();
+        order.Creator = creator;
+
+        var command = new CompleteToAssignedCommand(order, differentEmployee);
+        Assert.That(command.IsValid(), Is.False);
+    }
+
+    [Test]
+    public void ShouldBeValid()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Complete;
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var command = new CompleteToAssignedCommand(order, employee);
+        Assert.That(command.IsValid(), Is.True);
+    }
+
+    [Test]
+    public void ShouldTransitionStateProperly()
+    {
+        var order = new WorkOrder();
+        order.Number = "123";
+        order.Status = WorkOrderStatus.Complete;
+        order.CompletedDate = DateTime.Now.AddDays(-1);
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var command = new CompleteToAssignedCommand(order, employee);
+        command.Execute(new StateCommandContext());
+
+        Assert.That(order.Status, Is.EqualTo(WorkOrderStatus.Assigned));
+        Assert.That(order.CompletedDate, Is.Null);
+        Assert.That(order.AssignedDate, Is.Not.Null);
+    }
+
+    [Test]
+    public void ShouldClearCompletedDateWhenReassigning()
+    {
+        var order = new WorkOrder();
+        order.Number = "123";
+        order.Status = WorkOrderStatus.Complete;
+        order.CompletedDate = new DateTime(2025, 1, 15);
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var command = new CompleteToAssignedCommand(order, employee);
+        command.Execute(new StateCommandContext());
+
+        Assert.That(order.CompletedDate, Is.Null);
+    }
+
+    [Test]
+    public void ShouldUpdateAssignedDateWhenReassigning()
+    {
+        var order = new WorkOrder();
+        order.Number = "123";
+        order.Status = WorkOrderStatus.Complete;
+        order.CompletedDate = new DateTime(2025, 1, 15);
+        order.AssignedDate = new DateTime(2025, 1, 10);
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var context = new StateCommandContext { CurrentDateTime = new DateTime(2025, 2, 1) };
+        var command = new CompleteToAssignedCommand(order, employee);
+        command.Execute(context);
+
+        Assert.That(order.AssignedDate, Is.EqualTo(new DateTime(2025, 2, 1)));
+    }
+
+    protected override StateCommandBase GetStateCommand(WorkOrder order, Employee employee)
+    {
+        return new CompleteToAssignedCommand(order, employee);
+    }
+}

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -80,4 +80,59 @@ public class WorkOrderTests
         order.ChangeStatus(WorkOrderStatus.Assigned);
         Assert.That(order.Status, Is.EqualTo(WorkOrderStatus.Assigned));
     }
+
+    [Test]
+    public void CanReassign_WithCurrentUser_ShouldReturnTrueForDraftStatus()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Draft;
+        var employee = new Employee();
+
+        Assert.That(order.CanReassign(employee), Is.True);
+    }
+
+    [Test]
+    public void CanReassign_WithCurrentUser_ShouldReturnTrueForCompleteStatusWhenUserIsCreator()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Complete;
+        var creator = new Employee();
+        order.Creator = creator;
+
+        Assert.That(order.CanReassign(creator), Is.True);
+    }
+
+    [Test]
+    public void CanReassign_WithCurrentUser_ShouldReturnFalseForCompleteStatusWhenUserIsNotCreator()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Complete;
+        var creator = new Employee();
+        var otherEmployee = new Employee();
+        order.Creator = creator;
+
+        Assert.That(order.CanReassign(otherEmployee), Is.False);
+    }
+
+    [Test]
+    public void CanReassign_WithCurrentUser_ShouldReturnFalseForAssignedStatus()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Assigned;
+        var employee = new Employee();
+        order.Creator = employee;
+
+        Assert.That(order.CanReassign(employee), Is.False);
+    }
+
+    [Test]
+    public void CanReassign_WithCurrentUser_ShouldReturnFalseForInProgressStatus()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.InProgress;
+        var employee = new Employee();
+        order.Creator = employee;
+
+        Assert.That(order.CanReassign(employee), Is.False);
+    }
 }

--- a/src/UnitTests/Core/Services/StateCommandListTests.cs
+++ b/src/UnitTests/Core/Services/StateCommandListTests.cs
@@ -25,7 +25,7 @@ public class StateCommandListTests
         var facilitator = new StateCommandList();
         var commands = facilitator.GetAllStateCommands(new WorkOrder(), new Employee());
 
-        Assert.That(commands.Length, Is.EqualTo(6));
+        Assert.That(commands.Length, Is.EqualTo(7));
 
         Assert.That(commands[0], Is.InstanceOf(typeof(SaveDraftCommand)));
         Assert.That(commands[1], Is.InstanceOf(typeof(DraftToAssignedCommand)));
@@ -33,6 +33,7 @@ public class StateCommandListTests
         Assert.That(commands[3], Is.InstanceOf(typeof(InProgressToAssignedCommand)));
         Assert.That(commands[4], Is.InstanceOf(typeof(InProgressToCompleteCommand)));
         Assert.That(commands[5], Is.InstanceOf(typeof(AssignedToCancelledCommand)));
+        Assert.That(commands[6], Is.InstanceOf(typeof(CompleteToAssignedCommand)));
     }
 
     [Test]


### PR DESCRIPTION
Closes #800

## Summary

The creator of a work order should be able to reassign a completed work order to an assignee. When this happens, the work order status should transition from **Complete** back to **Assigned**, allowing the assignee to begin it again when ready.

Currently, **Complete** is a terminal state with no outbound transitions. This feature adds a new transition: `Complete → Assigned`, executable by the **Creator**.

TODO: Create an open spec for this before implementing

## User Experience Design

**User Flow:**
1. Creator navigates to a completed work order they previously created
2. System displays the work order in read-only mode with status "Complete" and the "Completed Date" field populated
3. Creator sees a "Reassign" button in the action section (only visible because they are the creator)
4. Creator clicks the "Reassign" button
5. System enables the "Assigned To" dropdown, allowing the creator to select a new assignee
6. Creator selects an assignee from the dropdown (may keep the same assignee or choose a different one)
7. Creator clicks the "Reassign" button to confirm
8. System transitions the work order status from "Complete" to "Assigned", clears the "Completed Date", and updates the "Assigned Date"
9. System displays the work order in editable mode (for the assignee) or read-only mode (for the creator, if they are not the assignee) with status "Assigned"

**UI Components:**
- New: `CompleteToAssignedCommand` state command - enables the "Reassign" button for creators viewing completed work orders they created
- Modified: `WorkOrderManage.razor` - the existing action button rendering loop (`@foreach (var command in ValidCommands)`) automatically displays the new "Reassign" button when the `CompleteToAssignedCommand` is valid
- Modified: `WorkOrder.CanReassign()` method - update to return `true` when status is `Complete` AND the current user is the creator, enabling the assignee dropdown
- Modified: `StateCommandList` - no changes needed; the existing `GetValidStateCommands()` logic automatically includes the new command when conditions are met

**Error States:**
- Non-creator views completed work order: "This work order is read-only for you at this time." message displayed in the action section (existing behavior)
- No assignee selected: Form validation prevents submission; DataAnnotationsValidator displays error in the validation summary
- Network/server error during transition: Standard error handling displays failure message; work order remains in Complete status

**Accessibility:**
- Keyboard navigation: "Reassign" button is focusable via Tab key and activatable via Enter/Space (follows existing button pattern with `btn btn-primary` class)
- Screen reader considerations: Button text "Reassign" clearly communicates the action; status changes are reflected in the heading which screen readers can announce via aria-live region or page refresh
- Color contrast: Uses existing `.btn-primary` styling (white text on purple gradient background) which meets WCAG AA contrast requirements; action section uses standard form controls with sufficient contrast ratios

Technical design document created at `openspec/800-technical-design.md`. The document covers:

- **7 affected components** across Domain, Unit Tests, Integration Tests, and Acceptance Tests layers
- **8 implementation steps** ordered logically: domain changes first, then UI updates, followed by tests
- **Key changes**: New `CompleteToAssignedCommand` state command, modified `CanReassign()` method with user parameter, UI updates to enable assignee dropdown for creator on completed work orders
- **No dependencies or database migrations** required - all changes are application-level

## Test Design

**Test Scenarios:**

### Scenario 1: Creator reassigns completed work order to same assignee
**Given:** A work order exists in Complete status, created by the current user, and the current user is logged in as the creator
**When:** The creator navigates to the completed work order, clicks the "Reassign" button, keeps the same assignee selected, and clicks "Reassign" to confirm
**Then:** The work order status transitions from "Complete" to "Assigned", the "Completed Date" field is cleared, the "Assigned Date" field is updated to the current date/time, and the work order displays with status "Assigned"

### Scenario 2: Creator reassigns completed work order to different assignee
**Given:** A work order exists in Complete status, created by the current user, and at least one other employee exists who can fulfill work orders
**When:** The creator navigates to the completed work order, clicks the "Reassign" button, selects a different assignee from the dropdown, and clicks "Reassign" to confirm
**Then:** The work order status transitions from "Complete" to "Assigned", the assignee is updated to the newly selected employee, the "Completed Date" field is cleared, the "Assigned Date" field is updated to the current date/time, and the work order displays with status "Assigned"

### Scenario 3: Non-creator cannot reassign completed work order
**Given:** A work order exists in Complete status, created by a different user, and the current user is logged in as a non-creator (e.g., the original assignee)
**When:** The non-creator navigates to the completed work order
**Then:** The work order displays in read-only mode, the "Reassign" button is not visible, and the read-only message "This work order is read-only for you at this time." is displayed

### Scenario 4: Reassign button only visible on Complete status
**Given:** A work order exists in Draft, Assigned, or InProgress status, created by the current user
**When:** The creator navigates to the work order
**Then:** The "Reassign" button is not visible in the action section (only status-appropriate buttons are displayed)

**Test Data Requirements:**
- Employee with admin role (can create and fulfill work orders) for creator role
- Second employee with fulfiller role for non-creator and alternative assignee scenarios
- Work order in Complete status created by test user with an assigned and completed date populated
- Work order in Draft/Assigned/InProgress status for negative scenario testing

**Test Location:** `src/AcceptanceTests/WorkOrders/WorkOrderReassignTests.cs`