### PR TITLE
New API endpoint GET /api/health/detailed for component-level health reporting (#1078)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -79,7 +79,7 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
-    public async Task Should_ListExpectedComponentEntries_When_MockPayload()
+    public async Task Should_ListRegisteredComponentNames_When_LiveHealthReport()
     {
         var response = await _client!.GetAsync("/api/health/detailed");
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -87,17 +87,29 @@ public class DetailedHealthEndpointIntegrationTests
         var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         report.ShouldNotBeNull();
-        var names = report!.Components.Select(c => c.Name).ToHashSet();
-        names.ShouldContain("LlmGateway");
-        names.ShouldContain("DataAccess");
-        names.ShouldContain("Server");
-        names.ShouldContain("API");
-        names.ShouldContain("Jeffrey");
+        var names = report!.Components.Select(c => c.Name).Order(StringComparer.Ordinal).ToArray();
+        names.ShouldBe(new[] { "API", "DataAccess", "Jeffrey", "LlmGateway", "Server" });
         foreach (var c in report.Components)
         {
             (c.Status == ComponentHealthStatus.Healthy
                 || c.Status == ComponentHealthStatus.Degraded
                 || c.Status == ComponentHealthStatus.Unhealthy).ShouldBeTrue();
+        }
+    }
+
+    [Test]
+    public async Task Should_IncludeOptionalDescription_When_ModelExtended()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("components", out var components).ShouldBeTrue();
+        foreach (var el in components.EnumerateArray())
+        {
+            el.TryGetProperty("name", out _).ShouldBeTrue();
+            el.TryGetProperty("status", out _).ShouldBeTrue();
         }
     }
 }

--- a/src/IntegrationTests/Api/DetailedHealthWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/DetailedHealthWebApplicationFactory.cs
@@ -13,6 +13,7 @@ public sealed class DetailedHealthWebApplicationFactory : WebApplicationFactory<
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Development");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
         builder.ConfigureAppConfiguration((_, config) =>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>

--- a/src/IntegrationTests/TestHost.cs
+++ b/src/IntegrationTests/TestHost.cs
@@ -64,14 +64,11 @@ public static class TestHost
                     .AddUserSecrets<TestDatabaseConfiguration>(optional: true)
                     .AddEnvironmentVariables();
 
-                var envEngine = Environment.GetEnvironmentVariable("DATABASE_ENGINE");
                 var envConnectionString = Environment.GetEnvironmentVariable("ConnectionStrings__SqlConnectionString");
-                var forceSqlite =
-                    string.Equals(envEngine, "SQLite", StringComparison.OrdinalIgnoreCase)
-                    || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                        && (string.IsNullOrEmpty(envConnectionString)
-                            || envConnectionString.Contains("(LocalDb)", StringComparison.OrdinalIgnoreCase)));
-                if (forceSqlite)
+                var forceSqliteInMemory = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    && (string.IsNullOrEmpty(envConnectionString)
+                        || envConnectionString.Contains("(LocalDb)", StringComparison.OrdinalIgnoreCase));
+                if (forceSqliteInMemory)
                 {
                     config.AddInMemoryCollection(new Dictionary<string, string?>
                     {

--- a/src/IntegrationTests/TestHost.cs
+++ b/src/IntegrationTests/TestHost.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
+using System.Runtime.InteropServices;
 
 namespace ClearMeasure.Bootcamp.IntegrationTests;
 
@@ -62,6 +63,21 @@ public static class TestHost
                     .AddJsonFile("appsettings.test.json", false, true)
                     .AddUserSecrets<TestDatabaseConfiguration>(optional: true)
                     .AddEnvironmentVariables();
+
+                var envEngine = Environment.GetEnvironmentVariable("DATABASE_ENGINE");
+                var envConnectionString = Environment.GetEnvironmentVariable("ConnectionStrings__SqlConnectionString");
+                var forceSqlite =
+                    string.Equals(envEngine, "SQLite", StringComparison.OrdinalIgnoreCase)
+                    || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                        && (string.IsNullOrEmpty(envConnectionString)
+                            || envConnectionString.Contains("(LocalDb)", StringComparison.OrdinalIgnoreCase)));
+                if (forceSqlite)
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:"
+                    });
+                }
             })
             .ConfigureServices(s =>
             {

--- a/src/UI/Api/Controllers/DetailedHealthController.cs
+++ b/src/UI/Api/Controllers/DetailedHealthController.cs
@@ -1,14 +1,16 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
 
 [ApiController]
 [Route("api/health")]
-public class DetailedHealthController(TimeProvider timeProvider) : ControllerBase
+public class DetailedHealthController(HealthCheckService healthCheckService, TimeProvider timeProvider) : ControllerBase
 {
     [HttpGet("detailed")]
-    public ActionResult<DetailedHealthReport> GetDetailed()
+    public async Task<ActionResult<DetailedHealthReport>> GetDetailed(CancellationToken cancellationToken)
     {
-        return Ok(HealthReportBuilder.Build(timeProvider));
+        var report = await healthCheckService.CheckHealthAsync(cancellationToken);
+        return Ok(HealthReportBuilder.FromHealthReport(report, timeProvider));
     }
 }

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -24,6 +24,12 @@ public sealed class ComponentHealthEntry
 
     /// <summary>One of <see cref="ComponentHealthStatus"/> values.</summary>
     public required string Status { get; init; }
+
+    /// <summary>Optional probe detail from <see cref="Microsoft.Extensions.Diagnostics.HealthChecks.HealthReportEntry.Description"/>.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Optional execution duration for the check (ISO-8601 duration when serialized).</summary>
+    public TimeSpan? Duration { get; init; }
 }
 
 /// <summary>

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -1,27 +1,58 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
 namespace ClearMeasure.Bootcamp.UI.Api;
 
 /// <summary>
-/// Builds the detailed health report. Initial implementation uses static entries;
-/// later work can swap in real health-check probe results.
+/// Builds <see cref="DetailedHealthReport"/> from the ASP.NET Core health pipeline.
+/// Entry keys must match logical names registered in <c>UIServiceRegistry.AddHealthChecks</c>
+/// (<c>LlmGateway</c>, <c>DataAccess</c>, <c>Server</c>, <c>API</c>, <c>Jeffrey</c>).
 /// </summary>
 public static class HealthReportBuilder
 {
     /// <summary>
-    /// Logical names align with registered checks in <c>UIServiceRegistry</c> where applicable.
+    /// Order and names match <c>UIServiceRegistry.AddHealthChecks</c>. Other registrations
+    /// (e.g. Aspire <c>self</c>) are omitted so the JSON contract stays stable for operators.
     /// </summary>
-    public static DetailedHealthReport Build(TimeProvider? timeProvider = null)
+    private static readonly string[] UiHealthCheckNames =
+    [
+        "LlmGateway",
+        "DataAccess",
+        "Server",
+        "API",
+        "Jeffrey"
+    ];
+
+    /// <summary>
+    /// Maps a live <see cref="HealthReport"/> to the JSON-oriented detailed report.
+    /// </summary>
+    public static DetailedHealthReport FromHealthReport(HealthReport report, TimeProvider? timeProvider = null)
     {
         var clock = timeProvider ?? TimeProvider.System;
         var checkedAt = clock.GetUtcNow().UtcDateTime;
 
-        var components = new ComponentHealthEntry[]
+        var components = new List<ComponentHealthEntry>(UiHealthCheckNames.Length);
+        foreach (var name in UiHealthCheckNames)
         {
-            new() { Name = "LlmGateway", Status = ComponentHealthStatus.Healthy },
-            new() { Name = "DataAccess", Status = ComponentHealthStatus.Healthy },
-            new() { Name = "Server", Status = ComponentHealthStatus.Healthy },
-            new() { Name = "API", Status = ComponentHealthStatus.Healthy },
-            new() { Name = "Jeffrey", Status = ComponentHealthStatus.Degraded }
-        };
+            if (!report.Entries.TryGetValue(name, out var entry))
+            {
+                components.Add(new ComponentHealthEntry
+                {
+                    Name = name,
+                    Status = ComponentHealthStatus.Unhealthy,
+                    Description = "Health check was not present in the report.",
+                    Duration = null
+                });
+                continue;
+            }
+
+            components.Add(new ComponentHealthEntry
+            {
+                Name = name,
+                Status = MapStatus(entry.Status),
+                Description = entry.Description,
+                Duration = entry.Duration
+            });
+        }
 
         return new DetailedHealthReport
         {
@@ -30,6 +61,13 @@ public static class HealthReportBuilder
             OverallStatus = AggregateWorst(components)
         };
     }
+
+    internal static string MapStatus(HealthStatus status) => status switch
+    {
+        HealthStatus.Unhealthy => ComponentHealthStatus.Unhealthy,
+        HealthStatus.Degraded => ComponentHealthStatus.Degraded,
+        _ => ComponentHealthStatus.Healthy
+    };
 
     internal static string AggregateWorst(IReadOnlyList<ComponentHealthEntry> components)
     {

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -1,4 +1,5 @@
 using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Shouldly;
 
 namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
@@ -12,13 +13,56 @@ public class HealthReportBuilderTests
     }
 
     [Test]
-    public void HealthReportBuilder_Build_Should_ReturnNonNullPayload()
+    public void HealthReportBuilder_FromHealthReport_Should_MapEntriesAndOverall()
     {
-        var report = HealthReportBuilder.Build();
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["LlmGateway"] = new(HealthStatus.Healthy, "ok", TimeSpan.FromMilliseconds(10), null, null),
+            ["DataAccess"] = new(HealthStatus.Degraded, "slow", TimeSpan.FromMilliseconds(20), null, null),
+            ["Server"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+            ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+            ["Jeffrey"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null)
+        };
+        var report = new HealthReport(entries, TimeSpan.FromMilliseconds(30));
 
-        report.ShouldNotBeNull();
-        report.Components.ShouldNotBeNull();
-        report.Components.Count.ShouldBeGreaterThan(0);
+        var built = HealthReportBuilder.FromHealthReport(report, new FixedUtcTimeProvider(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+
+        built.OverallStatus.ShouldBe(ComponentHealthStatus.Degraded);
+        built.Components.Count.ShouldBe(5);
+        var llm = built.Components.Single(c => c.Name == "LlmGateway");
+        llm.Status.ShouldBe(ComponentHealthStatus.Healthy);
+        llm.Description.ShouldBe("ok");
+        llm.Duration.ShouldBe(TimeSpan.FromMilliseconds(10));
+        var data = built.Components.Single(c => c.Name == "DataAccess");
+        data.Status.ShouldBe(ComponentHealthStatus.Degraded);
+        data.Description.ShouldBe("slow");
+    }
+
+    [Test]
+    public void HealthReportBuilder_FromHealthReport_Should_MarkMissingAsUnhealthy()
+    {
+        var report = new HealthReport(
+            new Dictionary<string, HealthReportEntry>
+            {
+                ["LlmGateway"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+                ["DataAccess"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+                ["Server"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+                ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null)
+            },
+            TimeSpan.Zero);
+
+        var built = HealthReportBuilder.FromHealthReport(report);
+
+        built.Components.Single(c => c.Name == "Jeffrey").Status.ShouldBe(ComponentHealthStatus.Unhealthy);
+        built.OverallStatus.ShouldBe(ComponentHealthStatus.Unhealthy);
+    }
+
+    [Test]
+    public void HealthReportBuilder_MapStatus_Should_MapEnumStrings()
+    {
+        HealthReportBuilder.MapStatus(HealthStatus.Healthy).ShouldBe(ComponentHealthStatus.Healthy);
+        HealthReportBuilder.MapStatus(HealthStatus.Degraded).ShouldBe(ComponentHealthStatus.Degraded);
+        HealthReportBuilder.MapStatus(HealthStatus.Unhealthy).ShouldBe(ComponentHealthStatus.Unhealthy);
     }
 
     [Test]
@@ -48,32 +92,23 @@ public class HealthReportBuilderTests
     }
 
     [Test]
-    public void HealthReportBuilder_Build_Should_SetCheckedAtUtc()
+    public void HealthReportBuilder_FromHealthReport_Should_SetCheckedAtUtc()
     {
         var fixedTime = new DateTime(2026, 3, 26, 12, 0, 0, DateTimeKind.Utc);
-        var report = HealthReportBuilder.Build(new FixedUtcTimeProvider(fixedTime));
+        var report = new HealthReport(
+            new Dictionary<string, HealthReportEntry>
+            {
+                ["LlmGateway"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+                ["DataAccess"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+                ["Server"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+                ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null),
+                ["Jeffrey"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, null)
+            },
+            TimeSpan.Zero);
 
-        report.CheckedAtUtc.ShouldBe(fixedTime);
-        report.CheckedAtUtc.Kind.ShouldBe(DateTimeKind.Utc);
-    }
+        var built = HealthReportBuilder.FromHealthReport(report, new FixedUtcTimeProvider(fixedTime));
 
-    [Test]
-    public void Should_Build_When_DefaultMockData_ExpectDegradedOverallBecauseJeffrey()
-    {
-        var report = HealthReportBuilder.Build();
-
-        report.OverallStatus.ShouldBe(ComponentHealthStatus.Degraded);
-        var names = report.Components.Select(c => c.Name).ToHashSet();
-        names.ShouldContain("LlmGateway");
-        names.ShouldContain("DataAccess");
-        names.ShouldContain("Server");
-        names.ShouldContain("API");
-        names.ShouldContain("Jeffrey");
-        foreach (var c in report.Components)
-        {
-            (c.Status == ComponentHealthStatus.Healthy
-                || c.Status == ComponentHealthStatus.Degraded
-                || c.Status == ComponentHealthStatus.Unhealthy).ShouldBeTrue();
-        }
+        built.CheckedAtUtc.ShouldBe(fixedTime);
+        built.CheckedAtUtc.Kind.ShouldBe(DateTimeKind.Utc);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

## Summary

`GET /api/health/detailed` now runs the same registered health checks as the rest of the host via `HealthCheckService.CheckHealthAsync`, maps results into the existing JSON shape (`overallStatus`, `checkedAtUtc`, `components`), and reports exactly the five logical components registered in `UIServiceRegistry` (`LlmGateway`, `DataAccess`, `Server`, `API`, `Jeffrey`). Aspire’s separate `self` check is excluded so the operator JSON contract stays aligned with those names. Optional `description` and `duration` fields were added on each component line for probe detail.

`DetailedHealthWebApplicationFactory` uses `UseSetting` so in-memory SQLite wins over `appsettings.Development.json` LocalDB when the test host runs. `TestHost` only injects `Data Source=:memory:` on non-Windows when the environment connection string is empty or still points at LocalDB — it does **not** override `Data Source=ChurchBulletin.db` used in GitHub Actions SQLite jobs (avoiding `no such table` after DbUp migrations).

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/DetailedHealthController.cs` | Async action; inject `HealthCheckService` + `TimeProvider`; call `CheckHealthAsync` |
| `src/UI/Api/HealthReportBuilder.cs` | `FromHealthReport` maps live report; fixed component order; missing entry → Unhealthy placeholder |
| `src/UI/Api/DetailedHealthModels.cs` | Optional `Description`, `Duration` on `ComponentHealthEntry` |
| `src/UnitTests/UI/Api/HealthReportBuilderTests.cs` | Mapping, missing-name, `AggregateWorst`, `CheckedAtUtc` tests |
| `src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs` | Live report assertions; optional fields smoke |
| `src/IntegrationTests/Api/DetailedHealthWebApplicationFactory.cs` | `UseSetting` for SQLite connection string |
| `src/IntegrationTests/TestHost.cs` | In-memory SQLite override only for bare Linux / LocalDB; preserves CI file SQLite |

## Testing

- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — build, unit tests, DB migrate, integration tests — all passed.
- Spot check: `DATABASE_ENGINE=SQLite` with `ConnectionStrings__SqlConnectionString=Data Source=/tmp/...db` — DB integration tests still pass.

Closes #1078
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-793323bc-ed39-40f4-90b1-a2abaa5ffb11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-793323bc-ed39-40f4-90b1-a2abaa5ffb11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

