### PR TITLE
Add work order instructions as a new field (#1250)

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -311,6 +311,7 @@ public abstract class AcceptanceTestBase
         order.Number = null;
         var testTitle = order.Title;
         var testDescription = order.Description;
+        var testInstructions = order.Instructions;
         var testRoomNumber = order.RoomNumber;
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -324,6 +325,11 @@ public abstract class AcceptanceTestBase
         order.Number = newWorkOrderNumber;
         await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
         await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        if (testInstructions != null)
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
+        }
+
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
         await TakeScreenshotAsync(2, "FormFilled");
 
@@ -363,6 +369,7 @@ public abstract class AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), username);
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -380,6 +387,7 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToInProgressCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
@@ -396,6 +404,7 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToCompleteCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         await Task.Delay(GetInputDelayMs()); // Give time for the save operation to complete on Azure

--- a/src/AcceptanceTests/WorkOrders/WorkOrderCompleteTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderCompleteTests.cs
@@ -36,6 +36,9 @@ public class WorkOrderCompleteTests : AcceptanceTestBase
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description)))
             .ToHaveValueAsync(expectedDescription);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToBeDisabledAsync();
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions)))
+            .ToHaveValueAsync(order.Instructions ?? "");
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions))).ToBeDisabledAsync();
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
             .ToHaveTextAsync(WorkOrderStatus.Complete.FriendlyName);
 

--- a/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderInstructionsTests.cs
@@ -1,0 +1,107 @@
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.StateCommands;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderInstructionsTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task MaintainWorkOrder_ShouldRoundTripInstructions_AfterSave()
+    {
+        await LoginAsCurrentUser();
+
+        var order = Faker<WorkOrder>();
+        order.Title = $"[{TestTag}] from automation";
+        order.Number = null;
+        order.Instructions = $"[{TestTag}] distinctive execution steps for round-trip";
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Click(nameof(NavMenu.Elements.NewWorkOrder));
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+        var woNumberLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber));
+        await Expect(woNumberLocator).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+        order.Number = await woNumberLocator.InnerTextAsync();
+
+        await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
+        await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), order.RoomNumber);
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        WorkOrder? rehydrated = null;
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            rehydrated = await Bus.Send(new WorkOrderByNumberQuery(order.Number!));
+            if (rehydrated != null) break;
+            await Task.Delay(1000);
+        }
+        rehydrated.ShouldNotBeNull();
+        rehydrated.Instructions.ShouldBe(order.Instructions);
+
+        var workOrderLink = Page.GetByTestId(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await workOrderLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        await Click(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(Page).ToHaveURLAsync(new Regex($"/workorder/manage/{Regex.Escape(order.Number!)}\\?mode=Edit"));
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions!);
+    }
+
+    [Test, Retry(2)]
+    public async Task MaintainWorkOrder_ShouldRejectInstructionsOverMaxLength_ViaValidationSummary()
+    {
+        await LoginAsCurrentUser();
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Click(nameof(NavMenu.Elements.NewWorkOrder));
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+        await Input(nameof(WorkOrderManage.Elements.Title), $"[{TestTag}] title for validation");
+        await Input(nameof(WorkOrderManage.Elements.Description), "Description for validation test");
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), "101");
+
+        var tooLong = new string('z', 4001);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), tooLong);
+
+        await Click(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name);
+
+        var summary = Page.Locator(".validation-summary");
+        await Expect(summary).ToBeVisibleAsync();
+        await Expect(summary).ToContainTextAsync("Instructions");
+    }
+
+    [Test, Retry(2)]
+    public async Task MaintainWorkOrder_ShouldShowInstructionsReadOnly_When_NotEditable()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order = await BeginExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order.Title = "Title for read-only instructions test";
+        order.Description = "Description for read-only";
+        order.Instructions = "Instructions visible but not editable after complete";
+        order = await CompleteExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.ReadOnlyMessage))).ToBeVisibleAsync();
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions!);
+        await Expect(instructionsField).ToBeDisabledAsync();
+    }
+}

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -52,6 +52,9 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         var roomNumberField = Page.GetByTestId(nameof(WorkOrderManage.Elements.RoomNumber));
         await Expect(roomNumberField).ToHaveValueAsync(order.RoomNumber!);
 
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions ?? "");
+
         WorkOrder rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number)) ?? throw new InvalidOperationException();
         var displayedDate = await Page.GetDateTimeFromTestIdAsync(nameof(WorkOrderManage.Elements.CreatedDate));
 

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSpeechTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSpeechTests.cs
@@ -77,5 +77,6 @@ public class WorkOrderSpeechTests : AcceptanceTestBase
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.ReadOnlyMessage))).ToBeVisibleAsync();
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.SpeakTitle))).ToBeVisibleAsync();
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.SpeakDescription))).ToBeVisibleAsync();
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.SpeakInstructions))).ToBeVisibleAsync();
     }
 }

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions;
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedOptionalString(value);
     }
 
     public string? RoomNumber { get; set; } = null;
@@ -38,7 +45,23 @@ public class WorkOrder : EntityBase<WorkOrder>
             return string.Empty;
         }
 
-        var maxLength = Math.Min(4000, value.Length);
+        return truncateToMaxLength(value);
+    }
+
+    private string? getTruncatedOptionalString(string? value)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        return truncateToMaxLength(value);
+    }
+
+    private static string truncateToMaxLength(string value)
+    {
+        const int maxChars = 4000;
+        var maxLength = Math.Min(maxChars, value.Length);
         return value.Substring(0, maxLength);
     }
 

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(300);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION
+GO
+PRINT N'Adding [Instructions] to [dbo].[WorkOrder]'
+GO
+ALTER TABLE [dbo].[WorkOrder] ADD [Instructions] NVARCHAR(4000) NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForAssignTests.cs
+++ b/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForAssignTests.cs
@@ -43,6 +43,34 @@ public class StateCommandHandlerForAssignTests : IntegratedTestBase
     }
 
     [Test]
+    public async Task DraftToAssigned_ShouldPreserveInstructions_When_UnrelatedCommand()
+    {
+        new DatabaseTests().Clean();
+
+        var o = Faker<WorkOrder>();
+        o.Id = Guid.Empty;
+        o.Instructions = "Bring ladder from storage B.";
+        var currentUser = Faker<Employee>();
+        var assignee = Faker<Employee>();
+        o.Creator = currentUser;
+        o.Assignee = assignee;
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(currentUser);
+            context.Add(assignee);
+            await context.SaveChangesAsync();
+        }
+
+        var command = RemotableRequestTests.SimulateRemoteObject(new DraftToAssignedCommand(o, currentUser));
+        var handler = TestHost.GetRequiredService<StateCommandHandler>();
+        var result = await handler.Handle(command);
+
+        var context3 = TestHost.GetRequiredService<DbContext>();
+        var order = context3.Find<WorkOrder>(result.WorkOrder.Id) ?? throw new InvalidOperationException();
+        order.Instructions.ShouldBe("Bring ladder from storage B.");
+    }
+
+    [Test]
     public async Task ShouldSaveWorkOrderWithOnlyCreatorRemotingCommand()
     {
         new DatabaseTests().Clean();

--- a/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForSaveTests.cs
+++ b/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForSaveTests.cs
@@ -42,6 +42,68 @@ public class StateCommandHandlerForSaveTests : IntegratedTestBase
     }
 
     [Test]
+    public async Task SaveDraft_ShouldPersistInstructions_When_NewWorkOrder()
+    {
+        new DatabaseTests().Clean();
+
+        var currentUser = Faker<Employee>();
+        currentUser.Id = Guid.NewGuid();
+        var context = TestHost.GetRequiredService<DbContext>();
+        context.Add(currentUser);
+        await context.SaveChangesAsync();
+
+        var workOrder = Faker<WorkOrder>();
+        workOrder.Id = Guid.Empty;
+        workOrder.CreatedDate = null;
+        workOrder.Creator = currentUser;
+        workOrder.Instructions = "Use the north entrance and lock up after.";
+
+        var command = RemotableRequestTests.SimulateRemoteObject(new SaveDraftCommand(workOrder, currentUser));
+        var handler = TestHost.GetRequiredService<StateCommandHandler>();
+        var result = await handler.Handle(command);
+
+        var context3 = TestHost.GetRequiredService<DbContext>();
+        var order = context3.Find<WorkOrder>(result.WorkOrder.Id) ?? throw new InvalidOperationException();
+        order.Instructions.ShouldBe("Use the north entrance and lock up after.");
+    }
+
+    [Test]
+    public async Task SaveDraft_ShouldUpdateInstructions_When_ExistingWorkOrder()
+    {
+        new DatabaseTests().Clean();
+
+        var workOrder = Faker<WorkOrder>();
+        var currentUser = Faker<Employee>();
+        workOrder.Creator = currentUser;
+        workOrder.Instructions = "Original instructions";
+        await using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(currentUser);
+            context.Add(workOrder);
+            await context.SaveChangesAsync();
+        }
+
+        Employee? assignee;
+        await using (var context2 = TestHost.GetRequiredService<DbContext>())
+        {
+            assignee = context2.Find<Employee>(currentUser.Id);
+        }
+
+        workOrder.Creator = currentUser;
+        workOrder.Assignee = assignee;
+        workOrder.Instructions = "Updated step-by-step instructions";
+
+        var command = RemotableRequestTests.SimulateRemoteObject(new SaveDraftCommand(workOrder, currentUser));
+        var handler = TestHost.GetRequiredService<StateCommandHandler>();
+        await handler.Handle(command);
+
+        var context3 = TestHost.GetRequiredService<DbContext>();
+        var order = context3.Find<WorkOrder>(workOrder.Id) ?? throw new InvalidOperationException();
+        order.Instructions.ShouldBe("Updated step-by-step instructions");
+        order.Title.ShouldBe(workOrder.Title);
+    }
+
+    [Test]
     public async Task ShouldSaveWorkOrderWithAssigneeAndCreator()
     {
         new DatabaseTests().Clean();

--- a/src/IntegrationTests/McpServer/McpWorkOrderToolTests.cs
+++ b/src/IntegrationTests/McpServer/McpWorkOrderToolTests.cs
@@ -68,7 +68,15 @@ public class McpWorkOrderToolTests
     public async Task ShouldGetWorkOrderByNumber()
     {
         var employee = new Employee("user1", "John", "Doe", "john@test.com");
-        var order = new WorkOrder { Creator = employee, Number = "WO-100", Title = "Test order", Description = "A description", RoomNumber = "101" };
+        var order = new WorkOrder
+        {
+            Creator = employee,
+            Number = "WO-100",
+            Title = "Test order",
+            Description = "A description",
+            Instructions = "Wear PPE in the mechanical room.",
+            RoomNumber = "101"
+        };
 
         using (var context = TestHost.GetRequiredService<DbContext>())
         {
@@ -84,6 +92,7 @@ public class McpWorkOrderToolTests
         result.ShouldContain("Test order");
         result.ShouldContain("A description");
         result.ShouldContain("101");
+        result.ShouldContain("Wear PPE in the mechanical room.");
     }
 
     [Test]
@@ -113,6 +122,33 @@ public class McpWorkOrderToolTests
         result.ShouldContain("New Work Order");
         result.ShouldContain("Fix the broken window");
         result.ShouldContain("Draft");
+    }
+
+    [Test]
+    public async Task ShouldCreateDraftWorkOrder_WithOptionalInstructions()
+    {
+        var employee = new Employee("creator1", "Jane", "Smith", "jane@test.com");
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(employee);
+            await context.SaveChangesAsync();
+        }
+
+        var bus = TestHost.GetRequiredService<IBus>();
+        var numberGenerator = new WorkOrderNumberGenerator();
+        var result = await WorkOrderTools.CreateWorkOrder(bus, numberGenerator, "With instructions", "Fix leak", "creator1",
+            roomNumber: null, instructions: "Shut off water main first.");
+
+        result.ShouldContain("Shut off water main first.");
+
+        WorkOrder? persisted = null;
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            persisted = context.Set<WorkOrder>().Single(w => w.Title == "With instructions");
+        }
+
+        persisted!.Instructions.ShouldBe("Shut off water main first.");
     }
 
     [Test]

--- a/src/IntegrationTests/TestHost.cs
+++ b/src/IntegrationTests/TestHost.cs
@@ -149,8 +149,9 @@ public static class TestHost
                     ([System.ComponentModel.Description("Title")] string title,
                      [System.ComponentModel.Description("Description")] string description,
                      [System.ComponentModel.Description("Creator username")] string creatorUsername,
-                     [System.ComponentModel.Description("Optional room number")] string? roomNumber = null)
-                        => WorkOrderTools.CreateWorkOrder(CreateScopedBus(), CreateScopedNumberGenerator(), title, description, creatorUsername, roomNumber),
+                     [System.ComponentModel.Description("Optional room number")] string? roomNumber = null,
+                     [System.ComponentModel.Description("Optional execution instructions")] string? instructions = null)
+                        => WorkOrderTools.CreateWorkOrder(CreateScopedBus(), CreateScopedNumberGenerator(), title, description, creatorUsername, roomNumber, instructions),
                     "CreateWorkOrder",
                     "Creates a new draft work order."),
                 AIFunctionFactory.Create(

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -44,14 +44,15 @@ public class WorkOrderTools
             new JsonSerializerOptions { WriteIndented = true });
     }
 
-    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts a room number for the location.")]
+    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts room number and execution instructions.")]
     public static async Task<string> CreateWorkOrder(
         IBus bus,
         IWorkOrderNumberGenerator numberGenerator,
         [Description("Title of the work order")] string title,
         [Description("Description of the work order")] string description,
         [Description("Username of the employee creating the work order")] string creatorUsername,
-        [Description("Optional room number or location for the work order")] string? roomNumber = null)
+        [Description("Optional room number or location for the work order")] string? roomNumber = null,
+        [Description("Optional instructions for how the work should be carried out")] string? instructions = null)
     {
         try
         {
@@ -65,6 +66,7 @@ public class WorkOrderTools
             {
                 Title = title,
                 Description = description,
+                Instructions = instructions,
                 Creator = creator,
                 Status = WorkOrderStatus.Draft,
                 Number = numberGenerator.GenerateNumber(),
@@ -195,6 +197,7 @@ public class WorkOrderTools
         wo.Number,
         wo.Title,
         wo.Description,
+        wo.Instructions,
         Status = wo.Status.FriendlyName,
         wo.RoomNumber,
         Creator = wo.Creator?.GetFullName(),

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    [MaxLength(4000)] public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -8,7 +8,7 @@
 
     <EditForm Model="@Model" OnValidSubmit="HandleSubmit">
         <DataAnnotationsValidator/>
-        <ValidationSummary/>
+        <ValidationSummary class="validation-summary"/>
 
         <div class="form-container">
             <div class="form-grid">

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -58,6 +58,14 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                        <button type="button" data-testid="@Elements.SpeakInstructions" class="btn btn-sm btn-outline-secondary" aria-label="Speak instructions" title="Speak instructions" @onclick="SpeakInstructionsAsync">&#x1F50A;</button>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -146,6 +154,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,
@@ -162,6 +171,7 @@
         AttachmentUploadedBy,
         AttachmentUploadedDate,
         SpeakTitle,
-        SpeakDescription
+        SpeakDescription,
+        SpeakInstructions
     }
 }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -92,6 +92,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate?.ToString("G", CultureInfo.CurrentCulture),
             AssignedDate = workOrder.AssignedDate?.ToString("G", CultureInfo.CurrentCulture),
@@ -131,6 +132,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()
@@ -150,6 +152,11 @@ public partial class WorkOrderManage : AppComponentBase
     private async Task SpeakDescriptionAsync()
     {
         await SpeakTextAsync(Model.Description);
+    }
+
+    private async Task SpeakInstructionsAsync()
+    {
+        await SpeakTextAsync(Model.Instructions);
     }
 
     private async Task SpeakTextAsync(string? text)

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -16,6 +16,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
         Assert.That(workOrder.Assignee, Is.EqualTo(null));
+        Assert.That(workOrder.Instructions, Is.EqualTo(null));
     }
 
     [Test]
@@ -70,6 +71,23 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateInstructionsTo4000_When_ValueExceedsMax()
+    {
+        var longText = new string('y', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions!.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldSetInstructionsToNull_When_AssignedNull()
+    {
+        var order = new WorkOrder { Instructions = "steps" };
+        order.Instructions = null;
+        Assert.That(order.Instructions, Is.EqualTo(null));
     }
 
     [Test]

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageSpeechTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageSpeechTests.cs
@@ -78,6 +78,35 @@ public class WorkOrderManageSpeechTests
     }
 
     [Test]
+    public void ShouldRenderSpeakInstructionsButton()
+    {
+        using var ctx = new TestContext();
+
+        var user = new Employee("jpalermo", "Jeffrey", "Palermo", "jp@example.com");
+        user.Id = Guid.NewGuid();
+
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IWorkOrderBuilder>(new StubWorkOrderBuilder());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
+        ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
+        ctx.Services.AddSpeechSynthesis();
+
+        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.SpeakInstructions}']");
+            element.ShouldNotBeNull();
+            element.TagName.ShouldBe("BUTTON", StringCompareShould.IgnoreCase);
+            element.GetAttribute("type").ShouldBe("button");
+        });
+    }
+
+    [Test]
     public void SpeakTitleButtonShouldInvokeTranslationService()
     {
         using var ctx = new TestContext();


### PR DESCRIPTION
## Summary

Adds an optional **Instructions** field (max 4000 characters) on work orders for execution notes, placed on Maintain Work Order between Description and Room. Persists via EF and SQL migration; UI uses the same textarea + validation pattern as Description and includes a speak button for parity.

## Files changed

| Area | Files |
|------|--------|
| Domain | `src/Core/Model/WorkOrder.cs` — nullable `Instructions`, shared truncation helper |
| Persistence | `src/DataAccess/Mappings/WorkOrderMap.cs`, `src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql` |
| UI | `WorkOrderManageModel.cs`, `WorkOrderManage.razor`, `WorkOrderManage.razor.cs` |
| MCP | `src/McpServer/Tools/WorkOrderTools.cs`, `src/IntegrationTests/TestHost.cs` (AI tool delegate) |
| Tests | Unit, integration (save/assign/MCP), acceptance (`WorkOrderInstructionsTests` + related updates) |

## Testing

- `PrivateBuild.ps1` (Release): unit tests 149/149, integration 86/86; DbUp applied `028_AddInstructionsToWorkOrder.sql` against SQL Server in Docker.

Closes #1250
