### PR TITLE
Add health check aggregator (#1399)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -119,7 +119,7 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
-    public async Task Should_ListExpectedComponentEntries_When_MockPayload()
+    public async Task Should_ListExpectedComponentEntries_When_AggregatedFromRegisteredChecks()
     {
         var response = await _client!.GetAsync("/api/health/detailed");
         response.StatusCode.ShouldBe(HttpStatusCode.OK);

--- a/src/UI/Api/Controllers/DetailedHealthController.cs
+++ b/src/UI/Api/Controllers/DetailedHealthController.cs
@@ -8,7 +8,9 @@ namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
 [ApiVersion("1.0")]
 [Route("api/health")]
 [Route($"{ApiRoutes.VersionedApiPrefix}/health")]
-public class DetailedHealthController(TimeProvider timeProvider) : ControllerBase
+public class DetailedHealthController(
+    TimeProvider timeProvider,
+    IDetailedHealthReportProvider detailedHealthReportProvider) : ControllerBase
 {
     [HttpGet]
     public ActionResult<SimpleHealthResponse> Get()
@@ -17,8 +19,9 @@ public class DetailedHealthController(TimeProvider timeProvider) : ControllerBas
     }
 
     [HttpGet("detailed")]
-    public ActionResult<DetailedHealthReport> GetDetailed()
+    public async Task<ActionResult<DetailedHealthReport>> GetDetailed(CancellationToken cancellationToken)
     {
-        return Ok(HealthReportBuilder.Build(timeProvider));
+        var report = await detailedHealthReportProvider.GetReportAsync(cancellationToken);
+        return Ok(report);
     }
 }

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -1,31 +1,21 @@
 namespace ClearMeasure.Bootcamp.UI.Api;
 
 /// <summary>
-/// Builds the detailed health report. Initial implementation uses static entries;
-/// later work can swap in real health-check probe results.
+/// Helpers for building and aggregating <see cref="DetailedHealthReport"/> component lines.
 /// </summary>
 public static class HealthReportBuilder
 {
     /// <summary>
-    /// Logical names align with registered checks in <c>UIServiceRegistry</c> where applicable.
+    /// Builds a report from explicit component lines (for tests and deterministic scenarios).
     /// </summary>
-    public static DetailedHealthReport Build(TimeProvider? timeProvider = null)
+    public static DetailedHealthReport FromEntries(
+        TimeProvider timeProvider,
+        IReadOnlyList<ComponentHealthEntry> components)
     {
-        var clock = timeProvider ?? TimeProvider.System;
-        var checkedAt = clock.GetUtcNow().UtcDateTime;
-
-        var components = new ComponentHealthEntry[]
-        {
-            new() { Name = "LlmGateway", Status = ComponentHealthStatus.Healthy },
-            new() { Name = "DataAccess", Status = ComponentHealthStatus.Healthy },
-            new() { Name = "Server", Status = ComponentHealthStatus.Healthy },
-            new() { Name = "API", Status = ComponentHealthStatus.Healthy },
-            new() { Name = "Jeffrey", Status = ComponentHealthStatus.Degraded }
-        };
-
+        var clock = timeProvider;
         return new DetailedHealthReport
         {
-            CheckedAtUtc = checkedAt,
+            CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             Components = components,
             OverallStatus = AggregateWorst(components)
         };

--- a/src/UI/Api/IDetailedHealthReportProvider.cs
+++ b/src/UI/Api/IDetailedHealthReportProvider.cs
@@ -1,0 +1,12 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Produces a <see cref="DetailedHealthReport"/> by aggregating registered health checks (excluding liveness-only probes).
+/// </summary>
+public interface IDetailedHealthReportProvider
+{
+    /// <summary>
+    /// Runs all non-live health checks and returns a JSON-oriented report.
+    /// </summary>
+    Task<DetailedHealthReport> GetReportAsync(CancellationToken cancellationToken = default);
+}

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -1,0 +1,77 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Aggregates <see cref="HealthCheckService"/> results into <see cref="DetailedHealthReport"/>.
+/// </summary>
+public sealed class DetailedHealthReportProvider(
+    HealthCheckService healthCheckService,
+    TimeProvider timeProvider) : IDetailedHealthReportProvider
+{
+    /// <inheritdoc />
+    public async Task<DetailedHealthReport> GetReportAsync(CancellationToken cancellationToken = default)
+    {
+        var report = await healthCheckService.CheckHealthAsync(
+            registration => !registration.Tags.Contains("live"),
+            cancellationToken);
+
+        return FromHealthReport(report, timeProvider);
+    }
+
+    internal static DetailedHealthReport FromHealthReport(HealthReport report, TimeProvider clock)
+    {
+        var components = report.Entries
+            .Select(pair => new ComponentHealthEntry
+            {
+                Name = pair.Key,
+                Status = MapComponentStatus(pair.Value.Status)
+            })
+            .OrderBy(c => c.Name, StringComparer.Ordinal)
+            .ToList();
+
+        return new DetailedHealthReport
+        {
+            CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
+            Components = components,
+            OverallStatus = MapOverallStatus(report.Status)
+        };
+    }
+
+    internal static DetailedHealthReport FromComponentStatuses(
+        IEnumerable<KeyValuePair<string, HealthStatus>> entries,
+        HealthStatus aggregateStatus,
+        TimeProvider clock)
+    {
+        var components = entries
+            .Select(pair => new ComponentHealthEntry
+            {
+                Name = pair.Key,
+                Status = MapComponentStatus(pair.Value)
+            })
+            .OrderBy(c => c.Name, StringComparer.Ordinal)
+            .ToList();
+
+        return new DetailedHealthReport
+        {
+            CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
+            Components = components,
+            OverallStatus = MapOverallStatus(aggregateStatus)
+        };
+    }
+
+    private static string MapOverallStatus(HealthStatus status) => status switch
+    {
+        HealthStatus.Unhealthy => ComponentHealthStatus.Unhealthy,
+        HealthStatus.Degraded => ComponentHealthStatus.Degraded,
+        _ => ComponentHealthStatus.Healthy
+    };
+
+    private static string MapComponentStatus(HealthStatus status) => status switch
+    {
+        HealthStatus.Unhealthy => ComponentHealthStatus.Unhealthy,
+        HealthStatus.Degraded => ComponentHealthStatus.Degraded,
+        _ => ComponentHealthStatus.Healthy
+    };
+}

--- a/src/UI/Server/UIServiceRegistry.cs
+++ b/src/UI/Server/UIServiceRegistry.cs
@@ -54,5 +54,7 @@ public class UiServiceRegistry : ServiceRegistry
             .AddCheck<Is64BitProcessHealthCheck>("Server")
             .AddCheck<HealthCheck>("API")
             .AddCheck<FunJeffreyCustomEventHealthCheck>("Jeffrey");
+
+        this.AddSingleton<IDetailedHealthReportProvider, DetailedHealthReportProvider>();
     }
 }

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -12,13 +12,17 @@ public class HealthReportBuilderTests
     }
 
     [Test]
-    public void HealthReportBuilder_Build_Should_ReturnNonNullPayload()
+    public void HealthReportBuilder_FromEntries_Should_ReturnNonNullPayload()
     {
-        var report = HealthReportBuilder.Build();
+        var components = new[]
+        {
+            new ComponentHealthEntry { Name = "A", Status = ComponentHealthStatus.Healthy }
+        };
+        var report = HealthReportBuilder.FromEntries(TimeProvider.System, components);
 
         report.ShouldNotBeNull();
         report.Components.ShouldNotBeNull();
-        report.Components.Count.ShouldBeGreaterThan(0);
+        report.Components.Count.ShouldBe(1);
     }
 
     [Test]
@@ -48,32 +52,27 @@ public class HealthReportBuilderTests
     }
 
     [Test]
-    public void HealthReportBuilder_Build_Should_SetCheckedAtUtc()
+    public void HealthReportBuilder_FromEntries_Should_SetCheckedAtUtc()
     {
         var fixedTime = new DateTime(2026, 3, 26, 12, 0, 0, DateTimeKind.Utc);
-        var report = HealthReportBuilder.Build(new FixedUtcTimeProvider(fixedTime));
+        var report = HealthReportBuilder.FromEntries(
+            new FixedUtcTimeProvider(fixedTime),
+            [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
 
         report.CheckedAtUtc.ShouldBe(fixedTime);
         report.CheckedAtUtc.Kind.ShouldBe(DateTimeKind.Utc);
     }
 
     [Test]
-    public void Should_Build_When_DefaultMockData_ExpectDegradedOverallBecauseJeffrey()
+    public void HealthReportBuilder_FromEntries_Should_AggregateWorstAcrossComponents()
     {
-        var report = HealthReportBuilder.Build();
+        var components = new[]
+        {
+            new ComponentHealthEntry { Name = "LlmGateway", Status = ComponentHealthStatus.Healthy },
+            new ComponentHealthEntry { Name = "Jeffrey", Status = ComponentHealthStatus.Degraded }
+        };
+        var report = HealthReportBuilder.FromEntries(TimeProvider.System, components);
 
         report.OverallStatus.ShouldBe(ComponentHealthStatus.Degraded);
-        var names = report.Components.Select(c => c.Name).ToHashSet();
-        names.ShouldContain("LlmGateway");
-        names.ShouldContain("DataAccess");
-        names.ShouldContain("Server");
-        names.ShouldContain("API");
-        names.ShouldContain("Jeffrey");
-        foreach (var c in report.Components)
-        {
-            (c.Status == ComponentHealthStatus.Healthy
-                || c.Status == ComponentHealthStatus.Degraded
-                || c.Status == ComponentHealthStatus.Unhealthy).ShouldBeTrue();
-        }
     }
 }

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -1,0 +1,55 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class DetailedHealthReportProviderTests
+{
+    private sealed class FixedUtcTimeProvider(DateTime utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new(utcNow, TimeSpan.Zero);
+    }
+
+    [Test]
+    public void FromComponentStatuses_Should_MapStatusesAndOverall()
+    {
+        var fixedTime = new DateTime(2026, 3, 30, 10, 0, 0, DateTimeKind.Utc);
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy,
+            ["DataAccess"] = HealthStatus.Unhealthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Unhealthy,
+            new FixedUtcTimeProvider(fixedTime));
+
+        detailed.CheckedAtUtc.ShouldBe(fixedTime);
+        detailed.OverallStatus.ShouldBe(ComponentHealthStatus.Unhealthy);
+        detailed.Components.Count.ShouldBe(2);
+        detailed.Components.ShouldContain(c => c.Name == "API" && c.Status == ComponentHealthStatus.Healthy);
+        detailed.Components.ShouldContain(c => c.Name == "DataAccess" && c.Status == ComponentHealthStatus.Unhealthy);
+    }
+
+    [Test]
+    public void FromComponentStatuses_Should_OrderComponentsByName()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["Zed"] = HealthStatus.Healthy,
+            ["Alpha"] = HealthStatus.Degraded
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Degraded,
+            TimeProvider.System);
+
+        detailed.Components[0].Name.ShouldBe("Alpha");
+        detailed.Components[1].Name.ShouldBe("Zed");
+    }
+}


### PR DESCRIPTION
## Summary

`GET /api/v1/health/detailed` (and unversioned `GET /api/health/detailed`) now returns a **real aggregate** of all registered ASP.NET Core health checks, excluding the Aspire **liveness** probe (`self` with tag `live`). Overall status follows the worst registered status (Unhealthy > Degraded > Healthy).

Previously the endpoint returned a **static mock** payload; it now reflects LlmGateway, DataAccess, Server, API, and Jeffrey checks as registered in `UiServiceRegistry`.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/IDetailedHealthReportProvider.cs` | New abstraction for building `DetailedHealthReport` from live checks |
| `src/UI/Server/DetailedHealthReportProvider.cs` | Implements aggregation via `HealthCheckService.CheckHealthAsync` + mapping to JSON DTOs |
| `src/UI/Server/UIServiceRegistry.cs` | Registers `IDetailedHealthReportProvider` |
| `src/UI/Api/Controllers/DetailedHealthController.cs` | Injects provider; `GetDetailed` is async |
| `src/UI/Api/HealthReportBuilder.cs` | Replaced mock `Build()` with `FromEntries()` for tests + kept `AggregateWorst` |
| `src/UnitTests/UI/Api/HealthReportBuilderTests.cs` | Updated for `FromEntries` |
| `src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs` | New unit tests for mapping/ordering |
| `src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs` | Renamed test method for clarity |

## Testing

- `dotnet test src/UnitTests --configuration Release`
- `PrivateBuild.ps1` (Release build, unit + integration with SQL Server container)

Closes #1399
