### PR TITLE
Add API response compression (#1395)

### DIFF
--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -8,6 +8,7 @@ using ClearMeasure.Bootcamp.McpServer.Tools;
 using ClearMeasure.Bootcamp.McpServer.Resources;
 using ClearMeasure.Bootcamp.UI.Api.Controllers;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.ResponseCompression;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,6 +29,13 @@ builder.Host.UseLamar(registry => { registry.IncludeRegistry<UiServiceRegistry>(
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<IDistributedBus, DistributedBus>();
 builder.Services.AddApiRateLimiting(builder.Configuration);
+
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
+});
 
 // Add Application Insights
 builder.Services.AddApplicationInsightsTelemetry();
@@ -88,10 +96,17 @@ else
 
 app.UseHttpsRedirection();
 
+app.UseResponseCompression();
+
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+if (string.Equals(app.Environment.EnvironmentName, "Testing", StringComparison.OrdinalIgnoreCase))
+{
+    app.MapGet("/_test/compression-probe", () => Results.Text(new string('A', 4096), "text/plain; charset=utf-8"));
+}
 
 app.UseApiRateLimiting();
 

--- a/src/UnitTests/UI.Server/ApiResponseCompressionWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiResponseCompressionWebTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class ApiResponseCompressionWebTests
+{
+    private ApiVersioningRoutingWebApplicationFactory? _factory;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp() => _factory = new ApiVersioningRoutingWebApplicationFactory();
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _factory?.Dispose();
+
+    [Test]
+    public async Task Should_ReturnContentEncodingBrotli_When_ClientAcceptsBrotli()
+    {
+        using var client = _factory!.CreateDefaultClient(new DecompressionHandler());
+        client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("br"));
+
+        using var response = await client.GetAsync("/_test/compression-probe");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentEncoding.ShouldContain("br");
+    }
+
+    [Test]
+    public async Task Should_ReturnContentEncodingGzip_When_ClientAcceptsGzipOnly()
+    {
+        using var client = _factory!.CreateDefaultClient(new DecompressionHandler());
+        client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+        using var response = await client.GetAsync("/_test/compression-probe");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentEncoding.ShouldContain("gzip");
+    }
+
+    /// <summary>
+    /// Prevents <see cref="HttpClient"/> from stripping <c>Content-Encoding</c> so tests can assert compression headers.
+    /// </summary>
+    private sealed class DecompressionHandler : DelegatingHandler
+    {
+        public DecompressionHandler() : base(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None })
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Registers ASP.NET Core response compression on the UI.Server host (where API controllers are mapped) with **Brotli** and **GZip** providers and `EnableForHttps = true`. Compression runs early in the pipeline after HTTPS redirection so JSON and text API responses can be compressed when clients send `Accept-Encoding`.

A **Testing-environment-only** minimal endpoint `GET /_test/compression-probe` returns 4KB of plain text so automated tests can observe `Content-Encoding` headers (responses smaller than the framework default threshold are not compressed).

## Files changed

| File | Change |
|------|--------|
| `src/UI/Server/Program.cs` | `AddResponseCompression` with Brotli + GZip; `UseResponseCompression`; Testing-only compression probe route |
| `src/UnitTests/UI.Server/ApiResponseCompressionWebTests.cs` | Web tests with `AutomaticDecompression = None` asserting `br` vs `gzip` encoding |

## Testing

- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — unit tests (158) and integration tests (85) passed.
- New tests: `ApiResponseCompressionWebTests` verifies `Content-Encoding: br` and `gzip` for the probe route.

Closes #1395