### PR TITLE
Implement unassign work order feature (Issue #811)

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderUnassignTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderUnassignTests.cs
@@ -1,0 +1,97 @@
+using ClearMeasure.Bootcamp.AcceptanceTests.Extensions;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderUnassignTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldUnassignWorkOrderReturningToDraft()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await woNumberLocator.WaitForAsync();
+        await Expect(woNumberLocator).ToHaveTextAsync(order.Number!);
+
+        // Assign the work order
+        await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
+        await Input(nameof(WorkOrderManage.Elements.Title), "test title");
+        await Input(nameof(WorkOrderManage.Elements.Description), "test description");
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Verify assignment
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var statusLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.Status));
+        await Expect(statusLocator).ToHaveTextAsync("Assigned");
+
+        var assigneeField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee));
+        await Expect(assigneeField).ToBeDisabledAsync();
+        await Expect(assigneeField).ToHaveValueAsync(CurrentUser.UserName);
+
+        // Unassign the work order
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToDraftCommand.Name);
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Verify unassignment
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await statusLocator.WaitForAsync();
+        await Expect(statusLocator).ToHaveTextAsync("Draft");
+
+        var updatedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ?? throw new InvalidOperationException();
+        updatedOrder.Assignee.ShouldBeNull();
+        updatedOrder.AssignedDate.ShouldBeNull();
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldNotAllowNonCreatorToUnassign()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+
+        // Get another employee to assign to
+        var employees = await Bus.Send(new EmployeeGetAllQuery());
+        var otherEmployee = employees.FirstOrDefault(e => e.Id != CurrentUser.Id) ?? throw new InvalidOperationException("No other employee found");
+
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Assign to other employee
+        await Select(nameof(WorkOrderManage.Elements.Assignee), otherEmployee.UserName);
+        await Input(nameof(WorkOrderManage.Elements.Title), "test title");
+        await Input(nameof(WorkOrderManage.Elements.Description), "test description");
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Login as the assigned employee (not the creator)
+        await Logout();
+        await LoginAs(otherEmployee.UserName!);
+
+        // Navigate to the work order
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await woNumberLocator.WaitForAsync();
+
+        // Verify that the Unassign button is not available
+        var unassignButton = Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToDraftCommand.Name);
+        await Expect(unassignButton).ToBeHiddenAsync();
+    }
+}

--- a/src/Core/Model/StateCommands/AssignedToDraftCommand.cs
+++ b/src/Core/Model/StateCommands/AssignedToDraftCommand.cs
@@ -1,0 +1,33 @@
+namespace ClearMeasure.Bootcamp.Core.Model.StateCommands;
+
+public record AssignedToDraftCommand(WorkOrder WorkOrder, Employee CurrentUser)
+: StateCommandBase(WorkOrder, CurrentUser)
+{
+    public const string Name = "Unassign";
+
+    public override WorkOrderStatus GetBeginStatus()
+    {
+        return WorkOrderStatus.Assigned;
+    }
+
+    public override WorkOrderStatus GetEndStatus()
+    {
+        return WorkOrderStatus.Draft;
+    }
+
+    public override string TransitionVerbPresentTense => Name;
+
+    public override string TransitionVerbPastTense => "Unassigned";
+
+    public override void Execute(StateCommandContext context)
+    {
+        WorkOrder.Assignee = null;
+        WorkOrder.AssignedDate = null;
+        base.Execute(context);
+    }
+
+    protected override bool UserCanExecute(Employee currentUser)
+    {
+        return currentUser == WorkOrder.Creator;
+    }
+}

--- a/src/Core/Services/Impl/StateCommandList.cs
+++ b/src/Core/Services/Impl/StateCommandList.cs
@@ -19,6 +19,7 @@ public class StateCommandList
         var commands = new List<IStateCommand>();
         commands.Add(new SaveDraftCommand(workOrder, currentUser));
         commands.Add(new DraftToAssignedCommand(workOrder, currentUser));
+        commands.Add(new AssignedToDraftCommand(workOrder, currentUser));
         commands.Add(new AssignedToInProgressCommand(workOrder, currentUser));
         commands.Add(new InProgressToAssignedCommand(workOrder, currentUser));
         commands.Add(new InProgressToCompleteCommand(workOrder, currentUser));

--- a/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForUnassignTests.cs
+++ b/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForUnassignTests.cs
@@ -1,0 +1,71 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.DataAccess.Handlers;
+using ClearMeasure.Bootcamp.UnitTests.Core.Queries;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.DataAccess.Handlers;
+
+public class StateCommandHandlerForUnassignTests : IntegratedTestBase
+{
+    [Test]
+    public async Task ShouldUnassignWorkOrderReturningToDraft()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = Faker<Employee>();
+        var assignee = Faker<Employee>();
+        var workOrder = Faker<WorkOrder>();
+        workOrder.Id = Guid.Empty;
+        workOrder.Creator = creator;
+        workOrder.Assignee = assignee;
+        workOrder.Status = WorkOrderStatus.Assigned;
+        workOrder.AssignedDate = TestHost.TestTime.DateTime.AddHours(-1);
+
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(assignee);
+            context.Add(workOrder);
+            await context.SaveChangesAsync();
+        }
+
+        var command = RemotableRequestTests.SimulateRemoteObject(new AssignedToDraftCommand(workOrder, creator));
+        var handler = TestHost.GetRequiredService<StateCommandHandler>();
+        var result = await handler.Handle(command);
+
+        var context2 = TestHost.GetRequiredService<DbContext>();
+        var savedOrder = context2.Find<WorkOrder>(result.WorkOrder.Id) ?? throw new InvalidOperationException();
+        savedOrder.Status.ShouldBe(WorkOrderStatus.Draft);
+        savedOrder.Assignee.ShouldBeNull();
+        savedOrder.AssignedDate.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task ShouldPreventNonCreatorFromUnassigning()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = Faker<Employee>();
+        var assignee = Faker<Employee>();
+        var otherUser = Faker<Employee>();
+        var workOrder = Faker<WorkOrder>();
+        workOrder.Id = Guid.Empty;
+        workOrder.Creator = creator;
+        workOrder.Assignee = assignee;
+        workOrder.Status = WorkOrderStatus.Assigned;
+
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(assignee);
+            context.Add(otherUser);
+            context.Add(workOrder);
+            await context.SaveChangesAsync();
+        }
+
+        var command = new AssignedToDraftCommand(workOrder, otherUser);
+        command.IsValid().ShouldBeFalse();
+    }
+}

--- a/src/UnitTests/Core/Services/StateCommandListTests.cs
+++ b/src/UnitTests/Core/Services/StateCommandListTests.cs
@@ -25,14 +25,15 @@ public class StateCommandListTests
         var facilitator = new StateCommandList();
         var commands = facilitator.GetAllStateCommands(new WorkOrder(), new Employee());
 
-        Assert.That(commands.Length, Is.EqualTo(6));
+        Assert.That(commands.Length, Is.EqualTo(7));
 
         Assert.That(commands[0], Is.InstanceOf(typeof(SaveDraftCommand)));
         Assert.That(commands[1], Is.InstanceOf(typeof(DraftToAssignedCommand)));
-        Assert.That(commands[2], Is.InstanceOf(typeof(AssignedToInProgressCommand)));
-        Assert.That(commands[3], Is.InstanceOf(typeof(InProgressToAssignedCommand)));
-        Assert.That(commands[4], Is.InstanceOf(typeof(InProgressToCompleteCommand)));
-        Assert.That(commands[5], Is.InstanceOf(typeof(AssignedToCancelledCommand)));
+        Assert.That(commands[2], Is.InstanceOf(typeof(AssignedToDraftCommand)));
+        Assert.That(commands[3], Is.InstanceOf(typeof(AssignedToInProgressCommand)));
+        Assert.That(commands[4], Is.InstanceOf(typeof(InProgressToAssignedCommand)));
+        Assert.That(commands[5], Is.InstanceOf(typeof(InProgressToCompleteCommand)));
+        Assert.That(commands[6], Is.InstanceOf(typeof(AssignedToCancelledCommand)));
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Implements the ability for work order creators to unassign assigned work orders, returning them to Draft status. This resolves issue #811.

## Changes

- **AssignedToDraftCommand**: New state command that transitions work orders from Assigned to Draft status
  - Only the work order creator can execute this command
  - Clears the assignee and assigned date when unassigning
  
- **StateCommandList**: Updated to register the new command in the list of available state transitions

- **Tests**: Added comprehensive test coverage
  - Unit tests verify command is in correct position in command list
  - Integration tests verify unassignment logic and authorization
  - Acceptance tests verify end-to-end unassignment workflow and multi-user scenarios

## Acceptance Criteria Met

✅ Creator can unassign an assigned work order  
✅ Work order returns to Draft status  
✅ Assignee is cleared  
✅ Assigned date is cleared  
✅ Non-creators cannot unassign work orders  

## Implementation Details

The implementation follows the Onion Architecture pattern established in the codebase:

1. **Domain Model** (`src/Core/Model/StateCommands/AssignedToDraftCommand.cs`):
   - New state command implementing the state transition
   - Validates that only the creator can execute
   - Clears assignee and assigned date during execution

2. **Service Layer** (`src/Core/Services/Impl/StateCommandList.cs`):
   - Registered new command in the available commands list
   - Positioned after DraftToAssignedCommand for logical flow

3. **Tests**:
   - `StateCommandListTests`: Verifies command count and position
   - `StateCommandHandlerForUnassignTests`: Integration tests for data persistence and authorization
   - `WorkOrderUnassignTests`: End-to-end UI tests for creator and non-creator scenarios

## How to Test

```bash
# Run unit tests
dotnet test src/UnitTests --configuration Release --filter "StateCommandListTests"

# Run integration tests  
dotnet test src/IntegrationTests --configuration Release --filter "StateCommandHandlerForUnassignTests"

# Run acceptance tests
dotnet test src/AcceptanceTests --configuration Debug --filter "WorkOrderUnassignTests"

# Full build
. .\build.ps1 ; Build
```