### PR TITLE
New API endpoint GET /api/version for build and deployment metadata (#1562)

### DIFF
--- a/src/UI/Api/Controllers/VersionController.cs
+++ b/src/UI/Api/Controllers/VersionController.cs
@@ -31,9 +31,11 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
         var assembly = Assembly.GetExecutingAssembly();
         var assemblyVersion = assembly.GetName().Version?.ToString();
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var buildConfiguration = assembly.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration;
         var payload = new VersionMetadataResponse(
             AssemblyVersion: assemblyVersion,
             InformationalVersion: informationalVersion,
+            BuildConfiguration: buildConfiguration,
             Environment: hostEnvironment.EnvironmentName,
             MachineName: Environment.MachineName,
             FrameworkDescription: RuntimeInformation.FrameworkDescription);
@@ -51,6 +53,7 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
 public record VersionMetadataResponse(
     string? AssemblyVersion,
     string? InformationalVersion,
+    string? BuildConfiguration,
     string? Environment,
     string MachineName,
     string FrameworkDescription);

--- a/src/UI/Api/UI.Api.csproj
+++ b/src/UI/Api/UI.Api.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<GenerateAssemblyConfigurationAttribute>true</GenerateAssemblyConfigurationAttribute>
 		<AssemblyName>ClearMeasure.Bootcamp.$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>ClearMeasure.Bootcamp.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<Configurations>Debug;Release;exclude-maui.slnf</Configurations>

--- a/src/UnitTests/UI.Api/VersionControllerTests.cs
+++ b/src/UnitTests/UI.Api/VersionControllerTests.cs
@@ -32,6 +32,7 @@ public class VersionControllerTests
         payload.ShouldNotBeNull();
         payload!.AssemblyVersion.ShouldNotBeNullOrEmpty();
         payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+        payload.BuildConfiguration.ShouldNotBeNullOrEmpty();
         payload.Environment.ShouldBe("TestEnvironment");
         payload.MachineName.ShouldBe(Environment.MachineName);
         payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -49,6 +49,24 @@ public class ApiVersioningEndpointTests
     }
 
     [Test]
+    public async Task Should_Return200_When_GetVersion_LegacyPath()
+    {
+        var response = await _client!.GetAsync("/api/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        root.GetProperty("assemblyVersion").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("informationalVersion").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("buildConfiguration").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("environment").GetString().ShouldNotBeNullOrEmpty();
+    }
+
+    [Test]
     public async Task Should_Return200_When_GetVersion_V1Path()
     {
         var response = await _client!.GetAsync("/api/v1.0/version");


### PR DESCRIPTION
## Summary

Extends `GET /api/version` (and `GET /api/v1.0/version`) with **build configuration** (`Debug` / `Release`) from the API assembly, matching the issue requirement for assembly version, informational version, build configuration, and runtime environment. The UI.Api project now emits `AssemblyConfigurationAttribute` so the value is populated at compile time.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/UI.Api.csproj` | Set `GenerateAssemblyConfigurationAttribute` to true |
| `src/UI/Api/Controllers/VersionController.cs` | Add `buildConfiguration` to `VersionMetadataResponse` and populate from assembly |
| `src/UnitTests/UI.Api/VersionControllerTests.cs` | Assert `buildConfiguration` is present |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | Integration-style test for legacy `/api/version` JSON shape |

## Testing

- `dotnet build src/ChurchBulletin.sln --configuration Release`
- `PrivateBuild.ps1` (unit + integration tests, DB migrations)

Closes #1562