### PR TITLE
New API endpoint GET /api/tools/random for configurable random data generation (#1567)

### DIFF
--- a/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
@@ -1,0 +1,227 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UI.Server.RateLimiting;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.Api;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ToolsRandomEndpointIntegrationTests
+{
+    private DetailedHealthWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DetailedHealthWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_TypeIsNumber()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=number");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("number");
+        doc.RootElement.GetProperty("value").GetInt32().ShouldBeInRange(int.MinValue, int.MaxValue);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_TypeIsString()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=string");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("string");
+        var s = doc.RootElement.GetProperty("value").GetString();
+        s.ShouldNotBeNullOrEmpty();
+        s!.Length.ShouldBe(24);
+        Regex.IsMatch(s, "^[a-zA-Z0-9]{24}$").ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_TypeIsUuid()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=uuid");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("uuid");
+        var s = doc.RootElement.GetProperty("value").GetString();
+        Guid.TryParse(s, out var guid).ShouldBeTrue();
+        guid.ToString("D").ShouldBe(s);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_TypeIsColor()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=color");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("color");
+        var s = doc.RootElement.GetProperty("value").GetString();
+        Regex.IsMatch(s!, "^#[0-9a-f]{6}$").ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return400ProblemDetails_When_TypeIsMissing()
+    {
+        var response = await _client!.GetAsync("/api/tools/random");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/problem+json");
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("status").GetInt32().ShouldBe(400);
+        doc.RootElement.GetProperty("detail").GetString()!.ShouldContain("type");
+    }
+
+    [Test]
+    public async Task Should_Return400ProblemDetails_When_TypeIsWhitespaceOnly()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=%20%20");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/problem+json");
+    }
+
+    [Test]
+    public async Task Should_Return400ProblemDetails_When_TypeIsUnknown()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=not-a-real-type");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/problem+json");
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("status").GetInt32().ShouldBe(400);
+        doc.RootElement.GetProperty("detail").GetString()!.ShouldContain("Unsupported");
+    }
+
+    [Test]
+    public async Task Should_ExposeSameBehavior_When_VersionedPathUsed()
+    {
+        var a = await _client!.GetAsync("/api/tools/random?type=uuid");
+        var b = await _client.GetAsync("/api/v1.0/tools/random?type=uuid");
+
+        a.StatusCode.ShouldBe(HttpStatusCode.OK);
+        b.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var ja = JsonDocument.Parse(await a.Content.ReadAsStringAsync());
+        var jb = JsonDocument.Parse(await b.Content.ReadAsStringAsync());
+        ja.RootElement.GetProperty("type").GetString().ShouldBe(jb.RootElement.GetProperty("type").GetString());
+        ja.RootElement.GetProperty("value").GetString()!.Length.ShouldBe(36);
+        jb.RootElement.GetProperty("value").GetString()!.Length.ShouldBe(36);
+    }
+
+    [Test]
+    public async Task Should_AllowAnonymousAccess_When_ApiKeyDisabled()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=number");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return401_When_ApiKeyRequiredAndHeaderMissing()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/health");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiKeyRequiredAndToolsRandomWithoutHeader()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/tools/random?type=uuid");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiKeyRequiredAndValidHeaderPresent()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(ApiKeyConstants.HeaderName, ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var response = await client.GetAsync("/api/tools/random?type=uuid");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_IncludeRateLimitHeaders_When_RateLimitingEnabled()
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["ApiRateLimiting:Enabled"] = "true",
+            ["ApiRateLimiting:PermitLimit"] = "10",
+            ["ApiRateLimiting:WindowSeconds"] = "2",
+            ["ApiRateLimiting:SegmentsPerWindow"] = "2",
+            ["ApiRateLimiting:QueueLimit"] = "0",
+            ["ApiRateLimiting:ApiKeyHeaderName"] = "X-API-Key"
+        };
+
+        await using var factory = new TunableApiRateLimitWebApplicationFactory(settings);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/tools/random?type=number");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues(RateLimitingMiddleware.HeaderLimit, out var limit).ShouldBeTrue();
+        response.Headers.TryGetValues(RateLimitingMiddleware.HeaderRemaining, out var remaining).ShouldBeTrue();
+        limit!.First().ShouldBe("10");
+        int.Parse(remaining!.First(), NumberFormatInfo.InvariantInfo).ShouldBeGreaterThanOrEqualTo(0);
+    }
+}

--- a/src/UI/Api/Controllers/ToolsRandomController.cs
+++ b/src/UI/Api/Controllers/ToolsRandomController.cs
@@ -1,0 +1,84 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Utility endpoints for generating sample random values (machine clients).
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsRandomController(IRandomToolPayloadGenerator generator) : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON object with <c>type</c> and <c>value</c> for the requested generator.
+    /// Query <c>type</c>: <c>number</c> (32-bit signed int), <c>string</c> (24 alphanumeric chars),
+    /// <c>uuid</c> (GUID string), <c>color</c> (CSS <c>#rrggbb</c> lowercase).
+    /// </summary>
+    [HttpGet("random")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(RandomToolResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult GetRandom([FromQuery] string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return Problem(
+                detail: "Query parameter 'type' is required. Supported values: number, string, uuid, color.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var normalized = type.Trim();
+        if (string.Equals(normalized, "number", StringComparison.OrdinalIgnoreCase))
+        {
+            var value = generator.NextInt32();
+            return OkJson(new RandomToolResponse("number", value));
+        }
+
+        if (string.Equals(normalized, "string", StringComparison.OrdinalIgnoreCase))
+        {
+            const int stringLength = 24;
+            var value = generator.NextAlphanumericString(stringLength);
+            return OkJson(new RandomToolResponse("string", value));
+        }
+
+        if (string.Equals(normalized, "uuid", StringComparison.OrdinalIgnoreCase))
+        {
+            var value = generator.NextGuid().ToString("D");
+            return OkJson(new RandomToolResponse("uuid", value));
+        }
+
+        if (string.Equals(normalized, "color", StringComparison.OrdinalIgnoreCase))
+        {
+            var value = generator.NextCssHexColor();
+            return OkJson(new RandomToolResponse("color", value));
+        }
+
+        return Problem(
+            detail: $"Unsupported type '{normalized}'. Supported values: number, string, uuid, color.",
+            statusCode: StatusCodes.Status400BadRequest);
+    }
+
+    private IActionResult OkJson(RandomToolResponse payload)
+    {
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}
+
+/// <summary>
+/// JSON body for <c>GET /api/tools/random</c>.
+/// </summary>
+/// <param name="Type">Echo of the requested generator kind.</param>
+/// <param name="Value">Generated value (number, string, uuid, or hex color).</param>
+public record RandomToolResponse(string Type, object Value);

--- a/src/UI/Api/IRandomToolPayloadGenerator.cs
+++ b/src/UI/Api/IRandomToolPayloadGenerator.cs
@@ -1,0 +1,27 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Produces sample random values for <c>GET /api/tools/random</c> integration and testing.
+/// </summary>
+public interface IRandomToolPayloadGenerator
+{
+    /// <summary>
+    /// Returns a pseudo-random 32-bit signed integer.
+    /// </summary>
+    int NextInt32();
+
+    /// <summary>
+    /// Returns a pseudo-random alphanumeric string of the given length.
+    /// </summary>
+    string NextAlphanumericString(int length);
+
+    /// <summary>
+    /// Returns a new RFC 4122 UUID.
+    /// </summary>
+    Guid NextGuid();
+
+    /// <summary>
+    /// Returns a CSS hex color in the form <c>#rrggbb</c> (lowercase hex digits).
+    /// </summary>
+    string NextCssHexColor();
+}

--- a/src/UI/Api/RandomToolPayloadGenerator.cs
+++ b/src/UI/Api/RandomToolPayloadGenerator.cs
@@ -1,0 +1,45 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Default <see cref="IRandomToolPayloadGenerator"/> using <see cref="Random"/> and <see cref="RandomNumberGenerator"/>.
+/// </summary>
+public sealed class RandomToolPayloadGenerator : IRandomToolPayloadGenerator
+{
+    private static ReadOnlySpan<char> AlphanumericChars =>
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    /// <inheritdoc />
+    public int NextInt32() => Random.Shared.Next();
+
+    /// <inheritdoc />
+    public string NextAlphanumericString(int length)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(length, 1);
+
+        var chars = AlphanumericChars;
+        var buffer = new char[length];
+        for (var i = 0; i < length; i++)
+            buffer[i] = chars[Random.Shared.Next(chars.Length)];
+
+        return new string(buffer);
+    }
+
+    /// <inheritdoc />
+    public Guid NextGuid() => Guid.NewGuid();
+
+    /// <inheritdoc />
+    public string NextCssHexColor()
+    {
+        Span<byte> rgb = stackalloc byte[3];
+        RandomNumberGenerator.Fill(rgb);
+        var sb = new StringBuilder(7);
+        sb.Append('#');
+        sb.Append(rgb[0].ToString("x2", null));
+        sb.Append(rgb[1].ToString("x2", null));
+        sb.Append(rgb[2].ToString("x2", null));
+        return sb.ToString();
+    }
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and tools/random endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicApiKeyExemptPath(value))
         {
             return false;
         }
@@ -65,7 +65,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicApiKeyExemptPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
@@ -80,9 +80,23 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
         }
 
+        if (segments.Length == 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("random", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         if (segments.Length >= 3
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
+            if (segments.Length >= 4
+                && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+                && segments[3].Equals("random", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddApiVersioning(options =>
 builder.Services.AddRazorPages();
 builder.Host.UseLamar(registry => { registry.IncludeRegistry<UiServiceRegistry>(); });
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<IRandomToolPayloadGenerator, RandomToolPayloadGenerator>();
 builder.Services.AddScoped<IDistributedBus, DistributedBus>();
 builder.Services.AddMemoryCache();
 builder.Services.Configure<IdempotencyOptions>(

--- a/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
+++ b/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
@@ -1,0 +1,72 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsRandomControllerTests
+{
+    [Test]
+    public void GetRandom_Should_ReturnJsonWithStubValues_When_TypeIsSupported()
+    {
+        var stub = new StubRandomToolPayloadGenerator();
+        var controller = new ToolsRandomController(stub)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var number = controller.GetRandom("number").ShouldBeOfType<ContentResult>();
+        number.StatusCode.ShouldBe(200);
+        var numberJson = number.Content.ShouldNotBeNull();
+        numberJson.ShouldContain("\"type\":\"number\"");
+        numberJson.ShouldContain("\"value\":42");
+
+        var str = controller.GetRandom("STRING").ShouldBeOfType<ContentResult>();
+        var strJson = str.Content.ShouldNotBeNull();
+        strJson.ShouldContain("\"type\":\"string\"");
+        strJson.ShouldContain("\"value\":\"aaaaaaaaaaaaaaaaaaaaaaaa\"");
+
+        var uuid = controller.GetRandom("uuid").ShouldBeOfType<ContentResult>();
+        var uuidJson = uuid.Content.ShouldNotBeNull();
+        uuidJson.ShouldContain("\"type\":\"uuid\"");
+        uuidJson.ShouldContain("11111111-1111-1111-1111-111111111111");
+
+        var color = controller.GetRandom("color").ShouldBeOfType<ContentResult>();
+        var colorJson = color.Content.ShouldNotBeNull();
+        colorJson.ShouldContain("\"type\":\"color\"");
+        colorJson.ShouldContain("#aabbcc");
+    }
+
+    [Test]
+    public void GetRandom_Should_Return400_When_TypeMissingOrInvalid()
+    {
+        var stub = new StubRandomToolPayloadGenerator();
+        var controller = new ToolsRandomController(stub)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var missing = controller.GetRandom(null).ShouldBeOfType<ObjectResult>();
+        missing.StatusCode.ShouldBe(400);
+
+        var whitespace = controller.GetRandom("   ").ShouldBeOfType<ObjectResult>();
+        whitespace.StatusCode.ShouldBe(400);
+
+        var bad = controller.GetRandom("nope").ShouldBeOfType<ObjectResult>();
+        bad.StatusCode.ShouldBe(400);
+    }
+
+    private sealed class StubRandomToolPayloadGenerator : IRandomToolPayloadGenerator
+    {
+        public int NextInt32() => 42;
+
+        public string NextAlphanumericString(int length) => new string('a', length);
+
+        public Guid NextGuid() => Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+        public string NextCssHexColor() => "#aabbcc";
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/tools/random", true)]
+    [TestCase("/api/v1.0/tools/random", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -65,4 +65,15 @@ public class ApiKeyAuthenticationWebTests
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return200_When_ToolsRandomWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1.0/tools/random?type=uuid");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }

--- a/src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs
+++ b/src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
 
 /// <summary>
-/// UI.Server test host with API key validation enabled for <c>/api/*</c> (except public version/time).
+/// UI.Server test host with API key validation enabled for <c>/api/*</c> (except public version, time, and tools/random).
 /// </summary>
 public sealed class ApiKeyProtectedWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **GET** `/api/tools/random` (and **GET** `/api/v1.0/tools/random`) with required query parameter **`type`**: `number`, `string`, `uuid`, or `color`. Successful responses are JSON objects `{ "type": "<kind>", "value": ... }` where `value` is a 32-bit signed integer, a 24-character alphanumeric string, a GUID string (`D` format), or a lowercase CSS hex color `#rrggbb`. Invalid or missing `type` returns **400** with problem details, consistent with other `/api/*` routes. The route uses the same API rate-limiting policy as other controllers. Optional API key middleware treats **`/api/tools/random`** and **`/api/v{version}/tools/random`** as public (no key required), alongside version and time.

## Files changed

| Area | Description |
|------|-------------|
| `src/UI/Api/IRandomToolPayloadGenerator.cs`, `RandomToolPayloadGenerator.cs` | Injectable generator for int, string, UUID, and hex color |
| `src/UI/Api/Controllers/ToolsRandomController.cs` | Controller action, ETag/304 for JSON body |
| `src/UI/Server/Program.cs` | Registers `IRandomToolPayloadGenerator` |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Exempts tools/random paths when API key is enabled |
| `src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs` | Integration coverage per issue test design |
| `src/UnitTests/UI.Api/ToolsRandomControllerTests.cs` | Deterministic controller tests with stub generator |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Path cases for exempt tools/random |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Web test: tools/random without key when protection on |
| `src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs` | Doc comment only |

## Testing

- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — succeeded (unit + integration tests green).
- Targeted runs: `dotnet test` with filter `ToolsRandomControllerTests` and `ToolsRandomEndpointIntegrationTests`.

Closes #1567

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9c9da9f-486e-43f4-9230-3a893e7a8600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9c9da9f-486e-43f4-9230-3a893e7a8600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

