### PR TITLE
Change login subtitle from Springfield to Shelbyville

### DIFF
--- a/src/UI.Shared/Pages/Login.razor
+++ b/src/UI.Shared/Pages/Login.razor
@@ -4,7 +4,7 @@
     <div class="login-card card">
         <div class="login-header">
             <h3>Church Staff Portal</h3>
-            <div class="login-subtitle">First Church of Springfield</div>
+            <div class="login-subtitle">First Church of Shelbyville</div>
         </div>
         <div class="login-body">
             <EditForm Model="@loginModel" OnValidSubmit="HandleLogin">

--- a/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
@@ -84,4 +84,21 @@ public class LoginPageTests
         provider.IsAuthenticated().ShouldBeTrue();
         provider.GetUsername().ShouldBe("hsimpson");
     }
+
+    [Test]
+    public void ShouldDisplayFirstChurchOfShelbyvilleSubtitle()
+    {
+        using var ctx = new TestContext();
+
+        var provider = new CustomAuthenticationStateProvider();
+        ctx.Services.AddSingleton(provider);
+        ctx.Services.AddSingleton<AuthenticationStateProvider>(provider);
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+
+        var component = ctx.RenderComponent<Login>();
+
+        var subtitle = component.Find(".login-subtitle");
+        subtitle.TextContent.ShouldBe("First Church of Shelbyville");
+    }
 }


### PR DESCRIPTION
## Summary
Changes the login page subtitle from 'First Church of Springfield' to 'First Church of Shelbyville'.

## Changes
- Updated \src/UI.Shared/Pages/Login.razor\ line 7: subtitle text change
- Added unit test \ShouldDisplayFirstChurchOfShelbyvilleSubtitle\ in \LoginPageTests.cs\

## Testing
- All 130 unit tests pass
- New test verifies the subtitle displays correctly

Closes #820