### PR TITLE
Force capitalize all names in the login drop-down (#1556)

### DIFF
--- a/src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs
+++ b/src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs
@@ -1,8 +1,14 @@
 using System.Net;
+using NUnit.Framework;
 
 namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
 
+/// <summary>
+/// Serial execution: <see cref="NeedsRebootHealthCheck.NeedsReboot"/> is process-wide; parallel tests
+/// in this fixture race with each other’s <see cref="TearDown"/> resetting the flag.
+/// </summary>
 [TestFixture]
+[NonParallelizable]
 public class NeedsRebootHealthCheckTests : AcceptanceTestBase
 {
     protected override bool RequiresBrowser => false;

--- a/src/AcceptanceTests/Authentication/LoginTests.cs
+++ b/src/AcceptanceTests/Authentication/LoginTests.cs
@@ -1,4 +1,6 @@
 using ClearMeasure.Bootcamp.UI.Shared.Components;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using Microsoft.Playwright;
 
 namespace ClearMeasure.Bootcamp.AcceptanceTests.Authentication;
 
@@ -34,8 +36,12 @@ public class LoginTests : AcceptanceTestBase
         await Page.WaitForURLAsync("**/login");
         await TakeScreenshotAsync(2);
 
+        var memberSelect = Page.GetByTestId(nameof(Login.Elements.User));
+        var homerOption = memberSelect.Locator("option[value='hsimpson']");
+        await Expect(homerOption).ToHaveTextAsync("Homer Simpson");
+
         // Fill in username only
-        await Select(nameof(UI.Shared.Pages.Login.Elements.User), "hsimpson");
+        await Select(nameof(Login.Elements.User), "hsimpson");
         await TakeScreenshotAsync(3);
 
         // Submit form


### PR DESCRIPTION
## Summary

The login page **Select Church Member** dropdown already renders display names with title-style casing via `GetLoginDropdownDisplayName` in `Login.razor.cs` (values stay as usernames). This PR adds an acceptance test that asserts the visible label for `hsimpson` is **Homer Simpson** on the real `/login` page.

`NeedsRebootHealthCheckTests` is marked `[NonParallelizable]` because `NeedsRebootHealthCheck.NeedsReboot` is process-wide; parallel NUnit children were racing and clearing the flag before `/_healthcheck/detailed` ran (fixing flaky **Acceptance Tests (ARM SQLite)** and **Integration Build (Windows LocalDB)** reporter failures on CI).

## Files changed

| File | Change |
|------|--------|
| `src/AcceptanceTests/Authentication/LoginTests.cs` | After navigating to `/login`, assert `option[value='hsimpson']` text is title-cased before selecting the user. |
| `src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs` | `[NonParallelizable]` + brief doc on why (static reboot flag). |

## Testing

- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: build succeeded; unit tests 239 passed; integration tests 97 passed.

Closes #1556
