### PR TITLE
Add request rate limiting (#1393)

### DIFF
--- a/src/UI/Server/ApiRateLimitingExtensions.cs
+++ b/src/UI/Server/ApiRateLimitingExtensions.cs
@@ -42,6 +42,7 @@ public static class ApiRateLimitingExtensions
                         seconds.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
                 }
 
+                context.HttpContext.Response.ContentType = "text/plain; charset=utf-8";
                 await context.HttpContext.Response.WriteAsync(
                     "Too many requests. Please try again later.",
                     cancellationToken);

--- a/src/UnitTests/Api/ApiRateLimitingWebTests.cs
+++ b/src/UnitTests/Api/ApiRateLimitingWebTests.cs
@@ -17,6 +17,8 @@ public class ApiRateLimitingWebTests
         var limited = await client.GetAsync("/api/version");
         limited.StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
         limited.Headers.RetryAfter.ShouldNotBeNull();
+        limited.Content.Headers.ContentType?.MediaType.ShouldBe("text/plain");
+        (await limited.Content.ReadAsStringAsync()).ShouldBe("Too many requests. Please try again later.");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Completes issue requirements for API rate limiting on **UI.Server** using `Microsoft.AspNetCore.RateLimiting`: sliding-window limits from `ApiRateLimiting` in appsettings, partition keys by authenticated user name else client IP (with `anonymous` fallback), 429 with `Retry-After` and plain-text body.

This PR tightens the 429 response by setting **`Content-Type: text/plain; charset=utf-8`** so clients reliably treat the body as plain text, and extends unit web tests to assert media type and exact message.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Server/ApiRateLimitingExtensions.cs` | Set plain-text Content-Type before writing 429 body |
| `src/UnitTests/Api/ApiRateLimitingWebTests.cs` | Assert `text/plain` and expected body on 429 |

## Testing

- `dotnet test` filter `ApiRateLimitingWebTests` (Release)
- Full `PrivateBuild.ps1`: unit tests (156), integration tests (85), DB migrations — all green

Closes #1393
