### PR TITLE
New API endpoint POST /api/tools/hash for computing SHA-256 hashes of text input (#1618)

### DIFF
--- a/src/IntegrationTests/Api/ToolsHashEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ToolsHashEndpointIntegrationTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ToolsHashEndpointIntegrationTests
+{
+    private DetailedHealthWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DetailedHealthWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndSha256_When_PostUnversionedPath()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new { text = "hello" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ToolsHashResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload.Sha256.ShouldBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+        payload.Md5.ShouldBeNull();
+        payload.Sha1.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task Should_Return200AndAllHashes_When_IncludeLegacyHashesTrue()
+    {
+        var response = await _client!.PostAsJsonAsync(
+            "/api/v1.0/tools/hash",
+            new { text = "abc", includeLegacyHashes = true });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ToolsHashResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload.Sha256.ShouldBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+        payload.Md5.ShouldBe("900150983cd24fb0d6963f7d28e17f72");
+        payload.Sha1.ShouldBe("a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    [Test]
+    public async Task Should_Return400_When_TextMissing()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new { });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+}

--- a/src/UI/Api/Controllers/ToolsHashController.cs
+++ b/src/UI/Api/Controllers/ToolsHashController.cs
@@ -1,0 +1,56 @@
+using System.Security.Cryptography;
+using System.Text;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Computes cryptographic digests of arbitrary text (UTF-8).
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/hash")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/hash")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsHashController : ControllerBase
+{
+    /// <summary>
+    /// Returns the SHA-256 hash of the request <c>text</c>. When <c>includeLegacyHashes</c> is true,
+    /// also returns MD5 and SHA-1 digests (hexadecimal, lowercase).
+    /// </summary>
+    [HttpPost]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ToolsHashResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Post([FromBody] ToolsHashRequest? request)
+    {
+        if (request?.Text is null)
+        {
+            return Problem(
+                detail: "A non-null \"text\" field is required in the JSON body.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var utf8 = Encoding.UTF8.GetBytes(request.Text);
+        var sha256Hex = Convert.ToHexStringLower(SHA256.HashData(utf8));
+
+        if (!request.IncludeLegacyHashes)
+        {
+            return Ok(new ToolsHashResponse { Sha256 = sha256Hex });
+        }
+
+        var md5Hex = Convert.ToHexStringLower(MD5.HashData(utf8));
+        var sha1Hex = Convert.ToHexStringLower(SHA1.HashData(utf8));
+        return Ok(new ToolsHashResponse
+        {
+            Sha256 = sha256Hex,
+            Md5 = md5Hex,
+            Sha1 = sha1Hex
+        });
+    }
+}

--- a/src/UI/Api/ToolsHashModels.cs
+++ b/src/UI/Api/ToolsHashModels.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON body for <c>POST /api/tools/hash</c>.
+/// </summary>
+public sealed record ToolsHashRequest(
+    string? Text,
+    bool IncludeLegacyHashes = false);
+
+/// <summary>
+/// JSON response for <c>POST /api/tools/hash</c>.
+/// </summary>
+public sealed record ToolsHashResponse
+{
+    /// <summary>
+    /// Lowercase hexadecimal SHA-256 digest of <see cref="ToolsHashRequest.Text"/> using UTF-8 encoding.
+    /// </summary>
+    [JsonPropertyName("sha256")]
+    public required string Sha256 { get; init; }
+
+    /// <summary>
+    /// Present when <see cref="ToolsHashRequest.IncludeLegacyHashes"/> was true.
+    /// </summary>
+    [JsonPropertyName("md5")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Md5 { get; init; }
+
+    /// <summary>
+    /// Present when <see cref="ToolsHashRequest.IncludeLegacyHashes"/> was true.
+    /// </summary>
+    [JsonPropertyName("sha1")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Sha1 { get; init; }
+}

--- a/src/UnitTests/UI.Api/ToolsHashControllerTests.cs
+++ b/src/UnitTests/UI.Api/ToolsHashControllerTests.cs
@@ -1,0 +1,83 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsHashControllerTests
+{
+    [Test]
+    public void Post_Should_Return400_When_RequestIsNull()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Post_Should_Return400_When_TextIsNull()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new ToolsHashRequest(null));
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Post_Should_ReturnSha256Only_When_LegacyNotRequested()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new ToolsHashRequest("hello", IncludeLegacyHashes: false));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<ToolsHashResponse>();
+        payload.Sha256.ShouldBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+        payload.Md5.ShouldBeNull();
+        payload.Sha1.ShouldBeNull();
+    }
+
+    [Test]
+    public void Post_Should_ReturnEmptyStringDigests_When_TextIsEmpty()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new ToolsHashRequest("", IncludeLegacyHashes: true));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<ToolsHashResponse>();
+        payload.Sha256.ShouldBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        payload.Md5.ShouldBe("d41d8cd98f00b204e9800998ecf8427e");
+        payload.Sha1.ShouldBe("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    }
+
+    [Test]
+    public void Post_Should_ReturnLegacyHashes_When_Requested()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new ToolsHashRequest("abc", IncludeLegacyHashes: true));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<ToolsHashResponse>();
+        payload.Sha256.ShouldBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+        payload.Md5.ShouldBe("900150983cd24fb0d6963f7d28e17f72");
+        payload.Sha1.ShouldBe("a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    private static ToolsHashController CreateController()
+    {
+        return new ToolsHashController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
Adds `POST /api/tools/hash` (and versioned `POST /api/v1.0/tools/hash`) for computing digests of request text using UTF-8. The response always includes `sha256` (lowercase hex). When the request sets `includeLegacyHashes` to `true`, the response also includes `md5` and `sha1`.

## Files changed
- `src/UI/Api/ToolsHashModels.cs` — request/response DTOs with JSON property names.
- `src/UI/Api/Controllers/ToolsHashController.cs` — endpoint implementation, anonymous, rate-limited like other API controllers.
- `src/UnitTests/UI.Api/ToolsHashControllerTests.cs` — controller unit tests.
- `src/IntegrationTests/Api/ToolsHashEndpointIntegrationTests.cs` — in-process HTTP tests against UI.Server.

## Testing
- `dotnet test` filters for the new unit and integration test classes.
- Full `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` (244 unit + 100 integration tests passed).

Closes #1618