### PR TITLE
Make the login button blink obviously (#1138)

### DIFF
--- a/src/UI.Shared/Components/LoginLink.razor.css
+++ b/src/UI.Shared/Components/LoginLink.razor.css
@@ -1,26 +1,57 @@
 .login-prompt-link {
 	display: inline-block;
-	transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-	animation: login-prompt-emphasis 1.2s ease-in-out infinite;
-	will-change: transform, opacity, box-shadow;
+	font-weight: 700;
+	text-decoration: none;
+	border-radius: 10px;
+	padding: 0.5rem 1rem;
+	transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, opacity 0.15s ease;
+	color: #1a365d;
+	background: linear-gradient(135deg, #fefcbf 0%, #fbd38d 45%, #f6ad55 100%);
+	border: 3px solid #c05621;
+	box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.9), 0 4px 14px rgba(221, 107, 32, 0.45);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.login-prompt-link {
+		animation: login-prompt-emphasis 1s ease-in-out infinite;
+		will-change: transform, opacity, box-shadow;
+	}
 }
 
 @keyframes login-prompt-emphasis {
 	0%, 100% {
 		opacity: 1;
 		transform: scale(1);
-		box-shadow: 0 0 0 0 rgba(123, 104, 238, 0.85), 0 0 12px 2px rgba(74, 144, 226, 0.45);
+		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.8), 0 4px 18px rgba(221, 107, 32, 0.5);
+		border-color: #c05621;
+		filter: brightness(1);
+	}
+	45% {
+		opacity: 1;
+		transform: scale(1.06);
+		box-shadow: 0 0 0 8px rgba(221, 107, 32, 0.35), 0 0 0 2px rgba(255, 255, 255, 0.9), 0 6px 24px rgba(221, 107, 32, 0.65);
+		border-color: #9c4221;
+		filter: brightness(1.08);
 	}
 	50% {
-		opacity: 0.88;
-		transform: scale(1.08);
-		box-shadow: 0 0 0 6px rgba(123, 104, 238, 0.35), 0 0 22px 6px rgba(74, 144, 226, 0.55);
+		opacity: 0.28;
+		transform: scale(0.96);
+		box-shadow: 0 0 0 2px rgba(221, 107, 32, 0.2), 0 2px 8px rgba(0, 0, 0, 0.15);
+		border-color: #744210;
+		filter: brightness(0.85);
+	}
+	55% {
+		opacity: 1;
+		transform: scale(1.1);
+		box-shadow: 0 0 0 10px rgba(255, 237, 74, 0.55), 0 0 0 3px rgba(255, 255, 255, 1), 0 8px 28px rgba(221, 107, 32, 0.7);
+		border-color: #dd6b20;
+		filter: brightness(1.15);
 	}
 }
 
 .login-prompt-link:focus-visible {
-	outline: 2px solid #4a5568;
-	outline-offset: 2px;
+	outline: 3px solid #2d3748;
+	outline-offset: 3px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -28,10 +59,12 @@
 		animation: none;
 		opacity: 1;
 		transform: none;
-		font-weight: 700;
-		color: #1a365d;
-		background-color: #bee3f8;
-		border: 3px solid #2b6cb0;
-		box-shadow: 0 0 0 3px rgba(43, 108, 176, 0.35);
+		filter: none;
+		will-change: auto;
+		font-weight: 800;
+		color: #1a202c;
+		background: #fefcbf;
+		border: 3px solid #c05621;
+		box-shadow: 0 0 0 4px rgba(221, 107, 32, 0.45), 0 4px 12px rgba(0, 0, 0, 0.12);
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The header **Login** link (shown only when unauthenticated via `AuthorizeView`) now uses a much more obvious repeating emphasis: high-contrast “call to action” pill styling, a sharp opacity dip that reads as a blink, and stronger scale/box-shadow pulses. Animation runs only under `prefers-reduced-motion: no-preference`, matching the pattern used for `.btn-login-portal` on the login page. For reduced motion, the link stays static with bold weight, strong border, and elevated contrast. `:focus-visible` uses a 3px outline so keyboard users do not rely on motion for discoverability.

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/Components/LoginLink.razor.css` | Reworked keyframes and base styles; gated infinite animation with `@media (prefers-reduced-motion: no-preference)`; strengthened reduced-motion and focus styles |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — build succeeded; 143 unit tests and 80 integration tests passed.
- `LoginLink` markup unchanged (`href`, `data-testid`, `login-prompt-link`); existing `LoginLinkTests` cover the DOM contract.
- Visual/motion behavior: manual check in browser recommended (CSS-only).

Closes #1138
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20712ab0-8f8f-4c69-bef1-aae9758017c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20712ab0-8f8f-4c69-bef1-aae9758017c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

