### PR TITLE
New API endpoint GET /api/metrics/summary for application runtime metrics (#1614)

### DIFF
--- a/src/UI/Api/Controllers/MetricsSummaryController.cs
+++ b/src/UI/Api/Controllers/MetricsSummaryController.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes basic runtime metrics for operators. <see cref="TotalRequestsServed"/> counts every HTTP request
+/// that reaches the host pipeline after request-counting middleware (static files, Blazor, APIs, health, etc.), per process.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/metrics/summary")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/metrics/summary")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class MetricsSummaryController(TimeProvider timeProvider, IRequestMetrics requestMetrics) : ControllerBase
+{
+    /// <summary>
+    /// Returns uptime, memory, GC stats, and total HTTP requests served for this process.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var process = Process.GetCurrentProcess();
+        var processStartUtc = new DateTimeOffset(process.StartTime).ToUniversalTime();
+        var now = timeProvider.GetUtcNow();
+        var uptime = now - processStartUtc;
+
+        var gcInfo = GC.GetGCMemoryInfo(GCKind.Any);
+        var payload = new MetricsSummaryResponse
+        {
+            Uptime = uptime,
+            MemoryBytes = process.WorkingSet64,
+            HeapSizeBytes = gcInfo.HeapSizeBytes,
+            GcCollections = new GcCollectionCounts
+            {
+                Gen0 = GC.CollectionCount(0),
+                Gen1 = GC.CollectionCount(1),
+                Gen2 = GC.CollectionCount(2)
+            },
+            TotalRequestsServed = requestMetrics.TotalCount,
+            TimestampUtc = now.UtcDateTime
+        };
+
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/IRequestMetrics.cs
+++ b/src/UI/Api/IRequestMetrics.cs
@@ -1,0 +1,13 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Thread-safe counter for HTTP requests observed by the host (one increment per incoming request).
+/// </summary>
+public interface IRequestMetrics
+{
+    /// <summary>Increments the count once for an incoming HTTP request.</summary>
+    void Increment();
+
+    /// <summary>Total requests counted since process start.</summary>
+    long TotalCount { get; }
+}

--- a/src/UI/Api/MetricsSummaryModels.cs
+++ b/src/UI/Api/MetricsSummaryModels.cs
@@ -1,0 +1,40 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/metrics/summary</c> and <c>GET /api/v1.0/metrics/summary</c>.
+/// </summary>
+public sealed record MetricsSummaryResponse
+{
+    /// <summary>Elapsed time since the host process started (same basis as <see cref="SimpleHealthResponseBuilder"/>).</summary>
+    public required TimeSpan Uptime { get; init; }
+
+    /// <summary>Working set size from <see cref="System.Diagnostics.Process.WorkingSet64"/>.</summary>
+    public required long MemoryBytes { get; init; }
+
+    /// <summary>Managed heap size from <see cref="GC.GetGCMemoryInfo"/>.</summary>
+    public required long HeapSizeBytes { get; init; }
+
+    /// <summary>GC collection counts for generations 0–2.</summary>
+    public required GcCollectionCounts GcCollections { get; init; }
+
+    /// <summary>Total HTTP requests counted for this process since start (see controller summary for semantics).</summary>
+    public required long TotalRequestsServed { get; init; }
+
+    /// <summary>UTC instant when the snapshot was taken.</summary>
+    public required DateTime TimestampUtc { get; init; }
+}
+
+/// <summary>
+/// Per-generation GC collection counts.
+/// </summary>
+public sealed record GcCollectionCounts
+{
+    /// <summary>Collections for generation 0.</summary>
+    public required int Gen0 { get; init; }
+
+    /// <summary>Collections for generation 1.</summary>
+    public required int Gen1 { get; init; }
+
+    /// <summary>Collections for generation 2.</summary>
+    public required int Gen2 { get; init; }
+}

--- a/src/UI/Api/RequestMetrics.cs
+++ b/src/UI/Api/RequestMetrics.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Default <see cref="IRequestMetrics"/> using <see cref="Interlocked"/> operations.
+/// </summary>
+public sealed class RequestMetrics : IRequestMetrics
+{
+    private long _count;
+
+    /// <inheritdoc />
+    public void Increment() => Interlocked.Increment(ref _count);
+
+    /// <inheritdoc />
+    public long TotalCount => Interlocked.Read(ref _count);
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and metrics summary endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -80,12 +80,30 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
         }
 
-        if (segments.Length >= 3
+        if (segments.Length == 3)
+        {
+            if (segments[1].Equals("metrics", StringComparison.OrdinalIgnoreCase)
+                && segments[2].Equals("summary", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
+            {
+                var leaf = segments[2];
+                return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
+                       || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        if (segments.Length >= 4
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                   || (leaf.Equals("metrics", StringComparison.OrdinalIgnoreCase)
+                       && segments[3].Equals("summary", StringComparison.OrdinalIgnoreCase));
         }
 
         return false;

--- a/src/UI/Server/Middleware/RequestCountingMiddleware.cs
+++ b/src/UI/Server/Middleware/RequestCountingMiddleware.cs
@@ -1,0 +1,18 @@
+using ClearMeasure.Bootcamp.UI.Api;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Middleware;
+
+/// <summary>
+/// Increments <see cref="IRequestMetrics"/> once per incoming HTTP request.
+/// </summary>
+public sealed class RequestCountingMiddleware(RequestDelegate next)
+{
+    /// <summary>
+    /// Invokes the next middleware after recording the request.
+    /// </summary>
+    public Task InvokeAsync(HttpContext context, IRequestMetrics requestMetrics)
+    {
+        requestMetrics.Increment();
+        return next(context);
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddApiVersioning(options =>
 builder.Services.AddRazorPages();
 builder.Host.UseLamar(registry => { registry.IncludeRegistry<UiServiceRegistry>(); });
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<IRequestMetrics, RequestMetrics>();
 builder.Services.AddScoped<IDistributedBus, DistributedBus>();
 builder.Services.AddMemoryCache();
 builder.Services.Configure<IdempotencyOptions>(
@@ -131,6 +132,8 @@ app.MapDefaultEndpoints();
 
 // Configure the HTTP request pipeline.
 app.UseCorrelationId();
+
+app.UseMiddleware<RequestCountingMiddleware>();
 
 app.UseWhen(
     context => ProblemDetailsPaths.IsMachineOriented(context.Request.Path),

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/metrics/summary", true)]
+    [TestCase("/api/v1.0/metrics/summary", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -80,4 +80,43 @@ public class ApiVersioningEndpointTests
         values.ShouldNotBeNull();
         string.Join(", ", values!).ShouldContain("1.0");
     }
+
+    [Test]
+    public async Task Should_Return200AndJsonWithExpectedProperties_When_GetMetricsSummary_LegacyAndV1Paths()
+    {
+        var legacy = await _client!.GetAsync("/api/metrics/summary");
+        var v1 = await _client.GetAsync("/api/v1.0/metrics/summary");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        foreach (var response in new[] { legacy, v1 })
+        {
+            var mediaType = response.Content.Headers.ContentType?.MediaType;
+            mediaType.ShouldNotBeNull();
+            mediaType!.ShouldContain("application/json");
+
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var root = doc.RootElement;
+            root.GetProperty("uptime").GetString().ShouldNotBeNullOrWhiteSpace();
+            root.GetProperty("memoryBytes").GetInt64().ShouldBeGreaterThanOrEqualTo(0);
+            root.GetProperty("heapSizeBytes").GetInt64().ShouldBeGreaterThanOrEqualTo(0);
+            root.GetProperty("totalRequestsServed").GetInt64().ShouldBeGreaterThanOrEqualTo(1);
+            root.GetProperty("timestampUtc").GetString().ShouldNotBeNullOrWhiteSpace();
+
+            var gc = root.GetProperty("gcCollections");
+            gc.GetProperty("gen0").GetInt32().ShouldBeGreaterThanOrEqualTo(0);
+            gc.GetProperty("gen1").GetInt32().ShouldBeGreaterThanOrEqualTo(0);
+            gc.GetProperty("gen2").GetInt32().ShouldBeGreaterThanOrEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Should_ReturnNotSuccess_When_GetMetricsSummary_UnsupportedVersion()
+    {
+        var response = await _client!.GetAsync("/api/v2.0/metrics/summary");
+
+        response.IsSuccessStatusCode.ShouldBeFalse();
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.NotFound, HttpStatusCode.BadRequest);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/metrics/summary` and `GET /api/v1.0/metrics/summary` returning JSON runtime metrics: uptime (aligned with simple health), working set and managed heap size, GC collection counts for generations 0–2, total HTTP requests served per process, and snapshot timestamp. Uses weak ETag + conditional GET (304) like detailed health. Registers `IRequestMetrics` with middleware after correlation ID so every request through the pipeline increments the counter (documented on the controller).

When API key authentication is enabled, metrics summary paths are treated as public operator endpoints (same idea as version/time).

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/MetricsSummaryController.cs` | New API controller with dual routes, rate limiting, anonymous access |
| `src/UI/Api/MetricsSummaryModels.cs` | Response and GC count DTOs |
| `src/UI/Api/IRequestMetrics.cs` | Counter abstraction |
| `src/UI/Api/RequestMetrics.cs` | Thread-safe implementation |
| `src/UI/Server/Middleware/RequestCountingMiddleware.cs` | Increments counter per request |
| `src/UI/Server/Program.cs` | DI + middleware registration |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Public paths for metrics summary (legacy + versioned) |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | 200 + JSON shape + unsupported version |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | ShouldValidate false for metrics paths |

## Testing

- `dotnet build src/ChurchBulletin.sln --configuration Release`
- `dotnet test` (filtered) for `ApiVersioningEndpointTests` and `ApiKeyAuthenticationMiddlewareTests`
- Full `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` (243 unit + 97 integration tests passed)

## Closes

Closes #1614

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe25a6ef-3733-46f8-aa99-cafa2abba13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe25a6ef-3733-46f8-aa99-cafa2abba13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

