### PR TITLE
Add work order instructions as a new field (#1190)

### DIFF
--- a/src/AcceptanceTests/AIAgents/AutoReformatAgentTests.cs
+++ b/src/AcceptanceTests/AIAgents/AutoReformatAgentTests.cs
@@ -25,6 +25,7 @@ public class AutoReformatAgentTests : AcceptanceTestBase
         // Save the draft with the bad title and description
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + "Save");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 

--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -311,6 +311,7 @@ public abstract class AcceptanceTestBase
         order.Number = null;
         var testTitle = order.Title;
         var testDescription = order.Description;
+        var testInstructions = order.Instructions;
         var testRoomNumber = order.RoomNumber;
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -324,6 +325,7 @@ public abstract class AcceptanceTestBase
         order.Number = newWorkOrderNumber;
         await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
         await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
         await TakeScreenshotAsync(2, "FormFilled");
 
@@ -363,6 +365,7 @@ public abstract class AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), username);
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -380,6 +383,7 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToInProgressCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
@@ -396,6 +400,7 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToCompleteCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         await Task.Delay(GetInputDelayMs()); // Give time for the save operation to complete on Azure

--- a/src/AcceptanceTests/WorkOrders/WorkOrderAssignTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderAssignTests.cs
@@ -25,6 +25,7 @@ public class WorkOrderAssignTests : AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
         await Input(nameof(WorkOrderManage.Elements.Title), "newtitle");
         await Input(nameof(WorkOrderManage.Elements.Description), "newdesc");
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -39,6 +40,9 @@ public class WorkOrderAssignTests : AcceptanceTestBase
         
         var descriptionField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Description));
         await Expect(descriptionField).ToHaveValueAsync("newdesc");
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions ?? "");
         
         var assigneeField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee));
         await Expect(assigneeField).ToBeDisabledAsync();

--- a/src/AcceptanceTests/WorkOrders/WorkOrderBeginTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderBeginTests.cs
@@ -17,13 +17,16 @@ public class WorkOrderBeginTests : AcceptanceTestBase
 
         order.Title = "Title from automation";
         order.Description = "Description";
+        order.Instructions = "Check breaker before wiring";
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToInProgressCommand.Name);
         order = await ClickWorkOrderNumberFromSearchPage(order);
 
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Title))).ToHaveValueAsync(order.Title!);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToHaveValueAsync(order.Description!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions))).ToHaveValueAsync(order.Instructions!);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee))).ToHaveValueAsync(CurrentUser.UserName);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status))).ToHaveTextAsync(WorkOrderStatus.InProgress.FriendlyName);
     }

--- a/src/AcceptanceTests/WorkOrders/WorkOrderCancelTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderCancelTests.cs
@@ -17,13 +17,16 @@ public class WorkOrderCancelTests : AcceptanceTestBase
 
         order.Title = "Title from automation";
         order.Description = "Description";
+        order.Instructions = "Safety: lock out panel";
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToCancelledCommand.Name);
         order = await ClickWorkOrderNumberFromSearchPage(order);
 
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Title))).ToHaveValueAsync(order.Title!);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToHaveValueAsync(order.Description!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions))).ToHaveValueAsync(order.Instructions!);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status))).ToHaveTextAsync(WorkOrderStatus.Cancelled.FriendlyName);
     }
 }

--- a/src/AcceptanceTests/WorkOrders/WorkOrderCompleteTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderCompleteTests.cs
@@ -21,8 +21,10 @@ public class WorkOrderCompleteTests : AcceptanceTestBase
 
         var expectedTitle = "Title from automation";
         var expectedDescription = "Description";
+        var expectedInstructions = "Bring ladder from storage";
         order.Title = expectedTitle;
         order.Description = expectedDescription;
+        order.Instructions = expectedInstructions;
         order = await CompleteExistingWorkOrder(order);
         order = await ClickWorkOrderNumberFromSearchPage(order);
 
@@ -36,6 +38,9 @@ public class WorkOrderCompleteTests : AcceptanceTestBase
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description)))
             .ToHaveValueAsync(expectedDescription);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToBeDisabledAsync();
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions)))
+            .ToHaveValueAsync(expectedInstructions);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions))).ToBeDisabledAsync();
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
             .ToHaveTextAsync(WorkOrderStatus.Complete.FriendlyName);
 

--- a/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsValidationTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsValidationTests.cs
@@ -1,0 +1,35 @@
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderInstructionsValidationTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldShowValidationSummaryWhenInstructionsExceed4000Characters()
+    {
+        await LoginAsCurrentUser();
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Click(nameof(NavMenu.Elements.NewWorkOrder));
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await Expect(woNumberLocator).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+
+        await Input(nameof(WorkOrderManage.Elements.Title), "Title for instructions validation");
+        await Input(nameof(WorkOrderManage.Elements.Description), "Description");
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), "101");
+
+        var overLimit = new string('z', 4001);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), overLimit);
+
+        var saveButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name;
+        await Click(saveButtonTestId);
+
+        var summary = Page.Locator(".validation-summary");
+        await Expect(summary).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+        await Expect(summary).ToContainTextAsync("Instructions");
+    }
+}

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -49,6 +49,9 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         var descriptionField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Description));
         await Expect(descriptionField).ToHaveValueAsync(order.Description!);
 
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions ?? "");
+
         var roomNumberField = Page.GetByTestId(nameof(WorkOrderManage.Elements.RoomNumber));
         await Expect(roomNumberField).ToHaveValueAsync(order.RoomNumber!);
 
@@ -78,6 +81,7 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
         await Input(nameof(WorkOrderManage.Elements.Title), "newtitle");
         await Input(nameof(WorkOrderManage.Elements.Description), "newdesc");
+        await Input(nameof(WorkOrderManage.Elements.Instructions), "newinstructions");
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
 
         await Page.WaitForURLAsync("**/workorder/search");
@@ -94,6 +98,9 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
 
         var descriptionField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Description));
         await Expect(descriptionField).ToHaveValueAsync("newdesc");
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync("newinstructions");
 
         var assigneeField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee));
         await Expect(assigneeField).ToHaveValueAsync(CurrentUser.UserName);

--- a/src/AcceptanceTests/WorkOrders/WorkOrderShelvedTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderShelvedTests.cs
@@ -19,13 +19,16 @@ public class WorkOrderShelvedTests : AcceptanceTestBase
 
         order.Title = "Title from automation";
         order.Description = "Description";
+        order.Instructions = "Resume after parts arrive";
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToAssignedCommand.Name);
         order = await ClickWorkOrderNumberFromSearchPage(order);
 
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Title))).ToHaveValueAsync(order.Title!);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToHaveValueAsync(order.Description!);
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions))).ToHaveValueAsync(order.Instructions!);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee))).ToHaveValueAsync(CurrentUser.UserName);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status))).ToHaveTextAsync(WorkOrderStatus.Assigned.FriendlyName);
     }

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions;
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedNullableString(value);
     }
 
     public string? RoomNumber { get; set; } = null;
@@ -30,6 +37,17 @@ public class WorkOrder : EntityBase<WorkOrder>
     public DateTime? CreatedDate { get; set; }
 
     public DateTime? CompletedDate { get; set; }
+
+    private string? getTruncatedNullableString(string? value)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        var maxLength = Math.Min(4000, value.Length);
+        return value.Substring(0, maxLength);
+    }
 
     private string? getTruncatedString(string? value)
     {

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(300);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,12 @@
+BEGIN TRANSACTION
+GO
+PRINT N'Adding [Instructions] to [dbo].[WorkOrder]'
+GO
+ALTER TABLE [dbo].[WorkOrder] ADD
+	[Instructions] nvarchar(4000) NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/IntegrationTests/TestHost.cs
+++ b/src/IntegrationTests/TestHost.cs
@@ -149,9 +149,9 @@ public static class TestHost
                     ([System.ComponentModel.Description("Title")] string title,
                      [System.ComponentModel.Description("Description")] string description,
                      [System.ComponentModel.Description("Creator username")] string creatorUsername,
-                     [System.ComponentModel.Description("Optional instructions")] string? instructions = null,
-                     [System.ComponentModel.Description("Optional room number")] string? roomNumber = null)
-                        => WorkOrderTools.CreateWorkOrder(CreateScopedBus(), CreateScopedNumberGenerator(), title, description, creatorUsername, instructions, roomNumber),
+                     [System.ComponentModel.Description("Optional room number")] string? roomNumber = null,
+                     [System.ComponentModel.Description("Optional instructions")] string? instructions = null)
+                        => WorkOrderTools.CreateWorkOrder(CreateScopedBus(), CreateScopedNumberGenerator(), title, description, creatorUsername, roomNumber, instructions),
                     "CreateWorkOrder",
                     "Creates a new draft work order."),
                 AIFunctionFactory.Create(

--- a/src/IntegrationTests/TestHost.cs
+++ b/src/IntegrationTests/TestHost.cs
@@ -149,8 +149,9 @@ public static class TestHost
                     ([System.ComponentModel.Description("Title")] string title,
                      [System.ComponentModel.Description("Description")] string description,
                      [System.ComponentModel.Description("Creator username")] string creatorUsername,
+                     [System.ComponentModel.Description("Optional instructions")] string? instructions = null,
                      [System.ComponentModel.Description("Optional room number")] string? roomNumber = null)
-                        => WorkOrderTools.CreateWorkOrder(CreateScopedBus(), CreateScopedNumberGenerator(), title, description, creatorUsername, roomNumber),
+                        => WorkOrderTools.CreateWorkOrder(CreateScopedBus(), CreateScopedNumberGenerator(), title, description, creatorUsername, instructions, roomNumber),
                     "CreateWorkOrder",
                     "Creates a new draft work order."),
                 AIFunctionFactory.Create(

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -44,15 +44,15 @@ public class WorkOrderTools
             new JsonSerializerOptions { WriteIndented = true });
     }
 
-    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts execution instructions and a room number for the location.")]
+    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts a room number and execution instructions for the location and fulfillment notes.")]
     public static async Task<string> CreateWorkOrder(
         IBus bus,
         IWorkOrderNumberGenerator numberGenerator,
         [Description("Title of the work order")] string title,
         [Description("Description of the work order")] string description,
         [Description("Username of the employee creating the work order")] string creatorUsername,
-        [Description("Optional execution instructions for fulfilling the work order")] string? instructions = null,
-        [Description("Optional room number or location for the work order")] string? roomNumber = null)
+        [Description("Optional room number or location for the work order")] string? roomNumber = null,
+        [Description("Optional execution instructions for fulfilling the work order")] string? instructions = null)
     {
         try
         {

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -44,13 +44,14 @@ public class WorkOrderTools
             new JsonSerializerOptions { WriteIndented = true });
     }
 
-    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts a room number for the location.")]
+    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts execution instructions and a room number for the location.")]
     public static async Task<string> CreateWorkOrder(
         IBus bus,
         IWorkOrderNumberGenerator numberGenerator,
         [Description("Title of the work order")] string title,
         [Description("Description of the work order")] string description,
         [Description("Username of the employee creating the work order")] string creatorUsername,
+        [Description("Optional execution instructions for fulfilling the work order")] string? instructions = null,
         [Description("Optional room number or location for the work order")] string? roomNumber = null)
     {
         try
@@ -65,6 +66,7 @@ public class WorkOrderTools
             {
                 Title = title,
                 Description = description,
+                Instructions = instructions,
                 Creator = creator,
                 Status = WorkOrderStatus.Draft,
                 Number = numberGenerator.GenerateNumber(),
@@ -195,6 +197,7 @@ public class WorkOrderTools
         wo.Number,
         wo.Title,
         wo.Description,
+        wo.Instructions,
         Status = wo.Status.FriendlyName,
         wo.RoomNumber,
         Creator = wo.Creator?.GetFullName(),

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    [MaxLength(4000)] public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -8,7 +8,7 @@
 
     <EditForm Model="@Model" OnValidSubmit="HandleSubmit">
         <DataAnnotationsValidator/>
-        <ValidationSummary/>
+        <ValidationSummary class="validation-summary"/>
 
         <div class="form-container">
             <div class="form-grid">
@@ -54,6 +54,13 @@
                     <div>
                         <InputTextArea data-testid="@Elements.Description" id="Description" @bind-Value="Model.Description" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
                         <button type="button" data-testid="@Elements.SpeakDescription" class="btn btn-sm btn-outline-secondary" aria-label="Speak description" title="Speak description" @onclick="SpeakDescriptionAsync">&#x1F50A;</button>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
                     </div>
                 </div>
 
@@ -146,6 +153,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -92,6 +92,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate?.ToString("G", CultureInfo.CurrentCulture),
             AssignedDate = workOrder.AssignedDate?.ToString("G", CultureInfo.CurrentCulture),
@@ -131,6 +132,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -16,6 +16,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
         Assert.That(workOrder.Assignee, Is.EqualTo(null));
+        Assert.That(workOrder.Instructions, Is.EqualTo(null));
     }
 
     [Test]
@@ -40,6 +41,7 @@ public class WorkOrderTests
         workOrder.Id = guid;
         workOrder.Title = "Title";
         workOrder.Description = "Description";
+        workOrder.Instructions = "Instructions text";
         workOrder.Status = WorkOrderStatus.Complete;
         workOrder.Number = "Number";
         workOrder.Creator = creator;
@@ -48,6 +50,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(guid));
         Assert.That(workOrder.Title, Is.EqualTo("Title"));
         Assert.That(workOrder.Description, Is.EqualTo("Description"));
+        Assert.That(workOrder.Instructions, Is.EqualTo("Instructions text"));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Complete));
         Assert.That(workOrder.Number, Is.EqualTo("Number"));
         Assert.That(workOrder.Creator, Is.EqualTo(creator));
@@ -70,6 +73,22 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('y', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions!.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldAllowNullInstructions()
+    {
+        var order = new WorkOrder { Instructions = null };
+        Assert.That(order.Instructions, Is.EqualTo(null));
     }
 
     [Test]

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageInstructionsTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageInstructionsTests.cs
@@ -1,0 +1,93 @@
+using Bunit;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using MediatR;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Palermo.BlazorMvc;
+using Shouldly;
+using Toolbelt.Blazor.Extensions.DependencyInjection;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
+
+[TestFixture]
+public class WorkOrderManageInstructionsTests
+{
+    [Test]
+    public void WorkOrderManage_ShouldRenderInstructionsTextAreaWithTestId()
+    {
+        using var ctx = new TestContext();
+
+        var user = new Employee("jpalermo", "Jeffrey", "Palermo", "jp@example.com");
+        user.Id = Guid.NewGuid();
+        var workOrderId = Guid.NewGuid();
+
+        ctx.Services.AddSingleton<IBus>(new StubInstructionsBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IWorkOrderBuilder>(new StubWorkOrderBuilderForInstructions(workOrderId));
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSessionForInstructions(user));
+        ctx.Services.AddSingleton<ITranslationService>(new StubTranslationServiceForInstructions());
+        ctx.Services.AddSpeechSynthesis();
+
+        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var instructions = component.Find($"[data-testid='{WorkOrderManage.Elements.Instructions}']");
+            instructions.ShouldNotBeNull();
+        });
+    }
+
+    private class StubInstructionsBus() : Bus(null!)
+    {
+        public override Task Publish(INotification notification) => Task.CompletedTask;
+
+        public override Task<TResponse> Send<TResponse>(IRequest<TResponse> request)
+        {
+            if (request is EmployeeGetAllQuery)
+            {
+                return Task.FromResult<TResponse>((TResponse)(object)Array.Empty<Employee>());
+            }
+
+            if (request is WorkOrderAttachmentsQuery)
+            {
+                return Task.FromResult<TResponse>((TResponse)(object)Array.Empty<WorkOrderAttachment>());
+            }
+
+            throw new NotImplementedException($"Unhandled request type: {request.GetType().Name}");
+        }
+    }
+
+    private class StubWorkOrderBuilderForInstructions(Guid workOrderId) : IWorkOrderBuilder
+    {
+        public WorkOrder CreateNewWorkOrder(Employee creator)
+        {
+            return new WorkOrder
+            {
+                Id = workOrderId,
+                Number = "WO-TEST",
+                Status = WorkOrderStatus.Draft,
+                Creator = creator,
+                Title = "Test Order"
+            };
+        }
+    }
+
+    private class StubUserSessionForInstructions(Employee user) : IUserSession
+    {
+        public Task<Employee?> GetCurrentUserAsync() => Task.FromResult<Employee?>(user);
+    }
+
+    private class StubTranslationServiceForInstructions : ITranslationService
+    {
+        public Task<string> TranslateAsync(string text, string targetLanguageCode) => Task.FromResult(text);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an optional **Instructions** field (up to 4,000 characters) for work orders: nullable column, domain property with truncation aligned to max length, EF mapping, maintain-work-order UI between Description and Room, MCP tool support, and tests.

## CI follow-up (SQL container job)

The **Integration Build (SQL container)** failure was caused by **`CreateWorkOrder` parameter order**: `instructions` was inserted **before** `roomNumber`, so LLM tool calls that still passed the 5th positional argument as room number ended up binding it to **`instructions`** instead, leaving **`RoomNumber` null** and breaking **`ApplicationChatHandlerTests.Handle_CreateAndAssignWorkOrder_AssignsWorkOrderForWilie`**.

**Fix (commit after initial PR):** restore **`roomNumber` before `instructions`** on `WorkOrderTools.CreateWorkOrder` and the `TestHost` `AIFunctionFactory` delegate so positional arguments match the pre-change tool contract.

## Files changed

| Area | Change |
|------|--------|
| `src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql` | New migration: `Instructions nvarchar(4000) NULL` |
| `src/Core/Model/WorkOrder.cs` | `Instructions` property with nullable truncation helper |
| `src/DataAccess/Mappings/WorkOrderMap.cs` | `HasMaxLength(4000)` for `Instructions` |
| `src/UI.Shared/Models/WorkOrderManageModel.cs` | `[MaxLength(4000)]` optional `Instructions` |
| `src/UI.Shared/Pages/WorkOrderManage.razor` | Textarea + `Elements.Instructions`; `ValidationSummary` uses `validation-summary` class for visible errors |
| `src/UI.Shared/Pages/WorkOrderManage.razor.cs` | Map Instructions in view model and submit |
| `src/McpServer/Tools/WorkOrderTools.cs` | Optional `instructions` **after** `roomNumber` on create; detail JSON includes `Instructions` |
| `src/IntegrationTests/TestHost.cs` | `CreateWorkOrder` AI delegate: same parameter order |
| `src/UnitTests/Core/Model/WorkOrderTests.cs` | Default, round-trip, truncation, null tests |
| `src/UnitTests/UI.Shared/Pages/WorkOrderManageInstructionsTests.cs` | Renders textarea with expected `data-testid` |
| `src/AcceptanceTests/AcceptanceTestBase.cs` + work order flows | Input/assert Instructions where forms persist state |
| `src/AcceptanceTests/WorkOrders/WorkOrderInstructionsValidationTests.cs` | Over-4000 chars shows validation summary |

## Testing

- `dotnet test src/UnitTests` — Release — all passed
- `DATABASE_ENGINE=SQLite pwsh ./PrivateBuild.ps1` — build, unit tests, integration tests — passed

Acceptance tests (Playwright) were not executed in this environment; CI should run them.

Closes #1190
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8345c1a8-ae3f-4068-9311-e5c918d2708e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8345c1a8-ae3f-4068-9311-e5c918d2708e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

