### PR TITLE
Make the login button blink obviously (#1611)

### DIFF
--- a/src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs
+++ b/src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs
@@ -2,7 +2,11 @@ using System.Net;
 
 namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
 
-[TestFixture]
+/// <summary>
+/// Uses a process-wide static flag toggled via <c>/_demo/setneedsreboot/*</c>; must not run in parallel
+/// with itself or concurrent tests could reset the flag between set and health probe.
+/// </summary>
+[TestFixture, NonParallelizable]
 public class NeedsRebootHealthCheckTests : AcceptanceTestBase
 {
     protected override bool RequiresBrowser => false;

--- a/src/AcceptanceTests/Authentication/LoginLinkVisualTests.cs
+++ b/src/AcceptanceTests/Authentication/LoginLinkVisualTests.cs
@@ -10,6 +10,7 @@ public class LoginLinkVisualTests : AcceptanceTestBase
     [Test, Retry(2)]
     public async Task LoginLink_Visible_And_Emphasized_WhenUnauthenticated()
     {
+        await Page.EmulateMediaAsync(new PageEmulateMediaOptions { ReducedMotion = ReducedMotion.NoPreference });
         await EnsureLoggedOutAsync();
 
         var loginLink = Page.GetByTestId(nameof(LoginLink.Elements.LoginLink));
@@ -18,6 +19,33 @@ public class LoginLinkVisualTests : AcceptanceTestBase
         var animationName = await loginLink.EvaluateAsync<string>(
             "el => getComputedStyle(el).animationName");
         animationName.ShouldNotBe("none");
+    }
+
+    [Test, Retry(2)]
+    public async Task LoginLink_OpacityDipsBelowThreshold_WhenMotionAllowed()
+    {
+        await Page.EmulateMediaAsync(new PageEmulateMediaOptions { ReducedMotion = ReducedMotion.NoPreference });
+        await EnsureLoggedOutAsync();
+
+        var loginLink = Page.GetByTestId(nameof(LoginLink.Elements.LoginLink));
+        await Expect(loginLink).ToBeVisibleAsync();
+
+        const double dimThreshold = 0.55;
+        var sawDim = false;
+        for (var i = 0; i < 30; i++)
+        {
+            var opacity = await loginLink.EvaluateAsync<double>(
+                "el => parseFloat(getComputedStyle(el).opacity)");
+            if (opacity < dimThreshold)
+            {
+                sawDim = true;
+                break;
+            }
+
+            await Task.Delay(80);
+        }
+
+        sawDim.ShouldBeTrue("login link opacity should dip during login-prompt-emphasis when motion is allowed");
     }
 
     [Test, Retry(2)]

--- a/src/IntegrationTests/LlmGateway/ApplicationChatHandlerTests.cs
+++ b/src/IntegrationTests/LlmGateway/ApplicationChatHandlerTests.cs
@@ -7,7 +7,11 @@ using Shouldly;
 
 namespace ClearMeasure.Bootcamp.IntegrationTests.LlmGateway;
 
-[TestFixture]
+/// <summary>
+/// Uses the shared <see cref="TestHost"/> database; parallel tests elsewhere call
+/// <c>DatabaseTests.Clean()</c> and can wipe rows between LLM work and DB assertions.
+/// </summary>
+[TestFixture, NonParallelizable]
 public class ApplicationChatHandlerTests : LlmTestBase
 {
     [Test]

--- a/src/UI.Shared/Components/LoginLink.razor.css
+++ b/src/UI.Shared/Components/LoginLink.razor.css
@@ -13,13 +13,13 @@
 
 @media (prefers-reduced-motion: no-preference) {
 	.login-prompt-link {
-		animation: login-prompt-emphasis 0.85s ease-in-out infinite;
+		animation: login-prompt-emphasis 1.15s ease-in-out infinite;
 		will-change: transform, opacity, box-shadow, filter;
 	}
 }
 
 @keyframes login-prompt-emphasis {
-	0%, 100% {
+	0%, 12% {
 		opacity: 1;
 		transform: scale(1);
 		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.85), 0 4px 18px rgba(221, 107, 32, 0.55);
@@ -27,29 +27,37 @@
 		filter: brightness(1);
 		text-shadow: 0 0 0 transparent;
 	}
-	40% {
-		opacity: 1;
-		transform: scale(1.08);
-		box-shadow: 0 0 0 10px rgba(221, 107, 32, 0.4), 0 0 0 3px rgba(255, 255, 255, 0.95), 0 8px 26px rgba(221, 107, 32, 0.7);
-		border-color: #dd6b20;
-		filter: brightness(1.12);
-		text-shadow: 0 0 12px rgba(255, 255, 255, 0.95), 0 0 20px rgba(255, 200, 50, 0.9);
-	}
-	48% {
-		opacity: 0.15;
-		transform: scale(0.92);
-		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.35), 0 2px 6px rgba(0, 0, 0, 0.2);
-		border-color: #9b2c2c;
-		filter: brightness(0.75);
+	18%, 24% {
+		opacity: 0.04;
+		transform: scale(0.86);
+		box-shadow: 0 0 0 0 transparent, 0 2px 4px rgba(0, 0, 0, 0.35);
+		border-color: #742a2a;
+		filter: brightness(0.45);
 		text-shadow: none;
 	}
-	52% {
+	35%, 48% {
 		opacity: 1;
 		transform: scale(1.12);
-		box-shadow: 0 0 0 14px rgba(255, 214, 10, 0.5), 0 0 0 4px rgba(255, 255, 255, 1), 0 10px 32px rgba(221, 107, 32, 0.75);
+		box-shadow: 0 0 0 14px rgba(255, 214, 10, 0.55), 0 0 0 4px rgba(255, 255, 255, 1), 0 10px 32px rgba(221, 107, 32, 0.8);
+		border-color: #dd6b20;
+		filter: brightness(1.22);
+		text-shadow: 0 0 14px rgba(255, 255, 255, 1), 0 0 28px rgba(255, 180, 0, 0.95);
+	}
+	54%, 60% {
+		opacity: 0.04;
+		transform: scale(0.86);
+		box-shadow: 0 0 0 0 transparent, 0 2px 4px rgba(0, 0, 0, 0.35);
+		border-color: #742a2a;
+		filter: brightness(0.45);
+		text-shadow: none;
+	}
+	72%, 100% {
+		opacity: 1;
+		transform: scale(1.05);
+		box-shadow: 0 0 0 8px rgba(221, 107, 32, 0.45), 0 0 0 2px rgba(255, 255, 255, 0.9), 0 8px 24px rgba(221, 107, 32, 0.65);
 		border-color: #c05621;
-		filter: brightness(1.2);
-		text-shadow: 0 0 14px rgba(255, 255, 255, 1), 0 0 24px rgba(255, 180, 0, 0.95);
+		filter: brightness(1.1);
+		text-shadow: 0 0 10px rgba(255, 255, 255, 0.9), 0 0 18px rgba(255, 200, 50, 0.85);
 	}
 }
 

--- a/src/UI.Shared/Components/LoginLink.razor.css
+++ b/src/UI.Shared/Components/LoginLink.razor.css
@@ -16,10 +16,22 @@
 		animation: login-prompt-emphasis 1.15s ease-in-out infinite;
 		will-change: transform, opacity, box-shadow, filter;
 	}
+
+	/* Keep focus ring and label readable while tabbing (opacity animation paused). */
+	.login-prompt-link:focus-visible {
+		animation: none;
+		opacity: 1;
+		transform: scale(1);
+		filter: brightness(1);
+		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.85), 0 4px 18px rgba(221, 107, 32, 0.55);
+		border-color: #c05621;
+		text-shadow: none;
+	}
 }
 
 @keyframes login-prompt-emphasis {
-	0%, 12% {
+	/* 100% must match 0% so the infinite loop has no jump. */
+	0%, 8%, 92%, 100% {
 		opacity: 1;
 		transform: scale(1);
 		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.85), 0 4px 18px rgba(221, 107, 32, 0.55);
@@ -27,15 +39,15 @@
 		filter: brightness(1);
 		text-shadow: 0 0 0 transparent;
 	}
-	18%, 24% {
-		opacity: 0.04;
-		transform: scale(0.86);
-		box-shadow: 0 0 0 0 transparent, 0 2px 4px rgba(0, 0, 0, 0.35);
+	14%, 20% {
+		opacity: 0.38;
+		transform: scale(0.9);
+		box-shadow: 0 0 0 0 transparent, 0 2px 6px rgba(0, 0, 0, 0.28);
 		border-color: #742a2a;
-		filter: brightness(0.45);
+		filter: brightness(0.72);
 		text-shadow: none;
 	}
-	35%, 48% {
+	32%, 44% {
 		opacity: 1;
 		transform: scale(1.12);
 		box-shadow: 0 0 0 14px rgba(255, 214, 10, 0.55), 0 0 0 4px rgba(255, 255, 255, 1), 0 10px 32px rgba(221, 107, 32, 0.8);
@@ -43,15 +55,15 @@
 		filter: brightness(1.22);
 		text-shadow: 0 0 14px rgba(255, 255, 255, 1), 0 0 28px rgba(255, 180, 0, 0.95);
 	}
-	54%, 60% {
-		opacity: 0.04;
-		transform: scale(0.86);
-		box-shadow: 0 0 0 0 transparent, 0 2px 4px rgba(0, 0, 0, 0.35);
+	50%, 56% {
+		opacity: 0.38;
+		transform: scale(0.9);
+		box-shadow: 0 0 0 0 transparent, 0 2px 6px rgba(0, 0, 0, 0.28);
 		border-color: #742a2a;
-		filter: brightness(0.45);
+		filter: brightness(0.72);
 		text-shadow: none;
 	}
-	72%, 100% {
+	68%, 84% {
 		opacity: 1;
 		transform: scale(1.05);
 		box-shadow: 0 0 0 8px rgba(221, 107, 32, 0.45), 0 0 0 2px rgba(255, 255, 255, 0.9), 0 8px 24px rgba(221, 107, 32, 0.65);


### PR DESCRIPTION
## Summary

The header **Login** link (shown when unauthenticated) uses a stronger `login-prompt-emphasis` animation: two dim phases per cycle, seamless loop (`0%`/`100%` aligned), minimum opacity **0.38** (still an obvious blink, not near-invisible). While `:focus-visible`, animation is **paused** and the link resets to full opacity so the focus ring stays usable.

`NeedsRebootHealthCheckTests` and `ApplicationChatHandlerTests` are `[NonParallelizable]` (static flag + shared SQLite `TestHost` DB races on parallel CI).

**New acceptance coverage:** `LoginLink_OpacityDipsBelowThreshold_WhenMotionAllowed` samples computed opacity over ~2.4s and requires a dip below 0.55 when `prefers-reduced-motion` is off.

Closes #1611

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/Components/LoginLink.razor.css` | Seamless keyframes, dim at 0.38, `:focus-visible` pauses animation |
| `src/AcceptanceTests/Authentication/LoginLinkVisualTests.cs` | Explicit `NoPreference` for animation test; opacity dip test |
| `src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs` | `[NonParallelizable]` |
| `src/IntegrationTests/LlmGateway/ApplicationChatHandlerTests.cs` | `[NonParallelizable]` |

## Testing

- `Build -UseSqlite`: unit + integration green.
