### PR TITLE
Add navigate hide button (#1612)

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -34,14 +34,7 @@
                             aria-expanded="@NavToggleAriaExpanded"
                             title="@NavToggleTitle"
                             aria-label="@NavToggleTitle">
-                        @if (_navVisible)
-                        {
-                            <i class="bi bi-chevron-double-left" aria-hidden="true"></i>
-                        }
-                        else
-                        {
-                            <i class="bi bi-list" aria-hidden="true"></i>
-                        }
+                        <i class="bi bi-list" aria-hidden="true"></i>
                     </button>
                     <div class="header-title">
                         <h3>Work Order Management</h3>

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -32,6 +32,8 @@ public class MainLayoutTests
         toggle.GetAttribute("aria-controls").ShouldBe("app-navigation-rail");
         toggle.GetAttribute("title")!.ShouldContain("Hide");
         toggle.GetAttribute("aria-label")!.ShouldContain("Hide");
+        toggle.InnerHtml.ShouldContain("bi-list");
+        toggle.InnerHtml.ShouldNotContain("bi-chevron-double-left");
         layout.Find("#app-navigation-rail").ClassList.ShouldContain("modern-sidebar");
         layout.Find(".modern-app").ClassList.ShouldNotContain("rail-collapsed");
     }


### PR DESCRIPTION
## Summary

The shared shell already had a top-left control (`NavRailToggle`) that shows or hides the left navigation rail for a wider content area. This change aligns the control with the requested **hamburger** behavior by using Bootstrap Icons `bi-list` in **both** rail-visible and rail-hidden states, while keeping `title` / `aria-label` (“Hide navigation panel” / “Show navigation panel”) and all existing accessibility attributes.

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/MainLayout.razor` | Single `bi-list` icon for the rail toggle (replaces chevron when open). |
| `src/UnitTests/UI.Shared/MainLayoutTests.cs` | Assert hamburger icon is present and chevron is not used on the toggle. |

## Testing

- `dotnet test src/UnitTests --configuration Release --filter "FullyQualifiedName~MainLayoutTests"`
- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` (unit + integration, SQL Server container)

Closes #1612