### PR TITLE
New API endpoint GET /api/health/detailed for component-level health reporting (#1559)

### DIFF
--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -40,6 +40,40 @@ public class ApiVersioningEndpointTests
     }
 
     [Test]
+    public async Task Should_Return200AndEquivalentComponentReport_When_GetDetailedHealth_LegacyAndV1Paths()
+    {
+        var legacy = await _client!.GetAsync("/api/health/detailed");
+        var v1 = await _client.GetAsync("/api/v1.0/health/detailed");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        using var legacyDoc = JsonDocument.Parse(await legacy.Content.ReadAsStringAsync());
+        using var v1Doc = JsonDocument.Parse(await v1.Content.ReadAsStringAsync());
+
+        legacyDoc.RootElement.GetProperty("overallStatus").GetString()
+            .ShouldBe(v1Doc.RootElement.GetProperty("overallStatus").GetString());
+
+        var legacyComponents = ReadComponentStatuses(legacyDoc.RootElement.GetProperty("components"));
+        var v1Components = ReadComponentStatuses(v1Doc.RootElement.GetProperty("components"));
+        legacyComponents.Count.ShouldBe(v1Components.Count);
+        legacyComponents.ShouldBeEquivalentTo(v1Components);
+    }
+
+    private static Dictionary<string, string> ReadComponentStatuses(JsonElement componentsArray)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var item in componentsArray.EnumerateArray())
+        {
+            var name = item.GetProperty("name").GetString() ?? "";
+            var status = item.GetProperty("status").GetString() ?? "";
+            map[name] = status;
+        }
+
+        return map;
+    }
+
+    [Test]
     public async Task Should_ReturnNotSuccess_When_GetSimpleHealth_UnsupportedVersion()
     {
         var response = await _client!.GetAsync("/api/v2.0/health");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GET /api/health/detailed` is exposed on `DetailedHealthController` in `UI.Api`. The action returns JSON (`DetailedHealthReport`) built from registered ASP.NET Core health checks (excluding liveness-tagged checks), including per-component status, descriptions, timing, and optional exception/data fields. This matches the issue requirement for component-level operational visibility.

This PR adds a **routing contract test**: legacy `/api/health/detailed` and versioned `/api/v1.0/health/detailed` must return the same overall status and the same per-component status map, paralleling the existing simple health test for `/api/health`.

## Files changed

| File | Description |
|------|-------------|
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | New test `Should_Return200AndEquivalentComponentReport_When_GetDetailedHealth_LegacyAndV1Paths` |

## Testing

- `dotnet test src/UnitTests --configuration Release --filter "FullyQualifiedName~ApiVersioningEndpointTests"`
- Full `PrivateBuild.ps1` (Release compile, 240 unit tests, SQL Server container, migrations, 100 integration tests) — all green

Closes #1559
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38718414-09c5-4094-9e47-ecb87da0d3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38718414-09c5-4094-9e47-ecb87da0d3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

