### PR TITLE
[Work Item #801] Software Factory - Allow assignee to reopen a completed work order back to In Progress status

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderReopenTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderReopenTests.cs
@@ -1,0 +1,54 @@
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderReopenTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldReopenCompletedWorkOrder()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order = await BeginExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order = await CompleteExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        var rehyratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ??
+                             throw new InvalidOperationException();
+        rehyratedOrder.Status.ShouldBe(WorkOrderStatus.Complete);
+        rehyratedOrder.CompletedDate.ShouldNotBeNull();
+
+        order = await ReopenExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        rehyratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ??
+                         throw new InvalidOperationException();
+        rehyratedOrder.Status.ShouldBe(WorkOrderStatus.InProgress);
+        rehyratedOrder.CompletedDate.ShouldBeNull();
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
+            .ToHaveTextAsync(WorkOrderStatus.InProgress.FriendlyName);
+    }
+
+    private async Task<WorkOrder> ReopenExistingWorkOrder(WorkOrder order)
+    {
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await woNumberLocator.WaitForAsync();
+        await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + CompleteToInProgressCommand.Name);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+        WorkOrder rehyratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ?? throw new InvalidOperationException();
+        return rehyratedOrder;
+    }
+}

--- a/src/Core/Model/StateCommands/CompleteToInProgressCommand.cs
+++ b/src/Core/Model/StateCommands/CompleteToInProgressCommand.cs
@@ -1,0 +1,33 @@
+using ClearMeasure.Bootcamp.Core.Services;
+
+namespace ClearMeasure.Bootcamp.Core.Model.StateCommands;
+
+public record CompleteToInProgressCommand(WorkOrder WorkOrder, Employee CurrentUser) : StateCommandBase(WorkOrder,
+CurrentUser)
+{
+    public const string Name = "Reopen";
+    public override string TransitionVerbPresentTense => Name;
+
+    public override string TransitionVerbPastTense => "Reopened";
+
+    public override WorkOrderStatus GetBeginStatus()
+    {
+        return WorkOrderStatus.Complete;
+    }
+
+    public override WorkOrderStatus GetEndStatus()
+    {
+        return WorkOrderStatus.InProgress;
+    }
+
+    protected override bool UserCanExecute(Employee currentUser)
+    {
+        return currentUser == WorkOrder.Assignee;
+    }
+
+    public override void Execute(StateCommandContext context)
+    {
+        WorkOrder.CompletedDate = null;
+        base.Execute(context);
+    }
+}

--- a/src/Core/Services/Impl/StateCommandList.cs
+++ b/src/Core/Services/Impl/StateCommandList.cs
@@ -23,6 +23,7 @@ public class StateCommandList
         commands.Add(new InProgressToAssignedCommand(workOrder, currentUser));
         commands.Add(new InProgressToCompleteCommand(workOrder, currentUser));
         commands.Add(new AssignedToCancelledCommand(workOrder, currentUser));
+        commands.Add(new CompleteToInProgressCommand(workOrder, currentUser));
 
         return commands.ToArray();
     }

--- a/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForReopenTests.cs
+++ b/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForReopenTests.cs
@@ -1,0 +1,49 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.DataAccess.Handlers;
+using ClearMeasure.Bootcamp.UnitTests.Core.Queries;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.DataAccess.Handlers;
+
+public class StateCommandHandlerForReopenTests : IntegratedTestBase
+{
+    [Test]
+    public async Task ShouldReopenWorkOrder()
+    {
+        new DatabaseTests().Clean();
+
+        var o = Faker<WorkOrder>();
+        o.Id = Guid.Empty;
+        var currentUser = Faker<Employee>();
+        o.Creator = currentUser;
+        o.Assignee = currentUser;
+        o.Status = WorkOrderStatus.Complete;
+        o.CompletedDate = DateTime.Now;
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(currentUser);
+            context.Add(o);
+            await context.SaveChangesAsync();
+        }
+
+        o.Title = "new title";
+        o.Description = "new desc";
+        o.RoomNumber = "new room";
+        var command = new CompleteToInProgressCommand(o, currentUser);
+        var remotedCommand = RemotableRequestTests.SimulateRemoteObject(command);
+
+        var handler = TestHost.GetRequiredService<StateCommandHandler>();
+        var result = await handler.Handle(remotedCommand);
+
+        var context3 = TestHost.GetRequiredService<DbContext>();
+        var order = context3.Find<WorkOrder>(result.WorkOrder.Id) ?? throw new InvalidOperationException();
+        order.Title.ShouldBe(order.Title);
+        order.Description.ShouldBe(order.Description);
+        order.Creator.ShouldBe(currentUser);
+        order.Assignee.ShouldBe(currentUser);
+        order.Status.ShouldBe(WorkOrderStatus.InProgress);
+        order.CompletedDate.ShouldBeNull();
+    }
+}

--- a/src/UnitTests/Core/Model/StateCommands/CompleteToInProgressCommandTests.cs
+++ b/src/UnitTests/Core/Model/StateCommands/CompleteToInProgressCommandTests.cs
@@ -1,0 +1,67 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Services;
+
+namespace ClearMeasure.Bootcamp.UnitTests.Core.Model.StateCommands;
+
+[TestFixture]
+public class CompleteToInProgressCommandTests : StateCommandBaseTests
+{
+    [Test]
+    public void ShouldNotBeValidInWrongStatus()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.InProgress;
+        var employee = new Employee();
+        order.Assignee = employee;
+
+        var command = new CompleteToInProgressCommand(order, employee);
+        Assert.That(command.IsValid(), Is.False);
+    }
+
+    [Test]
+    public void ShouldNotBeValidWithWrongEmployee()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Complete;
+        var employee = new Employee();
+        order.Assignee = employee;
+
+        var command = new CompleteToInProgressCommand(order, new Employee());
+        Assert.That(command.IsValid(), Is.False);
+    }
+
+    [Test]
+    public void ShouldBeValid()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Complete;
+        var employee = new Employee();
+        order.Assignee = employee;
+
+        var command = new CompleteToInProgressCommand(order, employee);
+        Assert.That(command.IsValid(), Is.True);
+    }
+
+    [Test]
+    public void ShouldTransitionStateProperly()
+    {
+        var order = new WorkOrder();
+        order.Number = "123";
+        order.Status = WorkOrderStatus.Complete;
+        order.CompletedDate = DateTime.Now;
+        var employee = new Employee();
+        order.Assignee = employee;
+
+        var command = new CompleteToInProgressCommand(order, employee);
+        command.Execute(new StateCommandContext());
+
+        Assert.That(order.Status, Is.EqualTo(WorkOrderStatus.InProgress));
+        Assert.That(order.CompletedDate, Is.Null);
+    }
+
+    protected override StateCommandBase GetStateCommand(WorkOrder order, Employee employee)
+    {
+        return new CompleteToInProgressCommand(order, employee);
+    }
+}

--- a/src/UnitTests/Core/Services/StateCommandListTests.cs
+++ b/src/UnitTests/Core/Services/StateCommandListTests.cs
@@ -25,7 +25,7 @@ public class StateCommandListTests
         var facilitator = new StateCommandList();
         var commands = facilitator.GetAllStateCommands(new WorkOrder(), new Employee());
 
-        Assert.That(commands.Length, Is.EqualTo(6));
+        Assert.That(commands.Length, Is.EqualTo(7));
 
         Assert.That(commands[0], Is.InstanceOf(typeof(SaveDraftCommand)));
         Assert.That(commands[1], Is.InstanceOf(typeof(DraftToAssignedCommand)));
@@ -33,6 +33,7 @@ public class StateCommandListTests
         Assert.That(commands[3], Is.InstanceOf(typeof(InProgressToAssignedCommand)));
         Assert.That(commands[4], Is.InstanceOf(typeof(InProgressToCompleteCommand)));
         Assert.That(commands[5], Is.InstanceOf(typeof(AssignedToCancelledCommand)));
+        Assert.That(commands[6], Is.InstanceOf(typeof(CompleteToInProgressCommand)));
     }
 
     [Test]


### PR DESCRIPTION
Closes #801

## Summary

The assignee of a work order should be able to reopen a completed work order. When this happens, the status should transition from **Complete** back to **In Progress**.

TODO: Create an open spec for this before implementing

## User Experience Design

**User Flow:**
1. User (assignee) navigates to work order search page
2. User locates a completed work order they are assigned to
3. User clicks on the work order row to view details
4. System displays WorkOrderManage page showing status "Complete" in header
5. System evaluates valid state commands for current user and work order
6. System displays "Reopen" button in action-buttons section (assignee only)
7. User clicks "Reopen" button
8. System transitions work order status from Complete to In Progress
9. System clears CompletedDate field
10. System navigates user back to work order search page
11. Work order now shows status "In Progress" in search results

**UI Components:**
- New: CompleteToInProgressCommand - State command enabling Complete → In Progress transition with "Reopen" verb, restricted to assignee
- Modified: StateCommandList.GetAllStateCommands() - Add CompleteToInProgressCommand to available commands list
- Modified: WorkOrderManage page - No changes needed; existing ValidCommands loop will automatically render "Reopen" button when command is valid

**Error States:**
- User is not the assignee: "Reopen" button not displayed; page shows read-only message "This work order is read-only for you at this time."
- Work order is not in Complete status: "Reopen" button not displayed; only valid commands for current status shown
- Concurrent modification: Standard EF Core optimistic concurrency handling; user sees error and must refresh

**Accessibility:**
- Keyboard navigation: "Reopen" button is a standard HTML button element, fully keyboard accessible via Tab navigation and Enter/Space activation
- Screen reader considerations: Button text "Reopen" is descriptive; work order status displayed in page header provides context; status change reflected in page title on navigation
- Color contrast: Existing btn-primary styling meets WCAG AA contrast requirements (white text on purple gradient background)
- Focus indicators: Existing CSS provides visible focus states via box-shadow on form controls and buttons
- Mobile responsiveness: Existing responsive CSS handles button layout on smaller screens via flex-wrap and column layout at 768px breakpoint

## Technical Design

**Affected Components:**

| Layer | File | Action |
|-------|------|--------|
| Domain | `src/Core/Model/StateCommands/CompleteToInProgressCommand.cs` | Create |
| Domain | `src/Core/Services/Impl/StateCommandList.cs` | Modify |
| Unit Tests | `src/UnitTests/Core/Model/StateCommands/CompleteToInProgressCommandTests.cs` | Create |
| Unit Tests | `src/UnitTests/Core/Services/StateCommandListTests.cs` | Modify |
| Integration Tests | `src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForReopenTests.cs` | Create |
| Acceptance Tests | `src/AcceptanceTests/WorkOrders/WorkOrderReopenTests.cs` | Create |

**Implementation Steps:**

1. Create `src/Core/Model/StateCommands/CompleteToInProgressCommand.cs` - New state command with "Reopen" verb, Complete→InProgress transition, assignee-only access, clears CompletedDate

2. Modify `src/Core/Services/Impl/StateCommandList.cs` - Add CompleteToInProgressCommand to GetAllStateCommands()

3. Create `src/UnitTests/Core/Model/StateCommands/CompleteToInProgressCommandTests.cs` - Validity and transition tests

4. Modify `src/UnitTests/Core/Services/StateCommandListTests.cs` - Update command count assertion to 7

5. Create `src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForReopenTests.cs` - Database persistence test

6. Create `src/AcceptanceTests/WorkOrders/WorkOrderReopenTests.cs` - Full UI workflow test

**Dependencies:** None

**Database Migrations:** None

Technical design saved to `openspec/801-technical-design.md`.

Now I have sufficient information to create the test design document.

## Test Design

**Test Scenarios:**

### Scenario 1: Assignee Reopens Completed Work Order
**Given:** A work order exists in Complete status and the current user is the assignee of that work order
**When:** The user navigates to the work order search page, clicks on the completed work order row, views the WorkOrderManage page showing "Complete" status, and clicks the "Reopen" button
**Then:** The work order status transitions from Complete to In Progress, the CompletedDate field is cleared (null), the user is navigated back to the work order search page, and the work order displays status "In Progress" in search results

### Scenario 2: Non-Assignee Cannot See Reopen Button
**Given:** A work order exists in Complete status and the current user is NOT the assignee of that work order
**When:** The user navigates to the work order and views the WorkOrderManage page
**Then:** The "Reopen" button is not displayed, and the page shows the read-only message "This work order is read-only for you at this time."

### Scenario 3: Reopen Button Not Displayed for Non-Complete Status
**Given:** A work order exists in In Progress status and the current user is the assignee
**When:** The user navigates to the work order and views the WorkOrderManage page
**Then:** The "Reopen" button is not displayed, only valid commands for the In Progress status are shown (e.g., "Complete" button)

**Test Data Requirements:**
- Work order in Complete status with an assigned employee (for Scenario 1 and 2)
- Work order in In Progress status with an assigned employee (for Scenario 3)
- Two test users: one as assignee, one as non-assignee (for Scenario 2)
- Test users with admin role (CanCreateWorkOrder and CanFulfillWorkOrder permissions)

**Test Location:** `src/AcceptanceTests/WorkOrders/WorkOrderReopenTests.cs`