### PR TITLE
Add request timeout middleware (#1436)

### DIFF
--- a/src/UI/Server/ApiRequestTimeoutOptions.cs
+++ b/src/UI/Server/ApiRequestTimeoutOptions.cs
@@ -1,0 +1,15 @@
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Configuration for request timeouts on HTTP API routes (see <see cref="ApiRequestTimeoutsExtensions"/>).
+/// </summary>
+public sealed class ApiRequestTimeoutOptions
+{
+    public const string SectionName = "ApiRequestTimeouts";
+
+    /// <summary>When false, API routes do not receive a request timeout policy.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Timeout duration for API requests when <see cref="Enabled"/> is true. Must be positive.</summary>
+    public int TimeoutSeconds { get; set; } = 120;
+}

--- a/src/UI/Server/ApiRequestTimeoutsExtensions.cs
+++ b/src/UI/Server/ApiRequestTimeoutsExtensions.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Timeouts;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Registers ASP.NET Core request timeout policies for API routes matched by <see cref="ApiRateLimitingExtensions.ShouldApplyToPath"/>.
+/// </summary>
+public static class ApiRequestTimeoutsExtensions
+{
+    /// <summary>Named policy applied to MVC API controllers when timeouts are enabled.</summary>
+    public const string ApiControllersPolicyName = "ApiControllers";
+
+    /// <summary>
+    /// Adds request timeout services and an API policy when <see cref="ApiRequestTimeoutOptions"/> is enabled with a positive timeout.
+    /// </summary>
+    public static IServiceCollection AddApiRequestTimeouts(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<ApiRequestTimeoutOptions>(configuration.GetSection(ApiRequestTimeoutOptions.SectionName));
+        services.AddRequestTimeouts();
+        services.AddSingleton<IConfigureOptions<RequestTimeoutOptions>, ConfigureApiRequestTimeoutPolicyOptions>();
+        return services;
+    }
+
+    private sealed class ConfigureApiRequestTimeoutPolicyOptions : IConfigureOptions<RequestTimeoutOptions>
+    {
+        private readonly IOptions<ApiRequestTimeoutOptions> _apiOptions;
+
+        public ConfigureApiRequestTimeoutPolicyOptions(IOptions<ApiRequestTimeoutOptions> apiOptions)
+        {
+            _apiOptions = apiOptions;
+        }
+
+        public void Configure(RequestTimeoutOptions options)
+        {
+            var api = _apiOptions.Value;
+            if (!api.Enabled || api.TimeoutSeconds <= 0)
+            {
+                return;
+            }
+
+            var timeout = TimeSpan.FromSeconds(api.TimeoutSeconds);
+            options.AddPolicy(
+                ApiControllersPolicyName,
+                new RequestTimeoutPolicy
+                {
+                    Timeout = timeout,
+                    TimeoutStatusCode = StatusCodes.Status504GatewayTimeout
+                });
+        }
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -16,7 +16,9 @@ using ClearMeasure.Bootcamp.UI.Server.Grpc;
 using ClearMeasure.Bootcamp.UI.Server.Middleware;
 using ClearMeasure.Bootcamp.UI.Server.Notifications;
 using ClearMeasure.Bootcamp.UI.Server.RateLimiting;
+using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -43,6 +45,7 @@ builder.Host.UseLamar(registry => { registry.IncludeRegistry<UiServiceRegistry>(
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<IDistributedBus, DistributedBus>();
 builder.Services.AddApiRateLimiting(builder.Configuration);
+builder.Services.AddApiRequestTimeouts(builder.Configuration);
 builder.Services.Configure<ApiKeyAuthenticationOptions>(
     builder.Configuration.GetSection(ApiKeyAuthenticationOptions.SectionName));
 builder.Services.PostConfigure<ApiKeyAuthenticationOptions>(o =>
@@ -151,6 +154,10 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseWhen(
+    context => ApiRateLimitingExtensions.ShouldApplyToPath(context.Request.Path),
+    branch => branch.UseRequestTimeouts());
+
 app.UseMiddleware<ApiKeyAuthenticationMiddleware>();
 app.UseMachineClientStatusCodeProblemDetails();
 
@@ -187,6 +194,14 @@ if (string.Equals(app.Environment.EnvironmentName, "Testing", StringComparison.O
         using var reader = new StreamReader(httpContext.Request.Body);
         await httpContext.Response.WriteAsync(await reader.ReadToEndAsync());
     });
+    app.MapGet(
+            "/api/_test/request-timeout-probe",
+            async (HttpContext httpContext) =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(30), httpContext.RequestAborted);
+                return Results.Ok();
+            })
+        .WithRequestTimeout(TimeSpan.FromMilliseconds(500));
 }
 
 app.UseRequestBodyBuffering();
@@ -198,6 +213,12 @@ app.UseOutputCache();
 
 app.MapRazorPages();
 var apiControllers = app.MapControllers();
+var apiRequestTimeoutOpts = app.Services.GetRequiredService<IOptions<ApiRequestTimeoutOptions>>().Value;
+if (apiRequestTimeoutOpts.Enabled && apiRequestTimeoutOpts.TimeoutSeconds > 0)
+{
+    apiControllers.WithRequestTimeout(ApiRequestTimeoutsExtensions.ApiControllersPolicyName);
+}
+
 if (app.Services.IsServerCorsActive())
 {
     apiControllers.RequireCors(ServerCorsOptions.PolicyName);

--- a/src/UI/Server/appsettings.json
+++ b/src/UI/Server/appsettings.json
@@ -44,5 +44,9 @@
   "RequestBodyBuffering": {
     "Enabled": true,
     "BufferThreshold": 1048576
+  },
+  "ApiRequestTimeouts": {
+    "Enabled": true,
+    "TimeoutSeconds": 120
   }
 }

--- a/src/UnitTests/UI.Server/RequestTimeoutApiWebTests.cs
+++ b/src/UnitTests/UI.Server/RequestTimeoutApiWebTests.cs
@@ -1,0 +1,20 @@
+using System.Net;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class RequestTimeoutApiWebTests
+{
+    [Test]
+    public async Task Should_Return504_When_ApiRequestExceedsConfiguredTimeout()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        factory.ClientOptions.AllowAutoRedirect = false;
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/_test/request-timeout-probe");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.GatewayTimeout);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements configurable request timeouts for HTTP API routes using ASP.NET Core built-in request timeout middleware (`Microsoft.AspNetCore.Http.Timeouts`). Timeouts apply to paths matched by the same logic as API rate limiting (`/api/*`, Blazor single-API paths). MVC controllers receive a named policy from configuration; on timeout the response status is **504 Gateway Timeout** when the pipeline does not otherwise handle cancellation.

Configuration section **`ApiRequestTimeouts`** in `appsettings.json`:

- `Enabled` (default `true`)
- `TimeoutSeconds` (default `120`)

## Files changed

| File | Change |
|------|--------|
| `src/UI/Server/ApiRequestTimeoutOptions.cs` | Options type and section name |
| `src/UI/Server/ApiRequestTimeoutsExtensions.cs` | Registers `AddRequestTimeouts` and named policy `ApiControllers` |
| `src/UI/Server/Program.cs` | `UseWhen` + `UseRequestTimeouts` for API paths; `MapControllers().WithRequestTimeout(...)`; Testing-only `GET /api/_test/request-timeout-probe` (500 ms timeout) |
| `src/UI/Server/appsettings.json` | Default `ApiRequestTimeouts` values |
| `src/UnitTests/UI.Server/RequestTimeoutApiWebTests.cs` | Asserts 504 from probe (no debugger; middleware active in Testing) |

## Testing

- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — green (217 unit, 94 integration tests)
- Filtered: `dotnet test src/UnitTests --configuration Release --filter "FullyQualifiedName~RequestTimeoutApiWebTests"`

**Note:** Per Microsoft docs, request timeouts do not trigger when a debugger is attached.

Closes #1436
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-580a09b1-6ce9-4d52-bf06-1cfd49936aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-580a09b1-6ce9-4d52-bf06-1cfd49936aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

