### PR TITLE
Document GitHub issue body update guidance for cloud agents

### DIFF
--- a/.cursor/rules/cloud-agent-instructions.mdc
+++ b/.cursor/rules/cloud-agent-instructions.mdc
@@ -124,3 +124,22 @@ After completing the interview, generate a non-technical Markdown summary. Avoid
 **Validation:** [Validation Rules]
 **Acceptance Criteria:** [Derived from conversation]
 ```
+
+---
+
+## GitHub REST API — Issue body updates (Cloud Agent)
+
+When updating an issue body via a **child process** (`python3`, `curl` with `-d @-`, etc.), any dynamic text must reach that process explicitly.
+
+### Failure mode: empty appended section
+
+Shell variables are **not** visible to child processes unless **exported**. A pattern such as `UX_DESIGN_CONTENT='...long text...'` followed by `python3 -c "… os.environ.get('UX_DESIGN_CONTENT') …"` produces an **empty** value and can PATCH the issue with only a heading and no design text. The API still returns **200**, so HTTP status alone is not enough.
+
+### Required practices
+
+1. **Pass prose reliably** — use one of:
+   - `export UX_DESIGN_CONTENT='…'` (or `export` immediately after assignment) before invoking Python; **or**
+   - Define the design text **inside** the Python script / heredoc (no cross-process env); **or**
+   - Pipe or write the full body via **stdin** / a **temp file** and read it in the updater.
+2. **Verify content, not only status** — after a successful PATCH, `GET` the issue (or use the PATCH response body) and confirm the **User Experience Design** section contains substantive text (e.g. minimum character count after the heading, or required keywords). If verification fails, **do not** post “complete” comments or apply workflow labels; retry the update instead.
+3. **Order of operations** — automation labels (e.g. ready-to-move) must run **only after** body content verification succeeds.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,10 @@ If Docker is unavailable, set `DATABASE_ENGINE=SQLite` before running the build 
 - **Ollama** (localhost:11434): Local LLM for AI agent features. Not required; errors in logs about Ollama connection refused are expected and harmless.
 - **Azure OpenAI**: Cloud LLM alternative. Requires `AI_OpenAI_ApiKey`, `AI_OpenAI_Url`, `AI_OpenAI_Model` env vars.
 
+### GitHub issue updates from scripts
+
+When appending issue bodies via `python3` or other subprocesses: **export** any variable the child reads (`export VAR=...`), or embed the text in the script. Unexported shell variables appear **empty** in the child, which can produce a successful API response with **blank** content. See **GitHub REST API — Issue body updates** in `.cursor/rules/cloud-agent-instructions.mdc`.
+
 ### Gotchas
 
 - NServiceBus runs in trial mode (no license). This produces a warning at startup but does not block functionality.


### PR DESCRIPTION
## Summary

Adds guidance so cloud agents do not PATCH GitHub issues with empty appended sections when subprocess updaters (e.g. Python) read shell variables that were never exported.

## Changes

- **`.cursor/rules/cloud-agent-instructions.mdc`:** New section on GitHub REST issue-body updates: subprocess env boundaries, ways to pass prose safely, verify body content after PATCH (not only HTTP status), and apply workflow labels only after verification.
- **`AGENTS.md`:** Short Cursor Cloud note pointing to that section.

Documentation-only; no build or test impact expected.