### PR TITLE
fix: 400 for corrupt compressed bodies + expand decompression tests (#1404)

### DIFF
--- a/src/UI/Server/Middleware/InvalidCompressedRequestBodyMiddleware.cs
+++ b/src/UI/Server/Middleware/InvalidCompressedRequestBodyMiddleware.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using Microsoft.AspNetCore.Http;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Middleware;
+
+/// <summary>
+/// Maps corrupt gzip/deflate request bodies (after <c>UseRequestDecompression</c>) to HTTP 400 instead of an unhandled 500.
+/// </summary>
+public sealed class InvalidCompressedRequestBodyMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception ex) when (IsCorruptCompression(ex))
+        {
+            if (context.Response.HasStarted)
+            {
+                throw;
+            }
+
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            context.Response.ContentType = "text/plain; charset=utf-8";
+            await context.Response.WriteAsync("The request body could not be decompressed.");
+        }
+    }
+
+    private static bool IsCorruptCompression(Exception ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e is InvalidDataException)
+            {
+                return true;
+            }
+
+            if (e is IOException && e.Message.Contains("gzip", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -143,6 +143,7 @@ else
 app.UseHttpsRedirection();
 
 app.UseRequestDecompression();
+app.UseMiddleware<InvalidCompressedRequestBodyMiddleware>();
 app.UseResponseCompression();
 
 app.UseBlazorFrameworkFiles();

--- a/src/UnitTests/UI.Server/RequestDecompressionWebTests.cs
+++ b/src/UnitTests/UI.Server/RequestDecompressionWebTests.cs
@@ -26,6 +26,47 @@ public class RequestDecompressionWebTests
     }
 
     [Test]
+    public async Task Should_ReturnOriginalBody_When_PostWithoutContentEncoding()
+    {
+        const string payload = "uncompressed-body";
+
+        var response = await _client!.PostAsync(
+            "/__test/request-body-echo",
+            new StringContent(payload, Encoding.UTF8, "text/plain"));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldBe(payload);
+    }
+
+    [Test]
+    public async Task Should_ReturnBadRequest_When_GzipContentEncoding_ButBodyIsNotValidGzip()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/__test/request-body-echo")
+        {
+            Content = new ByteArrayContent([0x01, 0x02, 0x03, 0xff])
+        };
+        request.Content.Headers.ContentEncoding.Add("gzip");
+
+        var response = await _client!.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_ReturnBadRequest_When_DeflateContentEncoding_ButBodyIsNotValidZlib()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/__test/request-body-echo")
+        {
+            Content = new ByteArrayContent([0x01, 0x02, 0x03, 0xff])
+        };
+        request.Content.Headers.ContentEncoding.Add("deflate");
+
+        var response = await _client!.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
     public async Task Should_ReturnDecompressedBody_When_PostGzipEncodedRequest()
     {
         const string payload = "{\"hello\":\"world\"}";


### PR DESCRIPTION
## Context

- **CI failure on `838a0645` (Windows LocalDB):** integration tests failed with **Azure OpenAI HTTP 429**, not request decompression. Already addressed on `master` via `LlmTestBase.ExecuteLlmAsync` / retries.
- **Copilot review on #1419:** asked for uncompressed passthrough and invalid compressed payload behavior.

## Changes

- `InvalidCompressedRequestBodyMiddleware` immediately after `UseRequestDecompression`: catches `InvalidDataException` (and gzip-related `IOException`) from body reads and returns **400** with a short plain-text body (avoids 500 for corrupt gzip/deflate).
- `RequestDecompressionWebTests`: uncompressed POST, invalid gzip, invalid deflate.

Related: #1404