### PR TITLE
New API endpoint GET /api/version for build and deployment metadata (#1616)

### DIFF
--- a/src/UI/Api/Controllers/VersionController.cs
+++ b/src/UI/Api/Controllers/VersionController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Asp.Versioning;
@@ -31,9 +32,13 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
         var assembly = Assembly.GetExecutingAssembly();
         var assemblyVersion = assembly.GetName().Version?.ToString();
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var buildConfiguration = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "BuildConfiguration")?.Value;
         var payload = new VersionMetadataResponse(
             AssemblyVersion: assemblyVersion,
             InformationalVersion: informationalVersion,
+            BuildConfiguration: buildConfiguration,
             Environment: hostEnvironment.EnvironmentName,
             MachineName: Environment.MachineName,
             FrameworkDescription: RuntimeInformation.FrameworkDescription);
@@ -47,10 +52,12 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
 
 /// <summary>
 /// JSON payload for <c>GET /api/version</c> and <c>GET /api/v1.0/version</c>.
+/// <para><see cref="BuildConfiguration"/> is emitted at compile time from MSBuild <c>$(Configuration)</c> (Debug, Release, etc.).</para>
 /// </summary>
 public record VersionMetadataResponse(
     string? AssemblyVersion,
     string? InformationalVersion,
+    string? BuildConfiguration,
     string? Environment,
     string MachineName,
     string FrameworkDescription);

--- a/src/UI/Api/UI.Api.csproj
+++ b/src/UI/Api/UI.Api.csproj
@@ -10,6 +10,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+			<_Parameter1>BuildConfiguration</_Parameter1>
+			<_Parameter2>$(Configuration)</_Parameter2>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
 		<InternalsVisibleTo Include="ClearMeasure.Bootcamp.UnitTests" />
 		<InternalsVisibleTo Include="ClearMeasure.Bootcamp.IntegrationTests" />
 	</ItemGroup>

--- a/src/UnitTests/UI.Api/VersionControllerTests.cs
+++ b/src/UnitTests/UI.Api/VersionControllerTests.cs
@@ -32,6 +32,7 @@ public class VersionControllerTests
         payload.ShouldNotBeNull();
         payload!.AssemblyVersion.ShouldNotBeNullOrEmpty();
         payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+        payload.BuildConfiguration.ShouldNotBeNullOrEmpty();
         payload.Environment.ShouldBe("TestEnvironment");
         payload.MachineName.ShouldBe(Environment.MachineName);
         payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -49,14 +49,27 @@ public class ApiVersioningEndpointTests
     }
 
     [Test]
-    public async Task Should_Return200_When_GetVersion_V1Path()
+    public async Task Should_Return200_When_GetVersion_LegacyAndV1Paths()
     {
-        var response = await _client!.GetAsync("/api/v1.0/version");
+        var legacy = await _client!.GetAsync("/api/version");
+        var v1 = await _client.GetAsync("/api/v1.0/version");
 
-        response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        var mediaType = response.Content.Headers.ContentType?.MediaType;
-        mediaType.ShouldNotBeNull();
-        mediaType!.ShouldContain("application/json");
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        foreach (var response in new[] { legacy, v1 })
+        {
+            var mediaType = response.Content.Headers.ContentType?.MediaType;
+            mediaType.ShouldNotBeNull();
+            mediaType!.ShouldContain("application/json");
+        }
+
+        using var legacyDoc = JsonDocument.Parse(await legacy.Content.ReadAsStringAsync());
+        using var v1Doc = JsonDocument.Parse(await v1.Content.ReadAsStringAsync());
+        legacyDoc.RootElement.GetProperty("assemblyVersion").GetString()
+            .ShouldBe(v1Doc.RootElement.GetProperty("assemblyVersion").GetString());
+        legacyDoc.RootElement.GetProperty("buildConfiguration").GetString()
+            .ShouldBe(v1Doc.RootElement.GetProperty("buildConfiguration").GetString());
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Completes the version metadata contract for **GET /api/version** (and **GET /api/v1.0/version**) by adding **build configuration** (MSBuild `$(Configuration)`, e.g. Debug/Release) to the JSON payload. Values come from compile-time `AssemblyMetadata` on the UI.Api assembly—no new NuGet packages.

The endpoint continues to return **assembly version**, **informational version**, **runtime environment** (`IHostEnvironment.EnvironmentName`), plus existing operational fields **machineName** and **frameworkDescription**. Metadata is read from **UI.Api** (`Assembly.GetExecutingAssembly()`), consistent with prior behavior.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/UI.Api.csproj` | Emit `AssemblyMetadata("BuildConfiguration", "$(Configuration)")` at compile time |
| `src/UI/Api/Controllers/VersionController.cs` | Read metadata; add `buildConfiguration` to `VersionMetadataResponse` |
| `src/UnitTests/UI.Api/VersionControllerTests.cs` | Assert non-empty `BuildConfiguration` |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | Assert legacy `/api/version` and `/api/v1.0/version` both 200 and agree on key fields |

## Testing

- `DATABASE_ENGINE=SQLite` **PrivateBuild.ps1**: solution build, 239 unit tests, 97 integration tests — all passed.

Closes #1616
