### PR TITLE
New API endpoint POST /api/tools/guid-generator for on-demand GUID creation (#1617)

### DIFF
--- a/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class GuidGeneratorEndpointIntegrationTests
+{
+    private DetailedHealthWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DetailedHealthWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndOneGuid_When_PostWithoutParameters()
+    {
+        var response = await _client!.PostAsync("/api/tools/guid-generator", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Guids.Count.ShouldBe(1);
+        Guid.TryParse(payload.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndManyGuids_When_QueryCountProvided()
+    {
+        var response = await _client!.PostAsync("/api/tools/guid-generator?count=7", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Guids.Count.ShouldBe(7);
+        payload.Guids.Select(g => Guid.Parse(g)).Distinct().Count().ShouldBe(7);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_VersionedRouteUsed()
+    {
+        var response = await _client!.PostAsync("/api/v1.0/tools/guid-generator?count=2", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload!.Guids.Count.ShouldBe(2);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_CountExceedsMax()
+    {
+        var response = await _client!.PostAsync("/api/tools/guid-generator?count=101", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_CountBelowOne()
+    {
+        var response = await _client!.PostAsync("/api/tools/guid-generator?count=0", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+}

--- a/src/UI/Api/Controllers/GuidGeneratorController.cs
+++ b/src/UI/Api/Controllers/GuidGeneratorController.cs
@@ -1,0 +1,56 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates one or more RFC 4122 GUIDs for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/guid-generator")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/guid-generator")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class GuidGeneratorController : ControllerBase
+{
+    private const int DefaultCount = 1;
+    private const int MaxCount = 100;
+
+    /// <summary>
+    /// Creates new GUIDs. Optional <paramref name="count"/> defaults to 1; maximum is 100.
+    /// </summary>
+    [HttpPost]
+    [AllowAnonymous]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(GuidGeneratorResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Post([FromBody] GuidGeneratorRequest? body, [FromQuery] int? count)
+    {
+        var resolved = body?.Count ?? count ?? DefaultCount;
+        if (resolved < 1 || resolved > MaxCount)
+        {
+            return Problem(
+                detail: $"Count must be between 1 and {MaxCount}, inclusive.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var guids = new string[resolved];
+        for (var i = 0; i < resolved; i++)
+            guids[i] = Guid.NewGuid().ToString("D");
+
+        return Ok(new GuidGeneratorResponse(guids));
+    }
+}
+
+/// <summary>
+/// Optional JSON body for <c>POST /api/tools/guid-generator</c>.
+/// </summary>
+public sealed record GuidGeneratorRequest(int? Count);
+
+/// <summary>
+/// JSON payload for GUID generator responses.
+/// </summary>
+public sealed record GuidGeneratorResponse(IReadOnlyList<string> Guids);

--- a/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
+++ b/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class GuidGeneratorControllerTests
+{
+    [Test]
+    public void Post_Should_ReturnOneGuid_When_CountOmitted()
+    {
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Post(null, null);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        var payload = (GuidGeneratorResponse)ok.Value!;
+        payload.Guids.Count.ShouldBe(1);
+        Guid.TryParse(payload.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Post_Should_ReturnRequestedCount_When_QueryCountProvided()
+    {
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Post(null, 5);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = (GuidGeneratorResponse)ok.Value!;
+        payload.Guids.Count.ShouldBe(5);
+        payload.Guids.Select(g => Guid.TryParse(g, out var id) ? id : Guid.Empty).Distinct().Count().ShouldBe(5);
+    }
+
+    [Test]
+    public void Post_Should_PreferBodyCount_When_BodyAndQueryProvided()
+    {
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Post(new GuidGeneratorRequest(2), 9);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = (GuidGeneratorResponse)ok.Value!;
+        payload.Guids.Count.ShouldBe(2);
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(101)]
+    public void Post_Should_Return400_When_CountOutOfRange(int count)
+    {
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Post(null, count);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Post_Should_SerializeGuidsAsCamelCase_When_JsonSerialized()
+    {
+        var controller = new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Post(null, 1);
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var json = JsonSerializer.Serialize(ok.Value, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        json.ShouldContain("\"guids\"");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `POST /api/tools/guid-generator` (and versioned `POST /api/v1.0/tools/guid-generator`) to generate one or more new GUIDs. Callers may pass `count` in the JSON body (`{ "count": N }`) or as a query parameter (`?count=N`). Default is 1; maximum is 100. Values outside 1–100 return HTTP 400 with a problem detail. The endpoint is anonymous, uses the same API rate limiting as other controllers, and returns JSON `{ "guids": [ "..." ] }`.

Closes #1617

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/GuidGeneratorController.cs` | New controller, request/response DTOs, validation |
| `src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs` | Unit tests for default count, query/body precedence, range errors |
| `src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs` | In-process HTTP tests via `DetailedHealthWebApplicationFactory` |

## Testing

- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` (full unit + integration suites): green
- Targeted: `dotnet test` filters for `GuidGeneratorControllerTests` and `GuidGeneratorEndpointIntegrationTests`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ef58f94-4648-4c88-bd01-d41b5b0afca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ef58f94-4648-4c88-bd01-d41b5b0afca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

