### PR TITLE
New API endpoint GET /api/tools/timestamp-converter for epoch and ISO conversions (#1619)

### DIFF
--- a/src/UI/Api/Controllers/TimestampConverterController.cs
+++ b/src/UI/Api/Controllers/TimestampConverterController.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Converts between Unix epoch timestamps and ISO-8601 instants for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/timestamp-converter")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/timestamp-converter")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class TimestampConverterController : ControllerBase
+{
+    private static readonly Regex EpochIntegerPattern = new(@"^-?\d+$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Converts the supplied <paramref name="value"/> (Unix epoch seconds or milliseconds, or ISO-8601) to multiple representations.
+    /// </summary>
+    /// <param name="value">Unix epoch (integer seconds or milliseconds) or an ISO-8601 date/time string.</param>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get([FromQuery] string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return BadRequest(new { error = "Query parameter 'value' is required." });
+
+        var trimmed = value.Trim();
+        if (!TryParseInstant(trimmed, out var instant, out var inputKind, out var error))
+            return BadRequest(new { error = error });
+
+        var utc = instant.UtcDateTime;
+        var payload = new TimestampConverterResponse(
+            InputKind: inputKind,
+            UnixSeconds: instant.ToUnixTimeSeconds(),
+            UnixMilliseconds: instant.ToUnixTimeMilliseconds(),
+            Iso8601Utc: utc.ToString("O", CultureInfo.InvariantCulture),
+            Iso8601WithOffset: instant.ToString("O", CultureInfo.InvariantCulture),
+            UtcRfc1123: utc.ToString("R", CultureInfo.InvariantCulture),
+            UtcLongDateString: utc.ToString("D", CultureInfo.InvariantCulture) + " " + utc.ToString("T", CultureInfo.InvariantCulture) + " UTC");
+
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+
+    private static bool TryParseInstant(
+        string trimmed,
+        out DateTimeOffset instant,
+        out string inputKind,
+        out string? error)
+    {
+        instant = default;
+        inputKind = "";
+        error = null;
+
+        if (EpochIntegerPattern.IsMatch(trimmed))
+        {
+            if (!long.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n))
+            {
+                error = "Epoch value is not a valid integer.";
+                return false;
+            }
+
+            var abs = n == long.MinValue ? ulong.MaxValue / 2 + 1 : (ulong)Math.Abs(n);
+            var asMs = abs >= 10_000_000_000UL;
+            try
+            {
+                instant = asMs
+                    ? DateTimeOffset.FromUnixTimeMilliseconds(n)
+                    : DateTimeOffset.FromUnixTimeSeconds(n);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                error = "Epoch value is out of the supported date range.";
+                return false;
+            }
+
+            inputKind = asMs ? "UnixEpochMilliseconds" : "UnixEpochSeconds";
+            return true;
+        }
+
+        if (DateTimeOffset.TryParse(trimmed, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+        {
+            instant = parsed;
+            inputKind = "Iso8601";
+            return true;
+        }
+
+        error = "Value is not a recognized Unix epoch integer or ISO-8601 date/time.";
+        return false;
+    }
+}
+
+/// <summary>
+/// JSON payload for timestamp conversion responses.
+/// </summary>
+public record TimestampConverterResponse(
+    string InputKind,
+    long UnixSeconds,
+    long UnixMilliseconds,
+    string Iso8601Utc,
+    string Iso8601WithOffset,
+    string UtcRfc1123,
+    string UtcLongDateString);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and timestamp-converter tool endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionOrTimeOrTimestampConverterPath(value))
         {
             return false;
         }
@@ -65,7 +65,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicVersionOrTimeOrTimestampConverterPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
@@ -84,8 +84,26 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
             var leaf = segments[2];
-            return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+            if (leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
+                || leaf.Equals("time", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        if (segments.Length >= 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         return false;

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -1,0 +1,92 @@
+using System.Globalization;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnBadRequest_WhenValueMissing()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(null);
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Test]
+    public void Get_Should_ReturnJsonWithEpochAndIso_WhenValueIsUnixSeconds()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("1700000000");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        var dto = JsonSerializer.Deserialize<TimestampConverterResponse>(content.Content!, ConditionalGetEtag.JsonSerializerOptions);
+        dto.ShouldNotBeNull();
+        dto.InputKind.ShouldBe("UnixEpochSeconds");
+        dto.UnixSeconds.ShouldBe(1700000000L);
+        dto.UnixMilliseconds.ShouldBe(1700000000000L);
+        dto.Iso8601Utc.ShouldBe("2023-11-14T22:13:20.0000000Z");
+    }
+
+    [Test]
+    public void Get_Should_ClassifyMilliseconds_WhenEpochHasManyDigits()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("1700000000000");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var dto = JsonSerializer.Deserialize<TimestampConverterResponse>(content.Content!, ConditionalGetEtag.JsonSerializerOptions);
+        dto!.InputKind.ShouldBe("UnixEpochMilliseconds");
+        dto.UnixSeconds.ShouldBe(1700000000L);
+    }
+
+    [Test]
+    public void Get_Should_PreserveOffsetInIso8601WithOffset_WhenIsoHasOffset()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("2024-06-01T12:00:00-05:00");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var dto = JsonSerializer.Deserialize<TimestampConverterResponse>(content.Content!, ConditionalGetEtag.JsonSerializerOptions);
+        dto!.InputKind.ShouldBe("Iso8601");
+        dto.Iso8601WithOffset.ShouldContain("-05:00");
+        dto.UnixSeconds.ShouldBe(DateTimeOffset.Parse("2024-06-01T12:00:00-05:00", null, DateTimeStyles.RoundtripKind).ToUnixTimeSeconds());
+    }
+
+    [Test]
+    public void Get_Should_ReturnBadRequest_WhenValueNotRecognized()
+    {
+        var controller = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("not-a-timestamp");
+
+        result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/tools/timestamp-converter", true)]
+    [TestCase("/api/v1.0/tools/timestamp-converter", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -65,4 +65,15 @@ public class ApiKeyAuthenticationWebTests
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return200_When_TimestampConverterWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/tools/timestamp-converter?value=1700000000");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }


### PR DESCRIPTION
## Summary

Adds `GET /api/tools/timestamp-converter` (and versioned `GET /api/v{version}/tools/timestamp-converter`) with required query `value`. Accepts Unix epoch integers (seconds vs milliseconds inferred when absolute value ≥ 10,000,000,000) or ISO-8601 strings. Response JSON includes `inputKind`, `unixSeconds`, `unixMilliseconds`, `iso8601Utc`, `iso8601WithOffset`, `utcRfc1123`, and `utcLongDateString`. Uses weak ETag with `If-None-Match` → 304. Rate limiting matches other API controllers. When optional API key auth is enabled, this path is treated as public (same category as `/api/time`).

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/TimestampConverterController.cs` | New controller and response DTO |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Public bypass for timestamp-converter; fix versioned path handling so only `/api/v*/version` and `/api/v*/time` short-circuit early |
| `src/UnitTests/UI.Api/TimestampConverterControllerTests.cs` | Controller unit tests |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | New public-path cases |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Integration-style test without API key |

## Testing

- `dotnet test` (UnitTests): TimestampConverter and API key suites
- `DATABASE_ENGINE=SQLite` `./PrivateBuild.ps1`: all unit + integration tests green

Closes #1619
