### PR TITLE
test: stabilize save-draft navigation in acceptance tests (#1411)

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -329,6 +329,7 @@ public abstract class AcceptanceTestBase
 
         var saveButtonTestId = nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name;
         await Click(saveButtonTestId);
+        await Page.WaitForURLAsync("**/workorder/search", new PageWaitForURLOptions { Timeout = 90_000 });
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         WorkOrder? rehyratedOrder = null;


### PR DESCRIPTION
## Summary

Master build failed on the **Acceptance Tests** job after merging CORS: `WorkOrderSaveDraftTests.ShouldAssignEmployeeAndSave` timed out waiting for navigation to `**/workorder/search` after saving a draft. The save path in `CreateAndSaveNewWorkOrder` only waited for `NetworkIdle`, which can complete before Blazor finishes client-side navigation on a loaded host.

This change explicitly waits for the search URL (90s timeout) after clicking Save, matching other tests in the same class.

## Files

- `src/AcceptanceTests/AcceptanceTestBase.cs` — `WaitForURLAsync("**/workorder/search", …)` after save draft click

## Testing

- `dotnet build src/AcceptanceTests/AcceptanceTests.csproj --configuration Release`

Related: #1411
