### PR TITLE
Add navigate hide button (#1077)

### DIFF
--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -5,6 +5,12 @@ namespace ClearMeasure.Bootcamp.UI.Shared;
 
 public partial class MainLayout : IAsyncDisposable
 {
+    /// <summary>
+    /// Must stay aligned with <c>@media (max-width: 768px)</c> in <c>MainLayout.razor.css</c> and the
+    /// <c>matchMedia</c> argument in <c>mainLayoutNav.js</c>.
+    /// </summary>
+    public const string NavRailBreakpointMediaQuery = "(max-width: 768px)";
+
     public enum Elements
     {
         NavRailToggle
@@ -66,7 +72,7 @@ public partial class MainLayout : IAsyncDisposable
             _jsModule = await Js.InvokeAsync<IJSObjectReference>("import",
                 "./_content/ClearMeasure.Bootcamp.UI.Shared/js/mainLayoutNav.js");
             _navToggleHelper = await _jsModule.InvokeAsync<IJSObjectReference>("initNavToggle", _dotNetRef,
-                "(max-width: 768px)");
+                NavRailBreakpointMediaQuery);
         }
         catch (JSDisconnectedException)
         {

--- a/src/UI.Shared/wwwroot/js/mainLayoutNav.js
+++ b/src/UI.Shared/wwwroot/js/mainLayoutNav.js
@@ -1,3 +1,4 @@
+// Breakpoint string must match MainLayout.NavRailBreakpointMediaQuery and @media in MainLayout.razor.css.
 export function initNavToggle(dotNetRef, mediaQuery) {
 	const mq = window.matchMedia(mediaQuery);
 	const handler = () => {

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -81,6 +81,33 @@ public class MainLayoutTests
         toggle.GetAttribute("aria-expanded").ShouldBe("true");
     }
 
+    [Test]
+    public void ShouldUseDocumentedNavRailBreakpointMediaQuery()
+    {
+        MainLayout.NavRailBreakpointMediaQuery.ShouldBe("(max-width: 768px)");
+    }
+
+    [Test]
+    public async Task ShouldInvokeFocusOnNavRailToggleWhenClosingOverlayOnNarrowViewport()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+        component.WaitForAssertion(() =>
+        {
+            layout.Find($"[data-testid='{nameof(MainLayout.Elements.NavRailToggle)}']").ShouldNotBeNull();
+        });
+
+        await component.InvokeAsync(() => layout.Instance.OnViewportChanged(true));
+
+        var toggle = layout.Find($"[data-testid='{nameof(MainLayout.Elements.NavRailToggle)}']");
+        toggle.Click();
+        toggle.Click();
+
+        ctx.JSInterop.VerifyFocusAsyncInvoke();
+    }
+
     private static TestContext CreateContext()
     {
         var ctx = new TestContext();


### PR DESCRIPTION
## Summary

Completes **#1077** by finishing test design items for the shared shell nav rail toggle: a single C# constant for the `(max-width: 768px)` breakpoint (used by `initNavToggle`), a regression test that `FocusAsync` runs when closing the overlay on a narrow viewport (via bUnit `VerifyFocusAsyncInvoke`), and a contract test for the media query string. Layout markup, CSS, JS bridge, and existing bUnit scenarios were already in place from prior work; this change tightens alignment and coverage.

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/MainLayout.razor.cs` | Added `NavRailBreakpointMediaQuery` constant; pass to `initNavToggle`. |
| `src/UI.Shared/wwwroot/js/mainLayoutNav.js` | Comment linking breakpoint to C# / CSS. |
| `src/UnitTests/UI.Shared/MainLayoutTests.cs` | `ShouldUseDocumentedNavRailBreakpointMediaQuery`, `ShouldInvokeFocusOnNavRailToggleWhenClosingOverlayOnNarrowViewport`. |

## Testing

- `dotnet test src/UnitTests --configuration Release --filter FullyQualifiedName~MainLayoutTests`
- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` (unit + integration green)

End-to-end Playwright for the toggle was not added; component tests above match the issue’s “optional E2E” path.

Closes #1077
