### PR TITLE
Change navigation header from 'UI' to 'Menu' #821

### DIFF
--- a/src/UI.Shared/NavMenu.razor
+++ b/src/UI.Shared/NavMenu.razor
@@ -1,6 +1,6 @@
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">UI</a>
+        <a class="navbar-brand" href="">Menu</a>
         <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
             <span class="navbar-toggler-icon"></span>
         </button>


### PR DESCRIPTION
## Summary
Changes the navigation header text from 'UI' to 'Menu' as requested in issue #821.

## Changes
- Updated \src/UI.Shared/NavMenu.razor\ line 3
- Changed anchor text from 'UI' to 'Menu'

## Testing
- Build succeeds
- Unit tests pass (129/129)

Closes #821