### PR TITLE
Add a GET /api/time endpoint that returns the current UTC timestamp (#1368)

### DIFF
--- a/src/UI/Api/Controllers/TimeController.cs
+++ b/src/UI/Api/Controllers/TimeController.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes the current UTC instant for operators and integrations.
+/// </summary>
+[ApiController]
+[Route("api/time")]
+public class TimeController(TimeProvider timeProvider) : ControllerBase
+{
+    /// <summary>
+    /// Returns the current UTC time as ISO 8601 plain text.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public ContentResult Get()
+    {
+        var text = timeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture);
+        return new ContentResult
+        {
+            Content = text,
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = 200
+        };
+    }
+}

--- a/src/UnitTests/UI.Api/TimeControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimeControllerTests.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimeControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnPlainTextIso8601Utc_ForFixedClock()
+    {
+        var fixedUtc = new DateTime(2026, 3, 30, 12, 0, 0, DateTimeKind.Utc);
+        var stubTimeProvider = new StubFixedUtcTimeProvider(fixedUtc);
+        var controller = new TimeController(stubTimeProvider);
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        var expected = new DateTimeOffset(fixedUtc, TimeSpan.Zero).ToString("O", CultureInfo.InvariantCulture);
+        content.Content.ShouldBe(expected);
+    }
+
+    private sealed class StubFixedUtcTimeProvider(DateTime utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new(utcNow, TimeSpan.Zero);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an unauthenticated `GET /api/time` endpoint that returns the current UTC instant as ISO 8601 plain text (`text/plain; charset=utf-8`) with HTTP 200. Uses constructor-injected `TimeProvider` (same pattern as detailed health) so the clock is testable.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/TimeController.cs` | New API controller: `[Route("api/time")]`, `[AllowAnonymous]`, `ContentResult` with invariant `"O"` format |
| `src/UnitTests/UI.Api/TimeControllerTests.cs` | Unit test with `StubFixedUtcTimeProvider`; asserts status 200, `text/plain`, and expected ISO string |

## Testing

- `dotnet test` filtered to `TimeControllerTests` (Release)
- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: unit tests (147) and integration tests (80) passed

Closes #1368
