### PR TITLE
New API endpoint GET /api/tools/timestamp-converter for epoch and ISO conversions (#1565)

### DIFF
--- a/src/IntegrationTests/Api/TimestampConverterIntegrationTests.cs
+++ b/src/IntegrationTests/Api/TimestampConverterIntegrationTests.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public sealed class TimestampConverterIntegrationTests
+{
+    private DetailedHealthWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DetailedHealthWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_ReturnJson_When_ValidEpochQuery()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?timestamp=0");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var json = await response.Content.ReadAsStringAsync();
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(json, ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.UnixSeconds.ShouldBe(0L);
+        payload.InputKind.ShouldBe("epoch_seconds");
+    }
+
+    [Test]
+    public async Task Should_Return400_When_TimestampMissing()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter");
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+}

--- a/src/UI/Api/Controllers/TimestampConverterController.cs
+++ b/src/UI/Api/Controllers/TimestampConverterController.cs
@@ -1,0 +1,113 @@
+using System.Globalization;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Converts between Unix epoch and ISO-8601 timestamps for operators and integrations.
+/// Public under <c>/api/*</c> like <see cref="TimeController"/> and <see cref="VersionController"/>:
+/// optional API key validation is skipped for this route when enabled, and the sliding-window rate limiter applies.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/timestamp-converter")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/timestamp-converter")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class TimestampConverterController : ControllerBase
+{
+    private const long MillisecondsThreshold = 1_000_000_000_000L;
+
+    /// <summary>
+    /// Converts a Unix epoch (seconds or milliseconds) or ISO-8601 string to all supported representations.
+    /// </summary>
+    /// <param name="timestamp">Required. Unix epoch as integer (seconds or milliseconds) or ISO-8601 instant string.</param>
+    [HttpGet]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(TimestampConverterResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] string? timestamp)
+    {
+        if (string.IsNullOrWhiteSpace(timestamp))
+        {
+            return Problem(
+                detail: "Query parameter 'timestamp' is required. Supply a Unix epoch (seconds or milliseconds) or an ISO-8601 string.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var trimmed = timestamp.Trim();
+        if (TryParseEpoch(trimmed, out var fromEpoch, out var epochUnit))
+        {
+            return OkPayload(fromEpoch, epochUnit);
+        }
+
+        if (DateTimeOffset.TryParse(
+                trimmed,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces,
+                out var parsed))
+        {
+            return OkPayload(parsed, "iso8601");
+        }
+
+        return Problem(
+            detail: $"Could not parse '{trimmed}' as a Unix epoch (seconds or milliseconds) or ISO-8601.",
+            statusCode: StatusCodes.Status400BadRequest);
+    }
+
+    private static bool TryParseEpoch(string s, out DateTimeOffset instant, out string inputKind)
+    {
+        instant = default;
+        inputKind = "";
+
+        if (!long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n))
+        {
+            return false;
+        }
+
+        if (n >= MillisecondsThreshold || n <= -MillisecondsThreshold)
+        {
+            instant = DateTimeOffset.FromUnixTimeMilliseconds(n);
+            inputKind = "epoch_milliseconds";
+            return true;
+        }
+
+        instant = DateTimeOffset.FromUnixTimeSeconds(n);
+        inputKind = "epoch_seconds";
+        return true;
+    }
+
+    private IActionResult OkPayload(DateTimeOffset instantUtc, string inputKind)
+    {
+        var utc = instantUtc.ToUniversalTime();
+        var payload = new TimestampConverterResponse(
+            InputKind: inputKind,
+            UnixSeconds: utc.ToUnixTimeSeconds(),
+            UnixMilliseconds: utc.ToUnixTimeMilliseconds(),
+            Iso8601Utc: utc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture),
+            UtcSortable: utc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture) + " UTC",
+            Rfc1123: utc.UtcDateTime.ToString("R", CultureInfo.InvariantCulture));
+
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/tools/timestamp-converter</c>.
+/// </summary>
+public record TimestampConverterResponse(
+    string InputKind,
+    long UnixSeconds,
+    long UnixMilliseconds,
+    string Iso8601Utc,
+    string UtcSortable,
+    string Rfc1123);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and timestamp-converter endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicUtilityApiPath(value))
         {
             return false;
         }
@@ -65,7 +65,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicUtilityApiPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
@@ -78,6 +78,21 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         if (segments.Length >= 3

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterControllerTests
+{
+    [Test]
+    public void Get_Should_Return400_When_TimestampMissing()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_ReturnEpochSeconds_When_SecondsInput()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("0");
+
+        var payload = AssertJsonOk(result);
+        payload.InputKind.ShouldBe("epoch_seconds");
+        payload.UnixSeconds.ShouldBe(0L);
+        payload.UnixMilliseconds.ShouldBe(0L);
+        payload.Iso8601Utc.ShouldBe("1970-01-01T00:00:00.0000000Z");
+    }
+
+    [Test]
+    public void Get_Should_ReturnEpochMilliseconds_When_MillisecondsInput()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("1700000000000");
+
+        var payload = AssertJsonOk(result);
+        payload.InputKind.ShouldBe("epoch_milliseconds");
+        payload.UnixMilliseconds.ShouldBe(1700000000000L);
+        payload.UnixSeconds.ShouldBe(1700000000L);
+    }
+
+    [Test]
+    public void Get_Should_ReturnIso8601_When_IsoInput()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("2024-01-15T12:30:45Z");
+
+        var payload = AssertJsonOk(result);
+        payload.InputKind.ShouldBe("iso8601");
+        payload.Iso8601Utc.ShouldBe("2024-01-15T12:30:45.0000000Z");
+        payload.UnixSeconds.ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesEtag()
+    {
+        var httpContext = new DefaultHttpContext();
+        var controller = new TimestampConverterController { ControllerContext = new ControllerContext { HttpContext = httpContext } };
+
+        var first = controller.Get("1000");
+        var etag = httpContext.Response.Headers.ETag.ToString();
+        etag.ShouldNotBeNullOrEmpty();
+
+        httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.IfNoneMatch = etag;
+        controller = new TimestampConverterController { ControllerContext = new ControllerContext { HttpContext = httpContext } };
+
+        var second = controller.Get("1000");
+
+        var status = second.ShouldBeOfType<StatusCodeResult>();
+        status.StatusCode.ShouldBe(304);
+    }
+
+    private static TimestampConverterResponse AssertJsonOk(IActionResult result)
+    {
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        return payload!;
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/tools/timestamp-converter", true)]
+    [TestCase("/api/v1.0/tools/timestamp-converter", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/tools/timestamp-converter` (and `GET /api/v1.0/tools/timestamp-converter`) so callers can convert a **Unix epoch** (seconds or milliseconds, inferred by magnitude) or an **ISO-8601** string into a single JSON payload with epoch seconds, epoch milliseconds, round-trip ISO UTC, a sortable UTC string, and RFC 1123. The endpoint is **anonymous**, uses the same **sliding-window rate limiting** as other `/api/*` routes, and is **excluded from optional API key validation** when enabled—matching `/api/time` and `/api/version` (documented on the controller).

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/TimestampConverterController.cs` | New controller, query `timestamp`, `ProblemDetails` on 400, weak ETag + 304 |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Treat `.../tools/timestamp-converter` as public utility path |
| `src/UnitTests/UI.Api/TimestampConverterControllerTests.cs` | Unit tests for success, 400, ETag |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Cases for public timestamp-converter paths |
| `src/IntegrationTests/Api/TimestampConverterIntegrationTests.cs` | In-process HTTP tests |

## Testing

- `dotnet test` (targeted) for new unit and integration tests
- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: unit (246) and integration (99) tests passed

Closes #1565
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-361bfc6d-5b6d-4ea4-9ddf-4bbff2fd28ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-361bfc6d-5b6d-4ea4-9ddf-4bbff2fd28ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

