### PR TITLE
Force capitalize all names in the login drop-down (#1123)

### DIFF
--- a/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
@@ -59,7 +59,7 @@ public class LoginPageTests
         employeeSelect.ShouldNotBeNull();
 
         var options = component.FindAll("option");
-        options.Count.ShouldBe(5);
+        options.Count.ShouldBe(6);
 
         options[0].GetAttribute("value").ShouldBe(string.Empty);
         options[0].TextContent.ShouldBe("-- Select a parishioner or staff member --");
@@ -83,6 +83,9 @@ public class LoginPageTests
 
         var jdoeOption = component.FindAll("option").Single(o => o.GetAttribute("value") == "jdoe");
         jdoeOption.TextContent.ShouldBe("Mary Jane Simpson");
+
+        var msmithOption = component.FindAll("option").Single(o => o.GetAttribute("value") == "msmith");
+        msmithOption.TextContent.ShouldBe("Mary-Jane Smith");
     }
 
     [Test]

--- a/src/UnitTests/UI.Shared/Pages/StubBus.cs
+++ b/src/UnitTests/UI.Shared/Pages/StubBus.cs
@@ -84,7 +84,8 @@ public class StubBus() : Bus(null!)
             new Employee("hsimpson", "HOMER", "SIMPSON", "homer@springfield.com"),
             new Employee("mburns", "Montgomery", "Burns", "burns@plant.com"),
             new Employee("nflanders", "Ned", "Flanders", "ned@flanders.com"),
-            new Employee("jdoe", "mary jane", "SIMPSON", "mj@test.com")
+            new Employee("jdoe", "mary jane", "SIMPSON", "mj@test.com"),
+            new Employee("msmith", "MARY-JANE", "SMITH", "mj@church.example")
         };
         return Task.FromResult<TResponse>((TResponse)(object)employees);
     }

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderSearchTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderSearchTests.cs
@@ -33,13 +33,13 @@ public class WorkOrderSearchTests
         assigneeSelect.ShouldNotBeNull();
         statusSelect.ShouldNotBeNull();
 
-        // Verify user options are loaded (4 employees + "All" option = 5 options)
+        // Verify user options are loaded (5 stub employees + "All" option = 6 options)
         var creatorOptions = creatorSelect.QuerySelectorAll("option");
-        creatorOptions.Length.ShouldBe(5);
+        creatorOptions.Length.ShouldBe(6);
         creatorOptions[0].TextContent.ShouldBe("All");
 
         var assigneeOptions = assigneeSelect.QuerySelectorAll("option");
-        assigneeOptions.Length.ShouldBe(5);
+        assigneeOptions.Length.ShouldBe(6);
         assigneeOptions[0].TextContent.ShouldBe("All");
 
         // Verify status options are loaded (4 statuses + "All" option = 5 options)


### PR DESCRIPTION
## Summary

- **UI behavior:** `Login.razor` already shows title-cased full names in the **Select Church Member** dropdown only; option **values** remain usernames (`GetLoginDropdownDisplayName` in `Login.razor.cs` — lowercases then `TextInfo.ToTitleCase`). That behavior is on `master` from the earlier merge for #1057.
- **This PR:** Extends shared test stub data with a hyphenated all-caps first name (`MARY-JANE` / `SMITH`) and asserts the login option label is `Mary-Jane Smith`. Updates `WorkOrderSearchTests` option counts because `StubBus` now returns five employees.

## Files changed

| File | Change |
|------|--------|
| `src/UnitTests/UI.Shared/Pages/StubBus.cs` | Fifth employee for hyphenated title-case coverage |
| `src/UnitTests/UI.Shared/Pages/LoginPageTests.cs` | Assert hyphenated label; expect 6 login options |
| `src/UnitTests/UI.Shared/Pages/WorkOrderSearchTests.cs` | Creator/assignee option counts 5 → 6 |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — green (143 unit, 80 integration).

Closes #1123