### PR TITLE
[Work Item #802] Software Factory - Allow creator to unassign an assigned work order back to Draft status

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderUnassignTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderUnassignTests.cs
@@ -1,0 +1,29 @@
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderUnassignTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldAssignThenUnassignWorkOrderBackToDraft()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order.Title = "Title from automation";
+        order.Description = "Description";
+        await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
+        await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToDraftCommand.Name);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Title))).ToHaveValueAsync(order.Title!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToHaveValueAsync(order.Description!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status))).ToHaveTextAsync(WorkOrderStatus.Draft.FriendlyName);
+    }
+}

--- a/src/Core/Model/StateCommands/AssignedToDraftCommand.cs
+++ b/src/Core/Model/StateCommands/AssignedToDraftCommand.cs
@@ -1,0 +1,34 @@
+using ClearMeasure.Bootcamp.Core.Services;
+
+namespace ClearMeasure.Bootcamp.Core.Model.StateCommands;
+
+public record AssignedToDraftCommand(WorkOrder WorkOrder, Employee CurrentUser) : StateCommandBase(WorkOrder,
+    CurrentUser)
+{
+    public const string Name = "Unassign";
+    public override string TransitionVerbPresentTense => Name;
+
+    public override string TransitionVerbPastTense => "Unassigned";
+
+    public override WorkOrderStatus GetBeginStatus()
+    {
+        return WorkOrderStatus.Assigned;
+    }
+
+    public override WorkOrderStatus GetEndStatus()
+    {
+        return WorkOrderStatus.Draft;
+    }
+
+    protected override bool UserCanExecute(Employee currentUser)
+    {
+        return currentUser == WorkOrder.Creator;
+    }
+
+    public override void Execute(StateCommandContext context)
+    {
+        WorkOrder.AssignedDate = null;
+        WorkOrder.Assignee = null;
+        base.Execute(context);
+    }
+}

--- a/src/Core/Services/Impl/StateCommandList.cs
+++ b/src/Core/Services/Impl/StateCommandList.cs
@@ -23,6 +23,7 @@ public class StateCommandList
         commands.Add(new InProgressToAssignedCommand(workOrder, currentUser));
         commands.Add(new InProgressToCompleteCommand(workOrder, currentUser));
         commands.Add(new AssignedToCancelledCommand(workOrder, currentUser));
+        commands.Add(new AssignedToDraftCommand(workOrder, currentUser));
 
         return commands.ToArray();
     }

--- a/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForUnassignTests.cs
+++ b/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForUnassignTests.cs
@@ -1,0 +1,78 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.DataAccess.Handlers;
+using ClearMeasure.Bootcamp.UnitTests.Core.Queries;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.DataAccess.Handlers;
+
+public class StateCommandHandlerForUnassignTests : IntegratedTestBase
+{
+    [Test]
+    public async Task ShouldUnassignWorkOrderAndSetStatusToDraft()
+    {
+        new DatabaseTests().Clean();
+
+        var workOrder = Faker<WorkOrder>();
+        workOrder.Id = Guid.Empty;
+        var creator = Faker<Employee>();
+        var assignee = Faker<Employee>();
+        workOrder.Creator = creator;
+        workOrder.Assignee = assignee;
+        workOrder.AssignedDate = DateTime.Now;
+        workOrder.Status = WorkOrderStatus.Assigned;
+
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(assignee);
+            await context.SaveChangesAsync();
+        }
+
+        var command = RemotableRequestTests.SimulateRemoteObject(new AssignedToDraftCommand(workOrder, creator));
+
+        var handler = TestHost.GetRequiredService<StateCommandHandler>();
+
+        var result = await handler.Handle(command);
+
+        var context3 = TestHost.GetRequiredService<DbContext>();
+        var order = context3.Find<WorkOrder>(result.WorkOrder.Id) ?? throw new InvalidOperationException();
+        order.Status.ShouldBe(WorkOrderStatus.Draft);
+        order.Creator.ShouldBe(creator);
+        order.Assignee.ShouldBeNull();
+        order.AssignedDate.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task ShouldUnassignWorkOrderWithRemotedCommand()
+    {
+        new DatabaseTests().Clean();
+
+        var workOrder = Faker<WorkOrder>();
+        workOrder.Id = Guid.Empty;
+        var creator = Faker<Employee>();
+        workOrder.Creator = creator;
+        workOrder.Status = WorkOrderStatus.Assigned;
+
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(workOrder);
+            await context.SaveChangesAsync();
+        }
+
+        var command = new AssignedToDraftCommand(workOrder, creator);
+        var remotedCommand = RemotableRequestTests.SimulateRemoteObject(command);
+
+        var handler = TestHost.GetRequiredService<StateCommandHandler>();
+        var result = await handler.Handle(remotedCommand);
+
+        var context3 = TestHost.GetRequiredService<DbContext>();
+        var order = context3.Find<WorkOrder>(result.WorkOrder.Id) ?? throw new InvalidOperationException();
+        order.Status.ShouldBe(WorkOrderStatus.Draft);
+        order.Creator.ShouldBe(creator);
+        order.Assignee.ShouldBeNull();
+        order.AssignedDate.ShouldBeNull();
+    }
+}

--- a/src/UnitTests/Core/Model/StateCommands/AssignedToDraftCommandTests.cs
+++ b/src/UnitTests/Core/Model/StateCommands/AssignedToDraftCommandTests.cs
@@ -1,0 +1,69 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Services;
+
+namespace ClearMeasure.Bootcamp.UnitTests.Core.Model.StateCommands;
+
+[TestFixture]
+public class AssignedToDraftCommandTests : StateCommandBaseTests
+{
+    [Test]
+    public void ShouldNotBeValidInWrongStatus()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Draft;
+        var employee = new Employee();
+        order.Assignee = employee;
+
+        var command = new AssignedToDraftCommand(order, employee);
+        Assert.That(command.IsValid(), Is.False);
+    }
+
+    [Test]
+    public void ShouldNotBeValidWithWrongEmployee()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Assigned;
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var command = new AssignedToDraftCommand(order, new Employee());
+        Assert.That(command.IsValid(), Is.False);
+    }
+
+    [Test]
+    public void ShouldBeValid()
+    {
+        var order = new WorkOrder();
+        order.Status = WorkOrderStatus.Assigned;
+        var employee = new Employee();
+        order.Creator = employee;
+
+        var command = new AssignedToDraftCommand(order, employee);
+        Assert.That(command.IsValid(), Is.True);
+    }
+
+    [Test]
+    public void ShouldTransitionStateProperly()
+    {
+        var order = new WorkOrder();
+        order.Number = "123";
+        order.Status = WorkOrderStatus.Assigned;
+        var employee = new Employee();
+        var assignee = new Employee();
+        order.Assignee = assignee;
+        order.AssignedDate = DateTime.Now;
+
+        var command = new AssignedToDraftCommand(order, employee);
+        command.Execute(new StateCommandContext());
+
+        Assert.That(order.Status, Is.EqualTo(WorkOrderStatus.Draft));
+        Assert.That(order.Assignee, Is.Null);
+        Assert.That(order.AssignedDate, Is.Null);
+    }
+
+    protected override StateCommandBase GetStateCommand(WorkOrder order, Employee employee)
+    {
+        return new AssignedToDraftCommand(order, employee);
+    }
+}

--- a/src/UnitTests/Core/Services/StateCommandListTests.cs
+++ b/src/UnitTests/Core/Services/StateCommandListTests.cs
@@ -25,7 +25,7 @@ public class StateCommandListTests
         var facilitator = new StateCommandList();
         var commands = facilitator.GetAllStateCommands(new WorkOrder(), new Employee());
 
-        Assert.That(commands.Length, Is.EqualTo(6));
+        Assert.That(commands.Length, Is.EqualTo(7));
 
         Assert.That(commands[0], Is.InstanceOf(typeof(SaveDraftCommand)));
         Assert.That(commands[1], Is.InstanceOf(typeof(DraftToAssignedCommand)));
@@ -33,6 +33,7 @@ public class StateCommandListTests
         Assert.That(commands[3], Is.InstanceOf(typeof(InProgressToAssignedCommand)));
         Assert.That(commands[4], Is.InstanceOf(typeof(InProgressToCompleteCommand)));
         Assert.That(commands[5], Is.InstanceOf(typeof(AssignedToCancelledCommand)));
+        Assert.That(commands[6], Is.InstanceOf(typeof(AssignedToDraftCommand)));
     }
 
     [Test]


### PR DESCRIPTION
Closes #802

## Summary

The creator of a work order should be able to unassign an assigned work order, returning it to Draft status. This covers the scenario where a creator mistakenly assigns a work order too quickly and needs to revert it.

TODO: Create an open spec for this before implementing

Now creating the UX design document based on the analysis of the existing patterns.

## User Experience Design

**User Flow:**
1. Creator navigates to an assigned work order they created via work order search or direct link
2. System displays the WorkOrderManage page with work order details and status "Assigned"
3. Creator sees the "Unassign" button in the action buttons section (alongside other valid commands like "Cancel")
4. Creator clicks the "Unassign" button
5. System validates the action (creator must be the work order creator, status must be "Assigned")
6. System clears the Assignee and AssignedDate fields, changes status to "Draft"
7. System navigates back to work order search with success state
8. Work order now appears in Draft status, allowing the creator to edit and reassign

**UI Components:**
- New: "Unassign" action button - follows existing `StateCommandBase` button pattern in WorkOrderManage.razor (lines 125-132), rendered dynamically when `AssignedToDraftCommand.IsValid()` returns true
- New: `AssignedToDraftCommand` state command class - follows pattern of `AssignedToCancelledCommand.cs` (transitions from Assigned status, only creator can execute)
- Modified: `StateCommandList.cs` - add `AssignedToDraftCommand` to the list of available commands returned by `GetAllStateCommands()`
- Modified: None to WorkOrderManage.razor - existing dynamic button rendering pattern automatically displays new command

**Error States:**
- Non-creator attempts unassign: Button not displayed (filtered out by `IsValid()` check in `StateCommandList.GetValidStateCommands()`)
- Work order not in Assigned status: Button not displayed (filtered by `GetBeginStatus()` returning `WorkOrderStatus.Assigned`)
- Concurrent modification (work order status changed): Standard EF Core concurrency handling displays error message in ValidationSummary
- Network/server error: Blazor error handling displays generic error message

**Accessibility:**
- Keyboard navigation: Button is focusable via Tab key, activates with Enter/Space (standard HTML button behavior, consistent with existing action buttons)
- Screen reader considerations: Button text "Unassign" is self-descriptive; no additional aria-label needed; status change announced via page reload showing updated status in heading
- Color contrast: Uses existing `btn btn-primary` Bootstrap class which meets WCAG AA contrast requirements
- Mobile responsiveness: Button follows existing `.action-buttons` flexbox layout that wraps on smaller screens (defined in WorkOrderManage.razor.css)

## Technical Design

**Affected Components:**

| Layer | File | Action |
|-------|------|--------|
| Domain | `src/Core/Model/StateCommands/AssignedToDraftCommand.cs` | Create |
| Domain | `src/Core/Services/Impl/StateCommandList.cs` | Modify |
| Unit Tests | `src/UnitTests/Core/Model/StateCommands/AssignedToDraftCommandTests.cs` | Create |
| Unit Tests | `src/UnitTests/Core/Services/StateCommandListTests.cs` | Modify |
| Integration Tests | `src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForUnassignTests.cs` | Create |
| Acceptance Tests | `src/AcceptanceTests/WorkOrders/WorkOrderUnassignTests.cs` | Create |

**Implementation Steps:**

1. Create `src/Core/Model/StateCommands/AssignedToDraftCommand.cs` - new state command class following `AssignedToCancelledCommand.cs` pattern: transition from `WorkOrderStatus.Assigned` to `WorkOrderStatus.Draft`, `UserCanExecute` returns true only when `currentUser == WorkOrder.Creator`, `Execute` clears `Assignee` and `AssignedDate`, `TransitionVerbPresentTense` returns "Unassign", `TransitionVerbPastTense` returns "Unassigned"

2. Modify `src/Core/Services/Impl/StateCommandList.cs` - add `new AssignedToDraftCommand(workOrder, currentUser)` to the list in `GetAllStateCommands()` method (line ~26, after `AssignedToCancelledCommand`)

3. Create `src/UnitTests/Core/Model/StateCommands/AssignedToDraftCommandTests.cs` - unit tests following `AssignedToCancelledCommandTests.cs` pattern: `ShouldNotBeValidInWrongStatus` (verify false when status is not Assigned), `ShouldNotBeValidWithWrongEmployee` (verify false when current user is not creator), `ShouldBeValid` (verify true when status is Assigned and current user is creator), `ShouldTransitionStateProperly` (verify status changes to Draft, Assignee and AssignedDate are cleared)

4. Modify `src/UnitTests/Core/Services/StateCommandListTests.cs` - update `ShouldReturnAllStateCommandsInCorrectOrder` test: change expected count from 6 to 7, add assertion `Assert.That(commands[6], Is.InstanceOf(typeof(AssignedToDraftCommand)));`

5. Create `src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForUnassignTests.cs` - integration test following `StateCommandHandlerForCancelTests.cs` pattern: verify handler persists work order with status Draft, null Assignee, null AssignedDate after executing `AssignedToDraftCommand`

6. Create `src/AcceptanceTests/WorkOrders/WorkOrderUnassignTests.cs` - acceptance test following `WorkOrderCancelTests.cs` pattern: login, create work order, assign it, navigate back to work order, click "Unassign" button, verify status changes to "Draft" and work order is editable

**Dependencies:** None

**Database Migrations:** None

**Tests:**

| Type | Location | Coverage |
|------|----------|----------|
| Unit | `src/UnitTests/Core/Model/StateCommands/AssignedToDraftCommandTests.cs` | IsValid returns false for wrong status, IsValid returns false for non-creator, IsValid returns true for creator with Assigned status, Execute transitions to Draft and clears Assignee/AssignedDate |
| Unit | `src/UnitTests/Core/Services/StateCommandListTests.cs` | GetAllStateCommands includes AssignedToDraftCommand in correct order |
| Integration | `src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForUnassignTests.cs` | StateCommandHandler persists AssignedToDraftCommand changes to database |
| Acceptance | `src/AcceptanceTests/WorkOrders/WorkOrderUnassignTests.cs` | Full user flow: creator can unassign assigned work order back to Draft via UI button |

Based on my analysis of the issue requirements, existing acceptance test patterns (particularly `WorkOrderCancelTests.cs` and `WorkOrderAssignTests.cs`), and the test infrastructure in `AcceptanceTestBase.cs`, here is the test design document:

## Test Design

**Test Scenarios:**

### Scenario 1: Creator unassigns assigned work order back to Draft
**Given:** A logged-in user (creator) with an assigned work order they created
**When:** The user navigates to the work order manage page, clicks the "Unassign" button
**Then:** The work order status changes to "Draft", Assignee field is cleared, AssignedDate is cleared, and the work order is editable again

### Scenario 2: Non-creator cannot see Unassign button
**Given:** A logged-in user who is NOT the creator of an assigned work order
**When:** The user navigates to the assigned work order manage page
**Then:** The "Unassign" button is not displayed (filtered by IsValid() returning false)

### Scenario 3: Unassign button not displayed for non-Assigned statuses
**Given:** A logged-in user (creator) with a work order in Draft status
**When:** The user navigates to the work order manage page
**Then:** The "Unassign" button is not displayed (only valid commands for Draft status are shown)

**Test Data Requirements:**
- Test user with admin role (CanCreateWorkOrder and CanFulfillWorkOrder permissions)
- Work order created by the test user in Draft status, then transitioned to Assigned status
- Assignee set to a valid employee (can be the same user for simplicity)

**Test Location:** `src/AcceptanceTests/WorkOrders/WorkOrderUnassignTests.cs`