### PR TITLE
New API endpoint POST /api/tools/guid-generator for on-demand GUID creation (#1563)

### DIFF
--- a/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Text.Json;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class GuidGeneratorEndpointIntegrationTests
+{
+    private DetailedHealthWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DetailedHealthWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndThreeGuids_When_PostUnversionedWithCount3()
+    {
+        var response = await _client!.PostAsync("/api/tools/guid-generator?count=3", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+
+        doc.RootElement.TryGetProperty("guids", out var guids).ShouldBeTrue();
+        guids.ValueKind.ShouldBe(JsonValueKind.Array);
+        guids.GetArrayLength().ShouldBe(3);
+        foreach (var el in guids.EnumerateArray())
+        {
+            Guid.TryParseExact(el.GetString(), "D", out _).ShouldBeTrue();
+        }
+    }
+
+    [Test]
+    public async Task Should_Return200AndOneGuid_When_PostVersionedWithCount1()
+    {
+        var response = await _client!.PostAsync("/api/v1.0/tools/guid-generator?count=1", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("guids", out var guids).ShouldBeTrue();
+        guids.GetArrayLength().ShouldBe(1);
+        Guid.TryParseExact(guids[0].GetString(), "D", out _).ShouldBeTrue();
+    }
+}

--- a/src/UI/Api/Controllers/GuidGeneratorController.cs
+++ b/src/UI/Api/Controllers/GuidGeneratorController.cs
@@ -1,0 +1,58 @@
+using System.Net.Mime;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates one or more new GUIDs for scripts, configs, and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/guid-generator")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/guid-generator")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class GuidGeneratorController : ControllerBase
+{
+    private const int MinCount = 1;
+    private const int MaxCount = 100;
+
+    /// <summary>
+    /// Creates new random GUIDs. Optional query <paramref name="count"/> defaults to 1; must be between 1 and 100 inclusive.
+    /// </summary>
+    /// <param name="count">Number of GUIDs to generate.</param>
+    [HttpPost]
+    [AllowAnonymous]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(GuidGeneratorResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Post([FromQuery] int count = 1)
+    {
+        if (ModelState.GetValidationState("count") == ModelValidationState.Invalid)
+        {
+            return Problem(
+                detail: $"Query parameter count must be an integer between {MinCount} and {MaxCount} inclusive.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (count < MinCount || count > MaxCount)
+        {
+            return Problem(
+                detail: $"count must be between {MinCount} and {MaxCount} inclusive.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var guids = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            guids[i] = Guid.NewGuid().ToString("D");
+        }
+
+        return Ok(new GuidGeneratorResponse(guids));
+    }
+}

--- a/src/UI/Api/GuidGeneratorModels.cs
+++ b/src/UI/Api/GuidGeneratorModels.cs
@@ -1,0 +1,7 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>POST /api/tools/guid-generator</c> and the versioned route.
+/// </summary>
+/// <param name="Guids">New GUID strings in canonical "D" format (32 hex digits with hyphens).</param>
+public record GuidGeneratorResponse(IReadOnlyList<string> Guids);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and tools utility endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicUtilityApiPath(value))
         {
             return false;
         }
@@ -65,12 +65,27 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicUtilityApiPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
         {
             return false;
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("guid-generator", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length == 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("guid-generator", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         if (segments.Length == 2)

--- a/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
+++ b/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
@@ -1,0 +1,80 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class GuidGeneratorControllerTests
+{
+    [Test]
+    public void Post_Should_ReturnOneCanonicalGuid_When_CountOmitted()
+    {
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Post();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.StatusCode.ShouldBe(200);
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(1);
+        Guid.TryParseExact(payload.Guids[0], "D", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Post_Should_ReturnHundredDistinctGuids_When_CountIs100()
+    {
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Post(100);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.StatusCode.ShouldBe(200);
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(100);
+        payload.Guids.Select(Guid.Parse).ToHashSet().Count.ShouldBe(100);
+    }
+
+    [TestCase(0)]
+    [TestCase(101)]
+    [TestCase(-1)]
+    public void Post_Should_Return400_When_CountOutOfRange(int count)
+    {
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Post(count);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        problem.Value.ShouldBeOfType<ProblemDetails>();
+    }
+
+    [Test]
+    public void Post_Should_Return400_When_CountIsNotInteger()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?count=not-a-number");
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+        controller.ModelState.AddModelError("count", "The value 'not-a-number' is not valid for count.");
+
+        var result = controller.Post();
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        problem.Value.ShouldBeOfType<ProblemDetails>();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/tools/guid-generator", true)]
+    [TestCase("/api/v1.0/tools/guid-generator", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `POST /api/tools/guid-generator` (and `POST /api/v1.0/tools/guid-generator`) for generating 1–100 new GUIDs in canonical `"D"` string form. Optional query `count` defaults to 1. Invalid or out-of-range `count` returns **400** with problem details. The route is anonymous, rate-limited like other public APIs, and exempt from API key middleware when key enforcement is enabled (same pattern as version/time).

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/GuidGeneratorController.cs` | New controller: dual routes, `[AllowAnonymous]`, validation, `Ok(GuidGeneratorResponse)` |
| `src/UI/Api/GuidGeneratorModels.cs` | `GuidGeneratorResponse` record for JSON (`guids` in camelCase) |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | `IsPublicUtilityApiPath` includes tools/guid-generator (unversioned + v-prefixed) |
| `src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs` | Controller unit tests |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | New public-path test cases |
| `src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs` | HTTP tests for both route shapes |

## Testing

- `dotnet test` (targeted): `GuidGeneratorControllerTests`, `ApiKeyAuthenticationMiddlewareTests`, `GuidGeneratorEndpointIntegrationTests`
- Full suite: `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — unit (247) and integration (99) tests passed

Closes #1563

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72ed1e85-968c-47a4-a366-c8ed0d145870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72ed1e85-968c-47a4-a366-c8ed0d145870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

