### PR TITLE
New API endpoint GET /api/features/flags for runtime feature flag status (#1566)

### DIFF
--- a/src/IntegrationTests/Api/FeatureFlagsIntegrationTests.cs
+++ b/src/IntegrationTests/Api/FeatureFlagsIntegrationTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class FeatureFlagsIntegrationTests
+{
+    private SqliteConnection? _sharedMemoryHold;
+    private GrpcWebApplicationFactory? _factory;
+    private HttpClient? _httpClient;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _sharedMemoryHold = new SqliteConnection(GrpcWebApplicationFactory.SqliteSharedMemoryConnectionString);
+        _sharedMemoryHold.Open();
+        _factory = new GrpcWebApplicationFactory();
+        _httpClient = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _httpClient?.Dispose();
+        _factory?.Dispose();
+        _sharedMemoryHold?.Dispose();
+    }
+
+    [TestCase("/api/features/flags")]
+    [TestCase("/api/v1.0/features/flags")]
+    public async Task Should_ReturnFeatureFlagsJson_When_Get(string url)
+    {
+        var response = await _httpClient!.GetAsync(url);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.ShouldBe("application/json");
+        var json = await response.Content.ReadAsStringAsync();
+        var payload = JsonSerializer.Deserialize<Dictionary<string, bool>>(
+            json,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Count.ShouldBe(ApplicationFeatureFlags.All.Count);
+        foreach (var kv in ApplicationFeatureFlags.All)
+        {
+            payload[kv.Key].ShouldBe(kv.Value);
+        }
+    }
+}

--- a/src/UI/Api/ApplicationFeatureFlags.cs
+++ b/src/UI/Api/ApplicationFeatureFlags.cs
@@ -1,0 +1,21 @@
+using System.Collections.Frozen;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Static in-memory registry of application feature flags and their default enabled state.
+/// </summary>
+public static class ApplicationFeatureFlags
+{
+    private static readonly FrozenDictionary<string, bool> Flags = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["RealtimeNotifications"] = true,
+        ["WorkOrderBulkImport"] = true,
+        ["ExperimentalAiChat"] = false
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// All defined flags keyed by name with the current enabled value.
+    /// </summary>
+    public static IReadOnlyDictionary<string, bool> All => Flags;
+}

--- a/src/UI/Api/Controllers/FeatureFlagsController.cs
+++ b/src/UI/Api/Controllers/FeatureFlagsController.cs
@@ -1,0 +1,36 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes runtime feature-flag state for operators and automation.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/features/flags")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/features/flags")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class FeatureFlagsController : ControllerBase
+{
+    /// <summary>
+    /// Returns all configured feature flags and whether each is enabled.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var payload = ApplicationFeatureFlags.All
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and feature-flag endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicDiagnosticApiPath(value))
         {
             return false;
         }
@@ -65,12 +65,27 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicDiagnosticApiPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
         {
             return false;
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("features", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("flags", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length == 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("features", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("flags", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         if (segments.Length == 2)

--- a/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagsControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnOk_WithExpectedShape()
+    {
+        var controller = new FeatureFlagsController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<Dictionary<string, bool>>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Count.ShouldBe(ApplicationFeatureFlags.All.Count);
+        foreach (var kv in ApplicationFeatureFlags.All)
+        {
+            payload[kv.Key].ShouldBe(kv.Value);
+        }
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesEtag()
+    {
+        var controller = new FeatureFlagsController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+        _ = controller.Get();
+        var etag = controller.HttpContext.Response.Headers.ETag.ToString();
+        etag.ShouldNotBeNullOrEmpty();
+
+        var secondController = new FeatureFlagsController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+        secondController.HttpContext.Request.Headers.IfNoneMatch = etag;
+
+        var second = secondController.Get();
+
+        second.ShouldBeOfType<StatusCodeResult>().StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/features/flags", true)]
+    [TestCase("/api/v1.0/features/flags", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/features/flags` (and versioned `GET /api/v1.0/features/flags`) returning a JSON object of feature flag names to boolean enabled state. Flags are defined in a static in-memory dictionary (`ApplicationFeatureFlags`), matching the issue. Optional API key middleware treats these paths like `version` and `time` so operators can read flags without a key when API key enforcement is enabled.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/ApplicationFeatureFlags.cs` | Frozen dictionary of flag names and default enabled values |
| `src/UI/Api/Controllers/FeatureFlagsController.cs` | MVC controller, weak ETag + 304 support, rate limiting |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Skip API key for `/api/features/flags` and versioned variant |
| `src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs` | Controller shape and conditional GET tests |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Public-path cases for feature flags |
| `src/IntegrationTests/Api/FeatureFlagsIntegrationTests.cs` | HTTP GET against both route templates |

## Testing

- `DATABASE_ENGINE=SQLite ./PrivateBuild.ps1` — all unit and integration tests green
- Filtered: `FeatureFlagsControllerTests`, `FeatureFlagsIntegrationTests`, `ApiKeyAuthenticationMiddlewareTests`

Closes #1566
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6ed5204-576a-40a9-b4fa-1b22db532391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6ed5204-576a-40a9-b4fa-1b22db532391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

