### PR TITLE
Add a GET /api/health endpoint with uptime info (#1369)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -27,6 +27,46 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_Return200AndJson_When_GetSimpleHealth()
+    {
+        var response = await _client!.GetAsync("/api/health");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("status", out var status).ShouldBeTrue();
+        status.GetString().ShouldBe(SimpleHealthStatus.Healthy);
+        doc.RootElement.TryGetProperty("currentTimeUtc", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_AllowAnonymousAccess_When_GetSimpleHealth()
+    {
+        using var anonymous = _factory!.CreateClient();
+        var response = await anonymous.GetAsync("/api/health");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_ReturnRecentUtcAndNonNegativeUptime_When_GetSimpleHealth()
+    {
+        var response = await _client!.GetAsync("/api/health");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<SimpleHealthResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.CurrentTimeUtc.Kind.ShouldBe(DateTimeKind.Utc);
+        (DateTime.UtcNow - payload.CurrentTimeUtc).Duration().ShouldBeLessThan(TimeSpan.FromMinutes(5));
+        payload.Uptime.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
     public async Task Should_Return200AndJson_When_GetDetailedHealth()
     {
         var response = await _client!.GetAsync("/api/health/detailed");

--- a/src/UI/Api/Controllers/DetailedHealthController.cs
+++ b/src/UI/Api/Controllers/DetailedHealthController.cs
@@ -6,6 +6,12 @@ namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
 [Route("api/health")]
 public class DetailedHealthController(TimeProvider timeProvider) : ControllerBase
 {
+    [HttpGet]
+    public ActionResult<SimpleHealthResponse> Get()
+    {
+        return Ok(SimpleHealthResponseBuilder.Build(timeProvider));
+    }
+
     [HttpGet("detailed")]
     public ActionResult<DetailedHealthReport> GetDetailed()
     {

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -1,6 +1,29 @@
 namespace ClearMeasure.Bootcamp.UI.Api;
 
 /// <summary>
+/// Lightweight JSON payload for <c>GET /api/health</c>.
+/// </summary>
+public sealed class SimpleHealthResponse
+{
+    /// <summary>Application-reported status (e.g. <see cref="SimpleHealthStatus.Healthy"/>).</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Current instant in UTC (ISO-8601 when serialized).</summary>
+    public required DateTime CurrentTimeUtc { get; init; }
+
+    /// <summary>Elapsed time since the host process started.</summary>
+    public required TimeSpan Uptime { get; init; }
+}
+
+/// <summary>
+/// Allowed values for <see cref="SimpleHealthResponse.Status"/>.
+/// </summary>
+public static class SimpleHealthStatus
+{
+    public const string Healthy = nameof(Healthy);
+}
+
+/// <summary>
 /// Machine-oriented detailed health payload for <c>GET /api/health/detailed</c>.
 /// </summary>
 public sealed class DetailedHealthReport

--- a/src/UI/Api/SimpleHealthResponseBuilder.cs
+++ b/src/UI/Api/SimpleHealthResponseBuilder.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Builds <see cref="SimpleHealthResponse"/> for <c>GET /api/health</c>.
+/// </summary>
+public static class SimpleHealthResponseBuilder
+{
+    /// <summary>
+    /// Creates a response using the process start time from <see cref="Process.GetCurrentProcess"/>.
+    /// </summary>
+    public static SimpleHealthResponse Build(TimeProvider timeProvider)
+    {
+        var processStartUtc = new DateTimeOffset(Process.GetCurrentProcess().StartTime).ToUniversalTime();
+        return Build(timeProvider, processStartUtc);
+    }
+
+    /// <summary>
+    /// Creates a response for a known process start instant (UTC), for tests and deterministic scenarios.
+    /// </summary>
+    public static SimpleHealthResponse Build(TimeProvider timeProvider, DateTimeOffset processStartUtcUtc)
+    {
+        var now = timeProvider.GetUtcNow();
+        var startUtc = processStartUtcUtc.ToUniversalTime();
+        var uptime = now - startUtc;
+
+        return new SimpleHealthResponse
+        {
+            Status = SimpleHealthStatus.Healthy,
+            CurrentTimeUtc = now.UtcDateTime,
+            Uptime = uptime
+        };
+    }
+}

--- a/src/UnitTests/UI/Api/SimpleHealthResponseBuilderTests.cs
+++ b/src/UnitTests/UI/Api/SimpleHealthResponseBuilderTests.cs
@@ -1,0 +1,48 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class SimpleHealthResponseBuilderTests
+{
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    [Test]
+    public void Build_Should_SetStatusHealthy_When_Default()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 3, 30, 12, 0, 0, TimeSpan.Zero));
+        var start = new DateTimeOffset(2026, 3, 30, 11, 0, 0, TimeSpan.Zero);
+
+        var response = SimpleHealthResponseBuilder.Build(clock, start);
+
+        response.Status.ShouldBe(SimpleHealthStatus.Healthy);
+    }
+
+    [Test]
+    public void Build_Should_SetCurrentTimeUtc_FromTimeProvider_When_Called()
+    {
+        var fixedNow = new DateTimeOffset(2026, 3, 30, 15, 30, 45, TimeSpan.Zero);
+        var clock = new FixedUtcTimeProvider(fixedNow);
+        var start = new DateTimeOffset(2026, 3, 30, 10, 0, 0, TimeSpan.Zero);
+
+        var response = SimpleHealthResponseBuilder.Build(clock, start);
+
+        response.CurrentTimeUtc.ShouldBe(fixedNow.UtcDateTime);
+        response.CurrentTimeUtc.Kind.ShouldBe(DateTimeKind.Utc);
+    }
+
+    [Test]
+    public void Build_Should_ComputeUptime_AsNowMinusStart_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 3, 30, 14, 0, 0, TimeSpan.Zero));
+        var start = new DateTimeOffset(2026, 3, 30, 12, 30, 0, TimeSpan.Zero);
+
+        var response = SimpleHealthResponseBuilder.Build(clock, start);
+
+        response.Uptime.ShouldBe(TimeSpan.FromHours(1.5));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/health` on the Blazor host, returning JSON with application status, current UTC time, and process uptime. Complements the existing `GET /api/health/detailed` endpoint.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/DetailedHealthController.cs` | `HttpGet` on route prefix for simple health |
| `src/UI/Api/DetailedHealthModels.cs` | `SimpleHealthResponse`, `SimpleHealthStatus` |
| `src/UI/Api/SimpleHealthResponseBuilder.cs` | Builds response from `TimeProvider` and process start |
| `src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs` | Integration tests for `/api/health` |
| `src/UnitTests/UI/Api/SimpleHealthResponseBuilderTests.cs` | Unit tests for builder logic |

## Testing

- `PrivateBuild.ps1` (Release): all unit and integration tests passed, including new cases.
- New unit tests cover status, `currentTimeUtc`, and uptime calculation with a fixed `TimeProvider`.

Closes #1369
