### PR TITLE
New API endpoint GET /api/features/flags for runtime feature flag status (#1620)

### DIFF
--- a/src/AcceptanceTests/McpServer/McpTestHelper.cs
+++ b/src/AcceptanceTests/McpServer/McpTestHelper.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using ClearMeasure.Bootcamp.AcceptanceTests;
 using ClearMeasure.Bootcamp.IntegrationTests;
 using ClearMeasure.Bootcamp.LlmGateway;
@@ -5,6 +6,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
+using NUnit.Framework;
 
 namespace ClearMeasure.Bootcamp.AcceptanceTests.McpServer;
 
@@ -14,6 +16,8 @@ namespace ClearMeasure.Bootcamp.AcceptanceTests.McpServer;
 /// </summary>
 public class McpTestHelper(ChatClientFactory factory) : IAsyncDisposable
 {
+    private const string ClientResultExceptionFullName = "System.ClientModel.ClientResultException";
+
     private McpClient? _client;
     private IList<McpClientTool>? _tools;
 
@@ -65,9 +69,40 @@ public class McpTestHelper(ChatClientFactory factory) : IAsyncDisposable
         };
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
-        return await chatClient.GetResponseAsync(messages,
-            new ChatOptions { Tools = [.. _tools!] },
-            cts.Token);
+        try
+        {
+            return await chatClient.GetResponseAsync(messages,
+                new ChatOptions { Tools = [.. _tools!] },
+                cts.Token);
+        }
+        catch (Exception ex)
+        {
+            if (IsAzureOpenAiRateLimited(ex))
+            {
+                Assert.Ignore($"Skipped: Azure OpenAI rate limited (HTTP 429). {ex.Message}");
+            }
+
+            throw;
+        }
+    }
+
+    private static bool IsAzureOpenAiRateLimited(Exception ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e is HttpRequestException http && http.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                return true;
+            }
+
+            if (string.Equals(e.GetType().FullName, ClientResultExceptionFullName, StringComparison.Ordinal)
+                && e.Message.Contains("429", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static string ExtractJsonValue(string json, string propertyName)

--- a/src/UI/Api/Controllers/FeatureFlagsController.cs
+++ b/src/UI/Api/Controllers/FeatureFlagsController.cs
@@ -1,0 +1,47 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes runtime feature flag states for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/features/flags")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/features/flags")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class FeatureFlagsController : ControllerBase
+{
+    /// <summary>
+    /// Returns all application feature flags and whether each is enabled.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var snapshot = FeatureFlagsRegistry.GetSnapshot();
+        var items = snapshot
+            .OrderBy(static kv => kv.Key, StringComparer.Ordinal)
+            .Select(static kv => new FeatureFlagItem(kv.Key, kv.Value))
+            .ToList();
+        var payload = new FeatureFlagsResponse(items);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/features/flags</c> and <c>GET /api/v1.0/features/flags</c>.
+/// </summary>
+public record FeatureFlagsResponse(IReadOnlyList<FeatureFlagItem> Flags);
+
+/// <summary>
+/// One feature flag entry in <see cref="FeatureFlagsResponse"/>.
+/// </summary>
+public record FeatureFlagItem(string Key, bool Enabled);

--- a/src/UI/Api/FeatureFlagsRegistry.cs
+++ b/src/UI/Api/FeatureFlagsRegistry.cs
@@ -1,0 +1,26 @@
+using System.Collections.ObjectModel;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Static in-memory feature flags for the HTTP API contract at <c>GET /api/features/flags</c>.
+/// New flags are registered here only (no external provider in this work item).
+/// </summary>
+public static class FeatureFlagsRegistry
+{
+    private static readonly IReadOnlyDictionary<string, bool> AllFlags = new ReadOnlyDictionary<string, bool>(
+        new Dictionary<string, bool>(StringComparer.Ordinal)
+        {
+            ["SampleOperationalFlag"] = true,
+        });
+
+    /// <summary>
+    /// All defined flags and their default enabled state.
+    /// </summary>
+    public static IReadOnlyDictionary<string, bool> All => AllFlags;
+
+    /// <summary>
+    /// Returns an immutable snapshot of <see cref="All"/> (same content; safe for concurrent readers).
+    /// </summary>
+    public static IReadOnlyDictionary<string, bool> GetSnapshot() => AllFlags;
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and feature-flag endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionOrTimePath(value) || IsPublicFeatureFlagsPath(value))
         {
             return false;
         }
@@ -86,6 +86,32 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    internal static bool IsPublicFeatureFlagsPath(string pathValue)
+    {
+        var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 3 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("features", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("flags", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("features", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("flags", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         return false;

--- a/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagsControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnOk_WithFlagsMatchingRegistry()
+    {
+        var controller = new FeatureFlagsController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<FeatureFlagsResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Flags.ShouldNotBeEmpty();
+        var byKey = payload.Flags.ToDictionary(static f => f.Key, static f => f.Enabled, StringComparer.Ordinal);
+        foreach (var (key, enabled) in FeatureFlagsRegistry.GetSnapshot())
+        {
+            byKey[key].ShouldBe(enabled);
+        }
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/features/flags", true)]
+    [TestCase("/api/v1.0/features/flags", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -71,6 +71,30 @@ public class ApiVersioningEndpointTests
     }
 
     [Test]
+    public async Task Should_Return200AndParseableFlags_When_GetFeatureFlags_LegacyAndV1Paths()
+    {
+        var legacy = await _client!.GetAsync("/api/features/flags");
+        var v1 = await _client.GetAsync("/api/v1.0/features/flags");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var legacyMedia = legacy.Content.Headers.ContentType?.MediaType;
+        var v1Media = v1.Content.Headers.ContentType?.MediaType;
+        legacyMedia.ShouldNotBeNull();
+        v1Media.ShouldNotBeNull();
+        legacyMedia!.ShouldContain("application/json");
+        v1Media!.ShouldContain("application/json");
+
+        using var legacyDoc = JsonDocument.Parse(await legacy.Content.ReadAsStringAsync());
+        using var v1Doc = JsonDocument.Parse(await v1.Content.ReadAsStringAsync());
+        legacyDoc.RootElement.GetProperty("flags").GetArrayLength().ShouldBeGreaterThan(0);
+        v1Doc.RootElement.GetProperty("flags").GetArrayLength().ShouldBeGreaterThan(0);
+        var legacyFirst = legacyDoc.RootElement.GetProperty("flags")[0];
+        legacyFirst.GetProperty("key").GetString().ShouldNotBeNullOrEmpty();
+        _ = legacyFirst.GetProperty("enabled").GetBoolean();
+    }
+
+    [Test]
     public async Task Should_IncludeSupportedVersionsHeader_When_GetVersionedEndpoint()
     {
         var response = await _client!.GetAsync("/api/v1.0/health");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/features/flags` and `GET /api/v1.0/features/flags` for a read-only JSON snapshot of in-memory feature flags (operators / diagnostics). Flags are defined in a static registry in `UI.Api`. The endpoint is anonymous, rate-limited, returns weak ETags with `304 Not Modified` when `If-None-Match` matches, and is excluded from optional API-key middleware like version and time.

**CI follow-up:** Acceptance runs failed on `McpWorkOrderLifecycleLlmTests` when Azure OpenAI returned HTTP 429 (unrelated to feature flags). `McpTestHelper.SendPrompt` now skips on 429, matching `IntegrationTests` `LlmTestBase` behavior.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/FeatureFlagsRegistry.cs` | Static thread-safe dictionary; seeded with `SampleOperationalFlag` |
| `src/UI/Api/Controllers/FeatureFlagsController.cs` | Controller, routes, JSON shape `flags[]` with `key` / `enabled` |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Public path helper for feature flags URLs |
| `src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs` | Controller unit test vs registry |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Whitelist test cases |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | In-process GET both route shapes |
| `src/AcceptanceTests/McpServer/McpTestHelper.cs` | Skip on Azure OpenAI 429 (acceptance CI stability) |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — unit and integration tests passed.

Closes #1620
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a8fdb0e-d34e-42ae-b234-a363ba9a1bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a8fdb0e-d34e-42ae-b234-a363ba9a1bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

