### PR TITLE
Add request logging middleware (#1371)

### DIFF
--- a/src/UI/Server/HttpRequestLoggingMiddleware.cs
+++ b/src/UI/Server/HttpRequestLoggingMiddleware.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Logs each HTTP request with method, path, status code, and elapsed duration.
+/// </summary>
+internal sealed class HttpRequestLoggingMiddleware(RequestDelegate next, ILogger<HttpRequestLoggingMiddleware> logger)
+{
+    private const string MessageTemplate =
+        "HTTP {Method} {Path} responded {StatusCode} in {DurationMs} ms";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            sw.Stop();
+            var path = context.Request.Path.HasValue ? context.Request.Path.Value! : string.Empty;
+            logger.LogInformation(
+                MessageTemplate,
+                context.Request.Method,
+                path,
+                context.Response.StatusCode,
+                sw.ElapsedMilliseconds);
+        }
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -76,6 +76,8 @@ else
 
 app.UseHttpsRedirection();
 
+app.UseMiddleware<HttpRequestLoggingMiddleware>();
+
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 

--- a/src/UnitTests/UI.Server/HttpRequestLoggingMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/HttpRequestLoggingMiddlewareTests.cs
@@ -1,0 +1,82 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class HttpRequestLoggingMiddlewareTests
+{
+    [Test]
+    public async Task Should_LogMethodPathStatusAndDuration_When_PipelineCompletes()
+    {
+        var sink = new LogSink();
+        var loggerFactory = LoggerFactory.Create(b => b.AddProvider(new SinkLoggerProvider(sink)));
+        var logger = loggerFactory.CreateLogger<HttpRequestLoggingMiddleware>();
+        var middleware = new HttpRequestLoggingMiddleware(
+            _ =>
+            {
+                _.Response.StatusCode = StatusCodes.Status418ImATeapot;
+                return Task.CompletedTask;
+            },
+            logger);
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "PATCH";
+        context.Request.Path = "/api/sample";
+
+        await middleware.InvokeAsync(context);
+
+        sink.Messages.Count.ShouldBe(1);
+        var line = sink.Messages[0];
+        line.ShouldContain("PATCH");
+        line.ShouldContain("/api/sample");
+        line.ShouldContain("418");
+        line.ShouldContain("ms");
+    }
+
+    private sealed class SinkLoggerProvider : ILoggerProvider
+    {
+        private readonly LogSink _sink;
+
+        public SinkLoggerProvider(LogSink sink) => _sink = sink;
+
+        public ILogger CreateLogger(string categoryName) => new SinkLogger(_sink);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class LogSink
+    {
+        public List<string> Messages { get; } = new();
+    }
+
+    private sealed class SinkLogger : ILogger
+    {
+        private readonly LogSink _sink;
+
+        public SinkLogger(LogSink sink) => _sink = sink;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (formatter is null)
+            {
+                return;
+            }
+
+            _sink.Messages.Add(formatter(state, exception));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds ASP.NET Core middleware on UI.Server that logs every HTTP request after the response completes, including **HTTP method**, **path**, **status code**, and **elapsed duration** (milliseconds). Logging uses structured parameters so Application Insights and other sinks can query on those fields.

## Files changed
| File | Description |
|------|-------------|
| `src/UI/Server/HttpRequestLoggingMiddleware.cs` | Middleware implementation |
| `src/UI/Server/Program.cs` | Registers middleware after HTTPS redirection |
| `src/UnitTests/UI.Server/HttpRequestLoggingMiddlewareTests.cs` | Unit test asserting log line contains method, path, status, and duration |

## Testing
- `DATABASE_ENGINE=SQLite` + `pwsh ./PrivateBuild.ps1` — unit tests (148) and integration tests (80) passed.
- `dotnet test src/UnitTests --filter FullyQualifiedName~HttpRequestLoggingMiddlewareTests`

Closes #1371
