### PR TITLE
Add structured logging with Serilog (#1394)

### DIFF
--- a/src/ChurchBulletin.ServiceDefaults/ChurchBulletin.ServiceDefaults.csproj
+++ b/src/ChurchBulletin.ServiceDefaults/ChurchBulletin.ServiceDefaults.csproj
@@ -11,6 +11,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
+
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
@@ -21,6 +22,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ChurchBulletin.ServiceDefaults/Extensions.cs
+++ b/src/ChurchBulletin.ServiceDefaults/Extensions.cs
@@ -23,6 +23,8 @@ public static class Extensions
     /// </summary>
     public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
+        builder.AddSerilogWithJsonConsole();
+
         builder.ConfigureOpenTelemetry();
 
         builder.AddDefaultHealthChecks();

--- a/src/ChurchBulletin.ServiceDefaults/SerilogLoggingExtensions.cs
+++ b/src/ChurchBulletin.ServiceDefaults/SerilogLoggingExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Serilog;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Configures Serilog as the primary logging pipeline with newline-delimited JSON console output.
+/// </summary>
+public static class SerilogLoggingExtensions
+{
+    /// <summary>
+    /// Clears default logging providers and registers Serilog, reading configuration from the <c>Serilog</c> section when present.
+    /// </summary>
+    public static TBuilder AddSerilogWithJsonConsole<TBuilder>(this TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.ClearProviders();
+        builder.Services.AddSerilog((_, configuration) =>
+        {
+            configuration
+                .ReadFrom.Configuration(builder.Configuration)
+                .Enrich.FromLogContext()
+                .Enrich.WithProperty("Application", builder.Environment.ApplicationName);
+        });
+
+        return builder;
+    }
+}

--- a/src/McpServer/McpServer.csproj
+++ b/src/McpServer/McpServer.csproj
@@ -17,6 +17,8 @@
 		<PackageReference Include="MediatR" Version="12.4.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+		<PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/McpServer/Program.cs
+++ b/src/McpServer/Program.cs
@@ -3,13 +3,17 @@ using ClearMeasure.Bootcamp.McpServer.Tools;
 using ClearMeasure.Bootcamp.McpServer.Resources;
 using Lamar.Microsoft.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Logging.AddConsole(options =>
+builder.Logging.ClearProviders();
+builder.Host.UseSerilog((context, _, configuration) =>
 {
-    options.LogToStandardErrorThreshold = LogLevel.Trace;
+    configuration
+        .ReadFrom.Configuration(context.Configuration)
+        .Enrich.FromLogContext()
+        .Enrich.WithProperty("Application", context.HostingEnvironment.ApplicationName);
 });
 
 builder.Host.UseLamar(registry => { registry.IncludeRegistry<McpServiceRegistry>(); });

--- a/src/McpServer/appsettings.json
+++ b/src/McpServer/appsettings.json
@@ -1,4 +1,22 @@
 {
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Formatting.Compact" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ]
+  },
   "ConnectionStrings": {
     "SqlConnectionString": "server=(LocalDb)\\MSSQLLocalDB;database=ChurchBulletin;Integrated Security=true;MultipleActiveResultSets=true"
   }

--- a/src/UI/Server/appsettings.json
+++ b/src/UI/Server/appsettings.json
@@ -1,4 +1,22 @@
 {
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Formatting.Compact" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ]
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/UnitTests/ServiceDefaults/SerilogLoggingExtensionsTests.cs
+++ b/src/UnitTests/ServiceDefaults/SerilogLoggingExtensionsTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.ServiceDefaults;
+
+[TestFixture]
+public sealed class SerilogLoggingExtensionsTests
+{
+    [Test]
+    public void WhenAddSerilogWithJsonConsole_ThenLoggerFactoryIsSerilog()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.AddSerilogWithJsonConsole();
+
+        using var host = builder.Build();
+        var factory = host.Services.GetRequiredService<ILoggerFactory>();
+
+        factory.GetType().Name.ShouldBe("SerilogLoggerFactory");
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -56,6 +56,7 @@
 		<ProjectReference Include="..\UI\Api\UI.Api.csproj" />
 		<ProjectReference Include="..\UI\Server\UI.Server.csproj" />
 		<ProjectReference Include="..\UI.Shared\UI.Shared.csproj" />
+		<ProjectReference Include="..\ChurchBulletin.ServiceDefaults\ChurchBulletin.ServiceDefaults.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Worker/appsettings.json
+++ b/src/Worker/appsettings.json
@@ -1,4 +1,22 @@
 {
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Formatting.Compact" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ]
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary

Replaces the default Microsoft.Extensions.Logging console pipeline with **Serilog** for hosts that use shared service defaults (**UI.Server**, **Worker**) and for the standalone **McpServer** executable. Log output to the console uses **newline-delimited JSON** via `Serilog.Formatting.Compact.CompactJsonFormatter`, which suits container and log aggregation workflows. OpenTelemetry logging integration in `ChurchBulletin.ServiceDefaults` is unchanged and continues to run alongside Serilog.

## Files changed

| Area | Change |
|------|--------|
| `ChurchBulletin.ServiceDefaults/SerilogLoggingExtensions.cs` | New: `AddSerilogWithJsonConsole` clears default providers and calls `AddSerilog` with config from the `Serilog` section. |
| `ChurchBulletin.ServiceDefaults/Extensions.cs` | Calls `AddSerilogWithJsonConsole` at the start of `AddServiceDefaults`. |
| `ChurchBulletin.ServiceDefaults.csproj` | Package references: `Serilog.AspNetCore` 10.0.0, `Serilog.Formatting.Compact` 3.0.0. |
| `UI/Server/appsettings.json` | `Serilog` section: minimum levels, console sink with compact JSON formatter. |
| `Worker/appsettings.json` | Same Serilog JSON console configuration (formatted as other Worker JSON). |
| `McpServer/Program.cs` | Serilog registration (no longer `AddConsole` to stderr). |
| `McpServer/appsettings.json` | `Serilog` section added. |
| `McpServer.csproj` | Same Serilog packages as above. |
| `UnitTests/ServiceDefaults/SerilogLoggingExtensionsTests.cs` | Asserts resolved `ILoggerFactory` is `SerilogLoggerFactory` after `AddSerilogWithJsonConsole`. |
| `UnitTests.csproj` | Project reference to `ChurchBulletin.ServiceDefaults`. |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — build, unit tests (157), integration tests (83) all passed.
- Filtered unit test: `SerilogLoggingExtensionsTests`.

Closes #1394