### PR TITLE
Fix setup.sh: specify solution path for dotnet restore

### DIFF
--- a/.cursor/setup.sh
+++ b/.cursor/setup.sh
@@ -87,7 +87,7 @@ echo "    Docker $(docker --version)"
 
 # ── 4. NuGet restore ──────────────────────────────────────────────────────
 echo "==> Restoring NuGet packages..."
-dotnet restore
+dotnet restore src/ChurchBulletin.sln
 
 echo ""
 echo "==> Environment setup complete."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Submitter checklist
- [ ] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

**Status:** Feature complete.

The `dotnet restore` command in `.cursor/setup.sh` was failing because it did not specify the solution file path. The working directory does not contain a `.sln` file directly — the solution is at `src/ChurchBulletin.sln`. Changed the bare `dotnet restore` call to `dotnet restore src/ChurchBulletin.sln`.

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [x] All changes delivered with accompanying tests
- [x] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fd40abf-bd88-497f-aced-6045d7fa3cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fd40abf-bd88-497f-aced-6045d7fa3cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

