### PR TITLE
Add navigate hide button (#1193)

### DIFF
--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -30,6 +30,7 @@ public class MainLayoutTests
         toggle.GetAttribute("aria-expanded").ShouldBe("true");
         toggle.GetAttribute("aria-controls").ShouldBe("app-navigation-rail");
         toggle.GetAttribute("title")!.ShouldContain("Hide");
+        toggle.GetAttribute("aria-label")!.ShouldContain("Hide");
         layout.Find("#app-navigation-rail").ClassList.ShouldContain("modern-sidebar");
         layout.Find(".modern-app").ClassList.ShouldNotContain("rail-collapsed");
     }


### PR DESCRIPTION
## Summary

The navigation rail hide/show toggle in `MainLayout` already matched issue #1193 (header toggle, wide collapse, narrow overlay, focus return, `768px` alignment). This PR tightens test coverage by asserting the toggle `aria-label` reflects the hide state on first render.

## Files changed

| File | Description |
|------|-------------|
| `src/UnitTests/UI.Shared/MainLayoutTests.cs` | Assert `aria-label` contains "Hide" when rail is expanded by default |

## Testing

- Ran `PrivateBuild.ps1`: build succeeded; **143** unit tests and **82** integration tests passed.
- No new acceptance (Playwright) tests: shell behavior remains covered by `MainLayoutTests`; existing acceptance suite unchanged.

Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

Closes #1193
