### PR TITLE
Add Emoji to top of homepage (#1029)

### DIFF
--- a/src/AcceptanceTests/App/LandingPageTests.cs
+++ b/src/AcceptanceTests/App/LandingPageTests.cs
@@ -30,5 +30,9 @@ public class LandingPageTests : AcceptanceTestBase
 
         await Expect(banner).ToBeVisibleAsync();
         await Expect(banner).ToContainTextAsync("Welcome to the AI Software Factory!");
+
+        var emoji = Page.GetByTestId(nameof(IndexPage.Elements.GreetingBannerEmoji));
+        await emoji.WaitForAsync();
+        await Expect(emoji).ToBeVisibleAsync();
     }
 }

--- a/src/UI.Shared/Pages/Index.razor
+++ b/src/UI.Shared/Pages/Index.razor
@@ -3,6 +3,7 @@
 <PageTitle>Clear Measure - .NET Bootcamp - Work Order Application</PageTitle>
 
 <div class="greeting-banner" data-testid="@nameof(Elements.GreetingBanner)">
+    <span class="greeting-banner-emoji" aria-hidden="true" data-testid="@nameof(Elements.GreetingBannerEmoji)">⛪</span>
     <p>Welcome to the AI Software Factory!</p>
 </div>
 
@@ -58,6 +59,7 @@
 @code {
     public enum Elements
     {
-        GreetingBanner
+        GreetingBanner,
+        GreetingBannerEmoji
     }
 }

--- a/src/UI.Shared/Pages/Index.razor.css
+++ b/src/UI.Shared/Pages/Index.razor.css
@@ -9,6 +9,17 @@
     font-weight: 600;
     letter-spacing: 0.5px;
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.greeting-banner-emoji {
+    display: block;
+    font-size: clamp(1.75rem, 5vw, 2.25rem);
+    line-height: 1;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
 }
 
 .greeting-banner p {

--- a/src/UnitTests/UI.Shared/Pages/IndexPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/IndexPageTests.cs
@@ -23,5 +23,9 @@ public class IndexPageTests
         var banner = component.Find($"[data-testid='{nameof(IndexPage.Elements.GreetingBanner)}']");
         banner.ShouldNotBeNull();
         banner.TextContent.ShouldContain("Welcome to the AI Software Factory!");
+
+        var emoji = component.Find($"[data-testid='{nameof(IndexPage.Elements.GreetingBannerEmoji)}']");
+        emoji.GetAttribute("aria-hidden").ShouldBe("true");
+        emoji.TextContent.ShouldContain("⛪");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a decorative church emoji (⛪) at the top of the homepage greeting banner in `Index.razor`, matching the church theme and existing emoji on the page. The glyph uses `aria-hidden="true"` so screen readers rely on the adjacent welcome text.

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/Pages/Index.razor` | Decorative span above greeting text; `GreetingBannerEmoji` test id |
| `src/UI.Shared/Pages/Index.razor.css` | Flex layout for banner; responsive `clamp()` emoji size |
| `src/UnitTests/UI.Shared/Pages/IndexPageTests.cs` | Assert emoji presence and `aria-hidden` |
| `src/AcceptanceTests/App/LandingPageTests.cs` | Playwright visibility for emoji element |

## Testing

- `dotnet test` filtered to `IndexPageTests` (Release)
- `DATABASE_ENGINE=SQLite` + `PrivateBuild.ps1` — unit and integration tests green (131 + 75)

Closes #1029

---

Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e52f799e-a2d3-4e0d-97e0-c089d895b8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e52f799e-a2d3-4e0d-97e0-c089d895b8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

