### PR TITLE
Add API versioning support (#1392)

### DIFF
--- a/src/UI/Server/UI.Server.csproj
+++ b/src/UI/Server/UI.Server.csproj
@@ -15,6 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
 		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
 		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
 		<PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -69,4 +69,15 @@ public class ApiVersioningEndpointTests
         mediaType.ShouldNotBeNull();
         mediaType!.ShouldContain("text/plain");
     }
+
+    [Test]
+    public async Task Should_IncludeSupportedVersionsHeader_When_GetVersionedEndpoint()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/health");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues("api-supported-versions", out var values).ShouldBeTrue();
+        values.ShouldNotBeNull();
+        string.Join(", ", values!).ShouldContain("1.0");
+    }
 }


### PR DESCRIPTION
## Summary

Issue #1392 asks for API versioning using **Asp.Versioning.Http**. The host already configured URL-segment versioning (`/api/v{version:apiVersion}/...`) via `Asp.Versioning.Mvc` (which pulls in `Asp.Versioning.Http` transitively). This change adds an **explicit** `Asp.Versioning.Http` package reference on `UI.Server` so the dependency matches the stated requirement, and adds a unit test that asserts version reporting via the `api-supported-versions` response header on a versioned route.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Server/UI.Server.csproj` | Add direct `Asp.Versioning.Http` 8.1.0 package reference |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | New test: `api-supported-versions` contains `1.0` for `GET /api/v1.0/health` |

## Testing

- `dotnet test src/UnitTests --configuration Release --filter "FullyQualifiedName~ApiVersioningEndpointTests"`
- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` (unit + integration tests)

Closes #1392
