### PR TITLE
Force capitalize all names in the login drop-down (#1057)

### DIFF
--- a/src/UI.Shared/Pages/Login.razor
+++ b/src/UI.Shared/Pages/Login.razor
@@ -17,7 +17,7 @@
                         <option value="">-- Select a parishioner or staff member --</option>
                         @foreach (var employee in employees)
                         {
-                            <option value="@employee.UserName">@employee.GetFullName()</option>
+                            <option value="@employee.UserName">@GetLoginDropdownDisplayName(employee)</option>
                         }
                     </InputSelect>
                     <ValidationMessage For="@(() => loginModel.Username)"/>

--- a/src/UI.Shared/Pages/Login.razor.cs
+++ b/src/UI.Shared/Pages/Login.razor.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.UI.Shared.Authentication;
@@ -32,6 +33,16 @@ public partial class Login : AppComponentBase
         {
             errorMessage = "Error loading employees: " + ex.Message;
         }
+    }
+
+    /// <summary>
+    /// Display-only formatting for the login member select. Lowercases first so all-caps mainframe
+    /// names and mixed local casing both normalize to title case; does not alter stored names.
+    /// </summary>
+    private static string GetLoginDropdownDisplayName(Employee employee)
+    {
+        var fullName = employee.GetFullName();
+        return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(fullName.ToLowerInvariant());
     }
 
     private async Task HandleLogin()

--- a/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
@@ -59,7 +59,30 @@ public class LoginPageTests
         employeeSelect.ShouldNotBeNull();
 
         var options = component.FindAll("option");
-        options.Count.ShouldBe(4);
+        options.Count.ShouldBe(5);
+
+        options[0].GetAttribute("value").ShouldBe(string.Empty);
+        options[0].TextContent.ShouldBe("-- Select a parishioner or staff member --");
+    }
+
+    [Test]
+    public void ShouldDisplayTitleCasedLabelsInLoginDropdown_ForMixedAndAllCapsNames()
+    {
+        using var ctx = new TestContext();
+
+        var provider = new CustomAuthenticationStateProvider();
+        ctx.Services.AddSingleton(provider);
+        ctx.Services.AddSingleton<AuthenticationStateProvider>(provider);
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+
+        var component = ctx.RenderComponent<Login>();
+
+        var hsimpsonOption = component.FindAll("option").Single(o => o.GetAttribute("value") == "hsimpson");
+        hsimpsonOption.TextContent.ShouldBe("Homer Simpson");
+
+        var jdoeOption = component.FindAll("option").Single(o => o.GetAttribute("value") == "jdoe");
+        jdoeOption.TextContent.ShouldBe("Mary Jane Simpson");
     }
 
     [Test]

--- a/src/UnitTests/UI.Shared/Pages/StubBus.cs
+++ b/src/UnitTests/UI.Shared/Pages/StubBus.cs
@@ -81,9 +81,10 @@ public class StubBus() : Bus(null!)
     {
         var employees = new[]
         {
-            new Employee("hsimpson", "Homer", "Simpson", "homer@springfield.com"),
+            new Employee("hsimpson", "HOMER", "SIMPSON", "homer@springfield.com"),
             new Employee("mburns", "Montgomery", "Burns", "burns@plant.com"),
-            new Employee("nflanders", "Ned", "Flanders", "ned@flanders.com")
+            new Employee("nflanders", "Ned", "Flanders", "ned@flanders.com"),
+            new Employee("jdoe", "mary jane", "SIMPSON", "mj@test.com")
         };
         return Task.FromResult<TResponse>((TResponse)(object)employees);
     }

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderSearchTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderSearchTests.cs
@@ -1,4 +1,4 @@
-﻿using Bunit;
+using Bunit;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
@@ -33,13 +33,13 @@ public class WorkOrderSearchTests
         assigneeSelect.ShouldNotBeNull();
         statusSelect.ShouldNotBeNull();
 
-        // Verify user options are loaded (3 employees + "All" option = 4 options)
+        // Verify user options are loaded (4 employees + "All" option = 5 options)
         var creatorOptions = creatorSelect.QuerySelectorAll("option");
-        creatorOptions.Length.ShouldBe(4);
+        creatorOptions.Length.ShouldBe(5);
         creatorOptions[0].TextContent.ShouldBe("All");
 
         var assigneeOptions = assigneeSelect.QuerySelectorAll("option");
-        assigneeOptions.Length.ShouldBe(4);
+        assigneeOptions.Length.ShouldBe(5);
         assigneeOptions[0].TextContent.ShouldBe("All");
 
         // Verify status options are loaded (4 statuses + "All" option = 5 options)


### PR DESCRIPTION
## Summary

Login page **Select Church Member** `<option>` labels now use title-style casing (`CultureInfo.CurrentCulture.TextInfo.ToTitleCase` on a lower-invariant copy of `GetFullName()`), so mainframe all-caps and locally mixed names look consistent. `option value` remains the employee username; no Core/DataAccess or persistence changes.

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/Pages/Login.razor` | Bind option text to `GetLoginDropdownDisplayName(employee)` |
| `src/UI.Shared/Pages/Login.razor.cs` | Add `GetLoginDropdownDisplayName` helper |
| `src/UnitTests/UI.Shared/Pages/StubBus.cs` | Fourth employee + all-caps Homer for casing coverage |
| `src/UnitTests/UI.Shared/Pages/LoginPageTests.cs` | Option count, placeholder, title-case label assertions |
| `src/UnitTests/UI.Shared/Pages/WorkOrderSearchTests.cs` | User dropdown option counts (4 employees + All) |

## Testing

- `dotnet test` filtered: Login + WorkOrderSearch dropdown test
- Full `PrivateBuild.ps1`: unit (137) + integration (82) passed

Closes #1057
