### PR TITLE
Add correlation ID middleware (#1398)

### DIFF
--- a/src/ChurchBulletin.ServiceDefaults/CorrelationIdConstants.cs
+++ b/src/ChurchBulletin.ServiceDefaults/CorrelationIdConstants.cs
@@ -1,0 +1,17 @@
+namespace ClearMeasure.Bootcamp.ServiceDefaults;
+
+/// <summary>
+/// Names for correlation identifier propagation over HTTP.
+/// </summary>
+public static class CorrelationIdConstants
+{
+    /// <summary>
+    /// Request and response header carrying the correlation identifier.
+    /// </summary>
+    public const string HeaderName = "X-Correlation-ID";
+
+    /// <summary>
+    /// Key used in <see cref="Microsoft.AspNetCore.Http.HttpContext.Items"/> for the current correlation identifier.
+    /// </summary>
+    public const string HttpContextItemKey = "CorrelationId";
+}

--- a/src/ChurchBulletin.ServiceDefaults/CorrelationIdMiddleware.cs
+++ b/src/ChurchBulletin.ServiceDefaults/CorrelationIdMiddleware.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace ClearMeasure.Bootcamp.ServiceDefaults;
+
+/// <summary>
+/// Ensures each HTTP request has a correlation identifier for logging, tracing, and response headers.
+/// </summary>
+public sealed class CorrelationIdMiddleware
+{
+    private const int MaxIncomingLength = 128;
+    private readonly RequestDelegate _next;
+    private readonly ILogger<CorrelationIdMiddleware> _logger;
+
+    public CorrelationIdMiddleware(RequestDelegate next, ILogger<CorrelationIdMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var correlationId = ResolveCorrelationId(context);
+        context.Items[CorrelationIdConstants.HttpContextItemKey] = correlationId;
+        context.Response.Headers[CorrelationIdConstants.HeaderName] = correlationId;
+
+        Activity.Current?.SetTag("correlation.id", correlationId);
+
+        using (_logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId }))
+        {
+            await _next(context);
+        }
+    }
+
+    private static string ResolveCorrelationId(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(CorrelationIdConstants.HeaderName, out var fromHeader))
+        {
+            var id = fromHeader.ToString().Trim();
+            if (id.Length > 0 && id.Length <= MaxIncomingLength)
+            {
+                return id;
+            }
+        }
+
+        return Guid.NewGuid().ToString("D");
+    }
+}

--- a/src/ChurchBulletin.ServiceDefaults/CorrelationIdMiddlewareExtensions.cs
+++ b/src/ChurchBulletin.ServiceDefaults/CorrelationIdMiddlewareExtensions.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Registers correlation identifier middleware on the HTTP pipeline.
+/// </summary>
+public static class CorrelationIdMiddlewareExtensions
+{
+    /// <summary>
+    /// Adds middleware that assigns or forwards <c>X-Correlation-ID</c>, adds it to logging scopes and the current <see cref="System.Diagnostics.Activity"/> when present.
+    /// </summary>
+    public static IApplicationBuilder UseCorrelationId(this IApplicationBuilder app) =>
+        app.UseMiddleware<ClearMeasure.Bootcamp.ServiceDefaults.CorrelationIdMiddleware>();
+}

--- a/src/McpServer/McpServer.csproj
+++ b/src/McpServer/McpServer.csproj
@@ -20,6 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\ChurchBulletin.ServiceDefaults\ChurchBulletin.ServiceDefaults.csproj" />
 		<ProjectReference Include="..\Core\Core.csproj" />
 		<ProjectReference Include="..\DataAccess\DataAccess.csproj" />
 		<ProjectReference Include="..\LlmGateway\LlmGateway.csproj" />

--- a/src/McpServer/Program.cs
+++ b/src/McpServer/Program.cs
@@ -43,6 +43,7 @@ var app = builder.Build();
 
 if (useHttp)
 {
+    app.UseCorrelationId();
     app.MapMcp();
 }
 

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -75,6 +75,8 @@ var app = builder.Build();
 app.MapDefaultEndpoints();
 
 // Configure the HTTP request pipeline.
+app.UseCorrelationId();
+
 if (app.Environment.IsDevelopment())
 {
     app.UseWebAssemblyDebugging();

--- a/src/UnitTests/UI.Server/CorrelationIdMiddlewareWebTests.cs
+++ b/src/UnitTests/UI.Server/CorrelationIdMiddlewareWebTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using ClearMeasure.Bootcamp.ServiceDefaults;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class CorrelationIdMiddlewareWebTests
+{
+    [Test]
+    public async Task Should_ReturnGeneratedCorrelationIdInHeader_When_RequestHasNoCorrelationHeader()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1.0/health");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues(CorrelationIdConstants.HeaderName, out var values).ShouldBeTrue();
+        var id = values!.Single();
+        id.Length.ShouldBeGreaterThan(0);
+        Guid.TryParse(id, out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_EchoCorrelationIdInResponse_When_RequestProvidesValidHeader()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        var client = factory.CreateClient();
+        const string expected = "test-correlation-abc";
+        client.DefaultRequestHeaders.Add(CorrelationIdConstants.HeaderName, expected);
+
+        var response = await client.GetAsync("/api/v1.0/health");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.GetValues(CorrelationIdConstants.HeaderName).Single().ShouldBe(expected);
+    }
+
+    [Test]
+    public async Task Should_IgnoreOversizedCorrelationHeader_When_HeaderExceedsMaxLength()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(CorrelationIdConstants.HeaderName, new string('x', 129));
+
+        var response = await client.GetAsync("/api/v1.0/health");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var returned = response.Headers.GetValues(CorrelationIdConstants.HeaderName).Single();
+        returned.Length.ShouldBe(36);
+        Guid.TryParse(returned, out _).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds ASP.NET Core middleware so each inbound HTTP request gets a stable correlation identifier: read from `X-Correlation-ID` when valid (non-empty, max 128 characters), otherwise a new GUID. The value is stored in `HttpContext.Items`, echoed on the response as `X-Correlation-ID`, added to the current `Activity` as tag `correlation.id`, and included in logging scopes for downstream correlation with OpenTelemetry and Application Insights.

Registered early in the pipeline on **UI.Server** and on the standalone **McpServer** when HTTP transport is used.

## Files changed

| File | Change |
|------|--------|
| `src/ChurchBulletin.ServiceDefaults/CorrelationIdConstants.cs` | Header name and `HttpContext` item key |
| `src/ChurchBulletin.ServiceDefaults/CorrelationIdMiddleware.cs` | Middleware implementation |
| `src/ChurchBulletin.ServiceDefaults/CorrelationIdMiddlewareExtensions.cs` | `UseCorrelationId()` extension |
| `src/UI/Server/Program.cs` | Call `UseCorrelationId()` after `MapDefaultEndpoints` |
| `src/McpServer/McpServer.csproj` | Reference ServiceDefaults |
| `src/McpServer/Program.cs` | `UseCorrelationId()` before `MapMcp` in HTTP mode |
| `src/UnitTests/UI.Server/CorrelationIdMiddlewareWebTests.cs` | WebApplicationFactory tests |

## Testing

- `dotnet test src/UnitTests --configuration Release --filter FullyQualifiedName~CorrelationIdMiddlewareWebTests`
- `DATABASE_ENGINE=SQLite pwsh -NoProfile -File ./PrivateBuild.ps1` — build, unit tests (159), integration tests (83) passed

Closes #1398
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-163334b2-7df7-40c6-acae-f6063bca2217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-163334b2-7df7-40c6-acae-f6063bca2217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

