### PR TITLE
New API endpoint GET /api/echo with request reflection for debugging (#1561)

### DIFF
--- a/src/UI/Api/Controllers/EchoController.cs
+++ b/src/UI/Api/Controllers/EchoController.cs
@@ -1,0 +1,115 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Net.Http.Headers;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Returns a JSON snapshot of the inbound HTTP request for debugging.
+/// Secret-bearing headers (<c>Authorization</c>, <c>Cookie</c>, <c>X-Api-Key</c>) are not echoed in clear text; values are replaced with <see cref="EchoResponse.RedactedPlaceholder"/>.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/echo")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/echo")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class EchoController : ControllerBase
+{
+    private const int MaxHeadersReturned = 64;
+
+    private static readonly HashSet<string> SensitiveHeaderNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            HeaderNames.Authorization,
+            HeaderNames.Cookie,
+            "X-Api-Key"
+        };
+
+    private static readonly HashSet<string> HopByHopHeaderNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            HeaderNames.Connection,
+            HeaderNames.KeepAlive,
+            "Proxy-Authenticate",
+            "Proxy-Authorization",
+            HeaderNames.TE,
+            HeaderNames.Trailer,
+            HeaderNames.TransferEncoding,
+            HeaderNames.Upgrade
+        };
+
+    /// <summary>
+    /// Reflects method, URL parts, connection metadata, and non-secret headers (capped, hop-by-hop excluded).
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var req = HttpContext.Request;
+        var conn = HttpContext.Connection;
+
+        var url = $"{req.Scheme}://{req.Host}{req.PathBase}{req.Path}{req.QueryString}";
+
+        var headerEntries = new List<EchoHeaderEntry>();
+        foreach (var header in req.Headers.OrderBy(h => h.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            if (HopByHopHeaderNames.Contains(header.Key))
+            {
+                continue;
+            }
+
+            var value = SensitiveHeaderNames.Contains(header.Key)
+                ? EchoResponse.RedactedPlaceholder
+                : string.Join(", ", header.Value.AsEnumerable());
+            headerEntries.Add(new EchoHeaderEntry(header.Key, value));
+            if (headerEntries.Count >= MaxHeadersReturned)
+            {
+                break;
+            }
+        }
+
+        var payload = new EchoResponse(
+            Method: req.Method,
+            Scheme: req.Scheme,
+            Host: req.Host.Value ?? string.Empty,
+            PathBase: req.PathBase.Value ?? string.Empty,
+            Path: req.Path.Value ?? string.Empty,
+            QueryString: req.QueryString.Value ?? string.Empty,
+            Url: url,
+            RemoteIpAddress: conn.RemoteIpAddress?.ToString(),
+            RemotePort: conn.RemotePort is > 0 ? conn.RemotePort : null,
+            Headers: headerEntries);
+
+        return Ok(payload);
+    }
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/echo</c> and <c>GET /api/v1.0/echo</c>.
+/// </summary>
+/// <param name="Headers">Subset of request headers; secret values are replaced with <see cref="RedactedPlaceholder"/>.</param>
+public sealed record EchoResponse(
+    string Method,
+    string Scheme,
+    string Host,
+    string PathBase,
+    string Path,
+    string QueryString,
+    string Url,
+    string? RemoteIpAddress,
+    int? RemotePort,
+    IReadOnlyList<EchoHeaderEntry> Headers)
+{
+    /// <summary>
+    /// Serialized in place of sensitive header values.
+    /// </summary>
+    public const string RedactedPlaceholder = "[REDACTED]";
+}
+
+/// <summary>
+/// One reflected header name and value for <see cref="EchoResponse"/>.
+/// </summary>
+public sealed record EchoHeaderEntry(string Name, string Value);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicUnauthenticatedApiPath(value))
         {
             return false;
         }
@@ -65,7 +65,10 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    /// <summary>
+    /// True for exact legacy <c>/api/{version|time|echo}</c> or versioned <c>/api/vX.Y/{version|time|echo}</c> only (no extra segments).
+    /// </summary>
+    internal static bool IsPublicUnauthenticatedApiPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
@@ -81,7 +84,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
                    || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
-        if (segments.Length >= 3
+        if (segments.Length == 3
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
             var leaf = segments[2];

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and echo endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -77,7 +77,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         {
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -85,7 +86,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         {
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -14,6 +14,7 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/echo", true)]
     [TestCase("/api/v1.0/echo", true)]
+    [TestCase("/api/v1.0/echo/extra", false)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/echo", true)]
+    [TestCase("/api/v1.0/echo", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs
+++ b/src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
 
 /// <summary>
-/// UI.Server test host with API key validation enabled for <c>/api/*</c> (except public version/time).
+/// UI.Server test host with API key validation enabled for <c>/api/*</c> (except public version, time, and echo).
 /// </summary>
 public sealed class ApiKeyProtectedWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
 {

--- a/src/UnitTests/UI.Server/EchoEndpointTests.cs
+++ b/src/UnitTests/UI.Server/EchoEndpointTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UI.Shared;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class EchoEndpointTests
+{
+    [Test]
+    public async Task Should_Return200AndJsonWithCoreFields_When_GetEcho_LegacyAndV1Paths()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var legacy = await client.GetAsync("/api/echo");
+        var v1 = await client.GetAsync("/api/v1.0/echo");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (legacy.Content.Headers.ContentType?.MediaType ?? "").ShouldContain("application/json");
+        (v1.Content.Headers.ContentType?.MediaType ?? "").ShouldContain("application/json");
+
+        var legacyBody = await legacy.Content.ReadFromJsonAsync<EchoResponseStub>();
+        var v1Body = await v1.Content.ReadFromJsonAsync<EchoResponseStub>();
+        legacyBody.ShouldNotBeNull();
+        v1Body.ShouldNotBeNull();
+        legacyBody!.Method.ShouldBe("GET");
+        v1Body!.Method.ShouldBe("GET");
+        legacyBody.Path.ShouldBe("/api/echo");
+        v1Body.Path.ShouldBe("/api/v1.0/echo");
+    }
+
+    [Test]
+    public async Task Should_ReflectQueryString_When_GetEchoWithQuery()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/echo?a=1&b=two");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<EchoResponseStub>();
+        body.ShouldNotBeNull();
+        body!.QueryString.ShouldBe("?a=1&b=two");
+        body.Url.ShouldContain("a=1");
+        body.Url.ShouldContain("b=two");
+    }
+
+    [Test]
+    public async Task Should_NotLeakSecretHeaders_When_SensitiveHeadersPresent()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer super-secret-token-12345");
+        request.Headers.TryAddWithoutValidation("Cookie", "session=evil");
+        request.Headers.TryAddWithoutValidation("X-Api-Key", "should-not-appear");
+
+        var response = await client.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var raw = await response.Content.ReadAsStringAsync();
+        raw.ShouldNotContain("super-secret-token-12345");
+        raw.ShouldNotContain("evil");
+        raw.ShouldNotContain("should-not-appear");
+
+        using var doc = JsonDocument.Parse(raw);
+        foreach (var h in doc.RootElement.GetProperty("headers").EnumerateArray())
+        {
+            var name = h.GetProperty("name").GetString();
+            var value = h.GetProperty("value").GetString();
+            if (string.Equals(name, "Authorization", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "Cookie", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "X-Api-Key", StringComparison.OrdinalIgnoreCase))
+            {
+                value.ShouldBe(EchoResponse.RedactedPlaceholder);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Should_IncludeCustomHeader_When_NonSensitiveHeaderSent()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.TryAddWithoutValidation("X-Test-Echo", "diagnostic-value");
+
+        var response = await client.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<EchoResponseStub>();
+        body.ShouldNotBeNull();
+        body!.Headers.ShouldContain(h =>
+            string.Equals(h.Name, "X-Test-Echo", StringComparison.OrdinalIgnoreCase)
+            && h.Value == "diagnostic-value");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_MiddlewareEnabled_BothEchoPaths()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var legacy = await client.GetAsync("/api/echo");
+        var v1 = await client.GetAsync("/api/v1.0/echo");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_ReturnNotSuccess_When_GetEcho_UnsupportedVersion()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v2.0/echo");
+
+        response.IsSuccessStatusCode.ShouldBeFalse();
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.NotFound, HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_NotReturnSuccessfulEcho_When_PostToEcho()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/api/echo", null);
+
+        response.IsSuccessStatusCode.ShouldBeFalse();
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.MethodNotAllowed, HttpStatusCode.NotFound);
+    }
+
+    private sealed class EchoResponseStub
+    {
+        public string Method { get; set; } = "";
+        public string Path { get; set; } = "";
+        public string QueryString { get; set; } = "";
+        public string Url { get; set; } = "";
+        public List<EchoHeaderEntryStub> Headers { get; set; } = [];
+    }
+
+    private sealed class EchoHeaderEntryStub
+    {
+        public string Name { get; set; } = "";
+        public string Value { get; set; } = "";
+    }
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/echo` and `GET /api/v1.0/echo` returning JSON that reflects the inbound HTTP request (method, URL parts, connection metadata, and a capped set of headers). Secret-bearing headers are redacted. Echo is excluded from API key middleware like version/time.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/EchoController.cs` | New controller, `EchoResponse` / `EchoHeaderEntry` DTOs |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Allowlist `/api/echo` and `/api/v1.0/echo` |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Test cases for echo paths |
| `src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs` | XML doc update |
| `src/UnitTests/UI.Server/EchoEndpointTests.cs` | WebApplicationFactory tests (routing, query, redaction, API key, versioning, verb) |

## Testing

- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — green (unit + integration)
- Filtered unit tests for echo and middleware — green

Closes #1561