### PR TITLE
Add work order instructions as a new field (#1555)

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -311,6 +311,7 @@ public abstract class AcceptanceTestBase
         order.Number = null;
         var testTitle = order.Title;
         var testDescription = order.Description;
+        var testInstructions = order.Instructions;
         var testRoomNumber = order.RoomNumber;
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -324,6 +325,11 @@ public abstract class AcceptanceTestBase
         order.Number = newWorkOrderNumber;
         await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
         await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        if (!string.IsNullOrEmpty(testInstructions))
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
+        }
+
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
         await TakeScreenshotAsync(2, "FormFilled");
 
@@ -364,6 +370,11 @@ public abstract class AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), username);
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        if (!string.IsNullOrEmpty(order.Instructions))
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        }
+
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -381,6 +392,11 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        if (!string.IsNullOrEmpty(order.Instructions))
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        }
+
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToInProgressCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
@@ -397,6 +413,11 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        if (!string.IsNullOrEmpty(order.Instructions))
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        }
+
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToCompleteCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         await Task.Delay(GetInputDelayMs()); // Give time for the save operation to complete on Azure

--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -325,10 +325,7 @@ public abstract class AcceptanceTestBase
         order.Number = newWorkOrderNumber;
         await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
         await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
-        if (!string.IsNullOrEmpty(testInstructions))
-        {
-            await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
-        }
+        await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
 
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
         await TakeScreenshotAsync(2, "FormFilled");
@@ -370,10 +367,7 @@ public abstract class AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), username);
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
-        if (!string.IsNullOrEmpty(order.Instructions))
-        {
-            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
-        }
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
 
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
 
@@ -392,10 +386,7 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
-        if (!string.IsNullOrEmpty(order.Instructions))
-        {
-            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
-        }
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
 
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToInProgressCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -413,10 +404,7 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
-        if (!string.IsNullOrEmpty(order.Instructions))
-        {
-            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
-        }
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
 
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToCompleteCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);

--- a/src/AcceptanceTests/WorkOrders/WorkOrderAssignTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderAssignTests.cs
@@ -25,6 +25,7 @@ public class WorkOrderAssignTests : AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), CurrentUser.UserName);
         await Input(nameof(WorkOrderManage.Elements.Title), "newtitle");
         await Input(nameof(WorkOrderManage.Elements.Description), "newdesc");
+        await Input(nameof(WorkOrderManage.Elements.Instructions), "newinstr");
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -39,7 +40,10 @@ public class WorkOrderAssignTests : AcceptanceTestBase
         
         var descriptionField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Description));
         await Expect(descriptionField).ToHaveValueAsync("newdesc");
-        
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync("newinstr");
+
         var assigneeField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Assignee));
         await Expect(assigneeField).ToBeDisabledAsync();
         await Expect(assigneeField).ToHaveValueAsync(CurrentUser.UserName);

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -49,6 +49,9 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         var descriptionField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Description));
         await Expect(descriptionField).ToHaveValueAsync(order.Description!);
 
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions ?? "");
+
         var roomNumberField = Page.GetByTestId(nameof(WorkOrderManage.Elements.RoomNumber));
         await Expect(roomNumberField).ToHaveValueAsync(order.RoomNumber!);
 

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions;
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedNullableString(value);
     }
 
     public string? RoomNumber { get; set; } = null;
@@ -30,6 +37,17 @@ public class WorkOrder : EntityBase<WorkOrder>
     public DateTime? CreatedDate { get; set; }
 
     public DateTime? CompletedDate { get; set; }
+
+    private string? getTruncatedNullableString(string? value)
+    {
+        if (value == null || value.Length == 0)
+        {
+            return null;
+        }
+
+        var maxLength = Math.Min(4000, value.Length);
+        return value.Substring(0, maxLength);
+    }
 
     private string? getTruncatedString(string? value)
     {

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -2,6 +2,8 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 
 public class WorkOrder : EntityBase<WorkOrder>
 {
+    private const int MaxLongTextLength = 4000;
+
     private string? _description = "";
     private string? _instructions;
 
@@ -40,23 +42,23 @@ public class WorkOrder : EntityBase<WorkOrder>
 
     private string? getTruncatedNullableString(string? value)
     {
-        if (value == null || value.Length == 0)
+        if (value == null)
         {
             return null;
         }
 
-        var maxLength = Math.Min(4000, value.Length);
-        return value.Substring(0, maxLength);
+        var truncated = getTruncatedString(value);
+        return truncated.Length == 0 ? null : truncated;
     }
 
-    private string? getTruncatedString(string? value)
+    private string getTruncatedString(string? value)
     {
         if (value == null)
         {
             return string.Empty;
         }
 
-        var maxLength = Math.Min(4000, value.Length);
+        var maxLength = Math.Min(MaxLongTextLength, value.Length);
         return value.Substring(0, maxLength);
     }
 

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(300);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
@@ -1,2 +1,11 @@
-ALTER TABLE dbo.WorkOrder
-ADD Instructions NVARCHAR(4000) NULL;
+BEGIN TRANSACTION
+GO
+PRINT N'Adding [Instructions] to [dbo].[WorkOrder]'
+GO
+ALTER TABLE [dbo].[WorkOrder] ADD [Instructions] NVARCHAR(4000) NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dbo.WorkOrder
+ADD Instructions NVARCHAR(4000) NULL;

--- a/src/IntegrationTests/Api/GrpcWorkOrderIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GrpcWorkOrderIntegrationTests.cs
@@ -71,6 +71,7 @@ public class GrpcWorkOrderIntegrationTests
                 Number = "GRPC-001",
                 Title = "Test title",
                 Description = "Test description",
+                Instructions = "Wear PPE.",
                 RoomNumber = "101",
                 Status = WorkOrderStatus.Draft,
                 Creator = creator,
@@ -87,6 +88,7 @@ public class GrpcWorkOrderIntegrationTests
         reply.WorkOrder.Number.ShouldBe("GRPC-001");
         reply.WorkOrder.Title.ShouldBe("Test title");
         reply.WorkOrder.Description.ShouldBe("Test description");
+        reply.WorkOrder.Instructions.ShouldBe("Wear PPE.");
         reply.WorkOrder.RoomNumber.ShouldBe("101");
         reply.WorkOrder.StatusKey.ShouldBe(WorkOrderStatus.Draft.Key);
         reply.WorkOrder.CreatorUsername.ShouldBe("grpc-creator");

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -19,6 +19,7 @@ public class WorkOrderMappingTests
             Number = "WO-01",
             Title = "Fix lighting",
             Description = "Replace broken light bulbs in conference room",
+            Instructions = "Turn off breaker before replacing bulbs.",
             RoomNumber = "CR-101",
             Status = WorkOrderStatus.Draft,
             Creator = creator
@@ -43,6 +44,7 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Number.ShouldBe("WO-01");
         rehydratedWorkOrder.Title.ShouldBe("Fix lighting");
         rehydratedWorkOrder.Description.ShouldBe("Replace broken light bulbs in conference room");
+        rehydratedWorkOrder.Instructions.ShouldBe("Turn off breaker before replacing bulbs.");
         rehydratedWorkOrder.RoomNumber.ShouldBe("CR-101");
         rehydratedWorkOrder.Status.ShouldBe(WorkOrderStatus.Draft);
         rehydratedWorkOrder.Creator.ShouldNotBeNull();

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -195,6 +195,7 @@ public class WorkOrderTools
         wo.Number,
         wo.Title,
         wo.Description,
+        wo.Instructions,
         Status = wo.Status.FriendlyName,
         wo.RoomNumber,
         Creator = wo.Creator?.GetFullName(),

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    [StringLength(4000)] public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -58,6 +58,14 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly" aria-describedby="InstructionsHelp"/>
+                        <span id="InstructionsHelp" class="visually-hidden">Execution guidance for the assignee.</span>
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -146,6 +154,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -92,6 +92,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate?.ToString("G", CultureInfo.CurrentCulture),
             AssignedDate = workOrder.AssignedDate?.ToString("G", CultureInfo.CurrentCulture),
@@ -131,6 +132,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UI/Server/Generated/Protos/Workorders.cs
+++ b/src/UI/Server/Generated/Protos/Workorders.cs
@@ -29,21 +29,21 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             "aW5nUmVwbHkSDwoHbWVzc2FnZRgBIAEoCSItChtHZXRXb3JrT3JkZXJCeU51",
             "bWJlclJlcXVlc3QSDgoGbnVtYmVyGAEgASgJIkYKGUdldFdvcmtPcmRlckJ5",
             "TnVtYmVyUmVwbHkSKQoKd29ya19vcmRlchgBIAEoCzIVLndvcmtvcmRlcnMu",
-            "V29ya09yZGVyIpMDCglXb3JrT3JkZXISDgoGbnVtYmVyGAEgASgJEg0KBXRp",
+            "V29ya09yZGVyIqkDCglXb3JrT3JkZXISDgoGbnVtYmVyGAEgASgJEg0KBXRp",
             "dGxlGAIgASgJEhMKC2Rlc2NyaXB0aW9uGAMgASgJEhMKC3Jvb21fbnVtYmVy",
             "GAQgASgJEhIKCnN0YXR1c19rZXkYBSABKAkSGAoQY3JlYXRvcl91c2VybmFt",
             "ZRgGIAEoCRIZChFhc3NpZ25lZV91c2VybmFtZRgHIAEoCRI6ChFhc3NpZ25l",
             "ZF9kYXRlX3V0YxgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBI",
             "AIgBARI5ChBjcmVhdGVkX2RhdGVfdXRjGAkgASgLMhouZ29vZ2xlLnByb3Rv",
             "YnVmLlRpbWVzdGFtcEgBiAEBEjsKEmNvbXBsZXRlZF9kYXRlX3V0YxgKIAEo",
-            "CzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIAogBAUIUChJfYXNzaWdu",
-            "ZWRfZGF0ZV91dGNCEwoRX2NyZWF0ZWRfZGF0ZV91dGNCFQoTX2NvbXBsZXRl",
-            "ZF9kYXRlX3V0YzKsAQoKV29ya09yZGVycxI2CgRQaW5nEhcud29ya29yZGVy",
-            "cy5QaW5nUmVxdWVzdBoVLndvcmtvcmRlcnMuUGluZ1JlcGx5EmYKFEdldFdv",
-            "cmtPcmRlckJ5TnVtYmVyEicud29ya29yZGVycy5HZXRXb3JrT3JkZXJCeU51",
-            "bWJlclJlcXVlc3QaJS53b3Jrb3JkZXJzLkdldFdvcmtPcmRlckJ5TnVtYmVy",
-            "UmVwbHlCJ6oCJENsZWFyTWVhc3VyZS5Cb290Y2FtcC5VSS5TZXJ2ZXIuR3Jw",
-            "Y2IGcHJvdG8z"));
+            "CzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIAogBARIUCgxpbnN0cnVj",
+            "dGlvbnMYCyABKAlCFAoSX2Fzc2lnbmVkX2RhdGVfdXRjQhMKEV9jcmVhdGVk",
+            "X2RhdGVfdXRjQhUKE19jb21wbGV0ZWRfZGF0ZV91dGMyrAEKCldvcmtPcmRl",
+            "cnMSNgoEUGluZxIXLndvcmtvcmRlcnMuUGluZ1JlcXVlc3QaFS53b3Jrb3Jk",
+            "ZXJzLlBpbmdSZXBseRJmChRHZXRXb3JrT3JkZXJCeU51bWJlchInLndvcmtv",
+            "cmRlcnMuR2V0V29ya09yZGVyQnlOdW1iZXJSZXF1ZXN0GiUud29ya29yZGVy",
+            "cy5HZXRXb3JrT3JkZXJCeU51bWJlclJlcGx5QieqAiRDbGVhck1lYXN1cmUu",
+            "Qm9vdGNhbXAuVUkuU2VydmVyLkdycGNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -51,7 +51,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.PingReply), global::ClearMeasure.Bootcamp.UI.Server.Grpc.PingReply.Parser, new[]{ "Message" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberRequest), global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberRequest.Parser, new[]{ "Number" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberReply), global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberReply.Parser, new[]{ "WorkOrder" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder), global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder.Parser, new[]{ "Number", "Title", "Description", "RoomNumber", "StatusKey", "CreatorUsername", "AssigneeUsername", "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, new[]{ "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder), global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder.Parser, new[]{ "Number", "Title", "Description", "RoomNumber", "StatusKey", "CreatorUsername", "AssigneeUsername", "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc", "Instructions" }, new[]{ "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, null, null, null)
           }));
     }
     #endregion
@@ -867,6 +867,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       assignedDateUtc_ = other.assignedDateUtc_ != null ? other.assignedDateUtc_.Clone() : null;
       createdDateUtc_ = other.createdDateUtc_ != null ? other.createdDateUtc_.Clone() : null;
       completedDateUtc_ = other.completedDateUtc_ != null ? other.completedDateUtc_.Clone() : null;
+      instructions_ = other.instructions_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -996,6 +997,18 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       }
     }
 
+    /// <summary>Field number for the "instructions" field.</summary>
+    public const int InstructionsFieldNumber = 11;
+    private string instructions_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Instructions {
+      get { return instructions_; }
+      set {
+        instructions_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -1021,6 +1034,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       if (!object.Equals(AssignedDateUtc, other.AssignedDateUtc)) return false;
       if (!object.Equals(CreatedDateUtc, other.CreatedDateUtc)) return false;
       if (!object.Equals(CompletedDateUtc, other.CompletedDateUtc)) return false;
+      if (Instructions != other.Instructions) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -1038,6 +1052,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       if (assignedDateUtc_ != null) hash ^= AssignedDateUtc.GetHashCode();
       if (createdDateUtc_ != null) hash ^= CreatedDateUtc.GetHashCode();
       if (completedDateUtc_ != null) hash ^= CompletedDateUtc.GetHashCode();
+      if (Instructions.Length != 0) hash ^= Instructions.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -1096,6 +1111,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
         output.WriteRawTag(82);
         output.WriteMessage(CompletedDateUtc);
       }
+      if (Instructions.Length != 0) {
+        output.WriteRawTag(90);
+        output.WriteString(Instructions);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1146,6 +1165,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
         output.WriteRawTag(82);
         output.WriteMessage(CompletedDateUtc);
       }
+      if (Instructions.Length != 0) {
+        output.WriteRawTag(90);
+        output.WriteString(Instructions);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1185,6 +1208,9 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       }
       if (completedDateUtc_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(CompletedDateUtc);
+      }
+      if (Instructions.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Instructions);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -1236,6 +1262,9 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
           CompletedDateUtc = new global::Google.Protobuf.WellKnownTypes.Timestamp();
         }
         CompletedDateUtc.MergeFrom(other.CompletedDateUtc);
+      }
+      if (other.Instructions.Length != 0) {
+        Instructions = other.Instructions;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -1305,6 +1334,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             input.ReadMessage(CompletedDateUtc);
             break;
           }
+          case 90: {
+            Instructions = input.ReadString();
+            break;
+          }
         }
       }
     #endif
@@ -1371,6 +1404,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
               CompletedDateUtc = new global::Google.Protobuf.WellKnownTypes.Timestamp();
             }
             input.ReadMessage(CompletedDateUtc);
+            break;
+          }
+          case 90: {
+            Instructions = input.ReadString();
             break;
           }
         }

--- a/src/UI/Server/Grpc/WorkOrdersGrpcService.cs
+++ b/src/UI/Server/Grpc/WorkOrdersGrpcService.cs
@@ -42,6 +42,7 @@ public class WorkOrdersGrpcService(IBus bus) : WorkOrders.WorkOrdersBase
             Number = source.Number ?? "",
             Title = source.Title ?? "",
             Description = source.Description ?? "",
+            Instructions = source.Instructions ?? "",
             RoomNumber = source.RoomNumber ?? "",
             StatusKey = source.Status.Key,
             CreatorUsername = source.Creator?.UserName ?? "",

--- a/src/UI/Server/Protos/workorders.proto
+++ b/src/UI/Server/Protos/workorders.proto
@@ -36,4 +36,5 @@ message WorkOrder {
   optional google.protobuf.Timestamp assigned_date_utc = 8;
   optional google.protobuf.Timestamp created_date_utc = 9;
   optional google.protobuf.Timestamp completed_date_utc = 10;
+  string instructions = 11;
 }

--- a/src/UnitTests/BogusOverrides.cs
+++ b/src/UnitTests/BogusOverrides.cs
@@ -21,6 +21,9 @@ internal class BogusOverrides : AutoGeneratorOverride
                 order.Number = new WorkOrderNumberGenerator().GenerateNumber();
                 order.Title = order.Title.ClampLength(1, 200);        // HasMaxLength(200)
                 order.Description = order.Description.ClampLength(1, 4000); // HasMaxLength(4000)
+                order.Instructions = order.Instructions == null
+                    ? null
+                    : order.Instructions.ClampLength(0, 4000);
                 order.RoomNumber = order.RoomNumber.ClampLength(1, 50);     // HasMaxLength(50)
                 break;
             case WorkOrderStatus:

--- a/src/UnitTests/BogusOverrides.cs
+++ b/src/UnitTests/BogusOverrides.cs
@@ -19,7 +19,7 @@ internal class BogusOverrides : AutoGeneratorOverride
         {
             case WorkOrder order:
                 order.Number = new WorkOrderNumberGenerator().GenerateNumber();
-                order.Title = order.Title.ClampLength(1, 200);        // HasMaxLength(200)
+                order.Title = order.Title.ClampLength(1, 300);        // HasMaxLength(300)
                 order.Description = order.Description.ClampLength(1, 4000); // HasMaxLength(4000)
                 order.Instructions = order.Instructions == null
                     ? null

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(null));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -40,6 +41,7 @@ public class WorkOrderTests
         workOrder.Id = guid;
         workOrder.Title = "Title";
         workOrder.Description = "Description";
+        workOrder.Instructions = "Do step A then B";
         workOrder.Status = WorkOrderStatus.Complete;
         workOrder.Number = "Number";
         workOrder.Creator = creator;
@@ -48,6 +50,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(guid));
         Assert.That(workOrder.Title, Is.EqualTo("Title"));
         Assert.That(workOrder.Description, Is.EqualTo("Description"));
+        Assert.That(workOrder.Instructions, Is.EqualTo("Do step A then B"));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Complete));
         Assert.That(workOrder.Number, Is.EqualTo("Number"));
         Assert.That(workOrder.Creator, Is.EqualTo(creator));
@@ -70,6 +73,23 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('y', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions!.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldNormalizeEmptyInstructionsToNull()
+    {
+        var order = new WorkOrder();
+        order.Instructions = "";
+        Assert.That(order.Instructions, Is.EqualTo(null));
     }
 
     [Test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an optional **Instructions** field on work orders (max 4000 characters) for execution guidance. The maintain work order screen shows a multi-line **Instructions** textarea after **Description** and before **Room**, with the same styling as Description, `for`/`id` labeling, and a visually hidden help phrase for screen readers. Domain truncation uses a shared `MaxLongTextLength` constant; empty input is stored as null.

## Follow-up (review / CI)

- **028** migration aligned with repo DbUp pattern (`BEGIN TRANSACTION`, `GO`, `@@ERROR` rollback).
- **WorkOrder**: single max-length constant; nullable instructions reuse string truncation then normalize empty to null.
- **AcceptanceTestBase**: always calls `Input` for Instructions (matches Title/Description; clears stale values).
- **BogusOverrides**: Title clamp **300** to match EF `HasMaxLength(300)`.

## Testing

`DATABASE_ENGINE=SQLite` `./PrivateBuild.ps1`: build + **241** unit + **97** integration tests passed on commit `af6d44d2`.

Earlier CI failures matched flaky tests unrelated to this feature (`NeedsRebootHealthCheck`, `ApplicationChatHandler`); a full rerun had previously gone green.

Closes #1555
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21ff3751-18eb-490d-b49d-e312507f3708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21ff3751-18eb-490d-b49d-e312507f3708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

