### PR TITLE
Make the login button blink obviously (#1721)

### DIFF
--- a/src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs
+++ b/src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
 
 [TestFixture]
+[NonParallelizable]
 public class NeedsRebootHealthCheckTests : AcceptanceTestBase
 {
     protected override bool RequiresBrowser => false;

--- a/src/AcceptanceTests/Authentication/LoginLinkVisualTests.cs
+++ b/src/AcceptanceTests/Authentication/LoginLinkVisualTests.cs
@@ -24,26 +24,24 @@ public class LoginLinkVisualTests : AcceptanceTestBase
             "el => getComputedStyle(el).animationDuration");
         ParseCssSeconds(durationText).ShouldBeGreaterThanOrEqualTo(1.5);
 
-        var minOpacity = 1.0;
-        var maxOpacity = 0.0;
-        for (var i = 0; i < 45; i++)
-        {
-            var opacity = await loginLink.EvaluateAsync<double>(
-                "el => parseFloat(getComputedStyle(el).opacity)");
-            if (opacity < minOpacity)
-            {
-                minOpacity = opacity;
+        var opacityDeltaSeen = await loginLink.EvaluateAsync<bool>(
+            """
+            async el => {
+                let minO = 1;
+                let maxO = 0;
+                const threshold = 0.2;
+                const deadline = performance.now() + 4500;
+                while (performance.now() < deadline) {
+                    const o = parseFloat(getComputedStyle(el).opacity);
+                    if (o < minO) minO = o;
+                    if (o > maxO) maxO = o;
+                    if (maxO - minO > threshold) return true;
+                    await new Promise(r => requestAnimationFrame(r));
+                }
+                return maxO - minO > threshold;
             }
-
-            if (opacity > maxOpacity)
-            {
-                maxOpacity = opacity;
-            }
-
-            await Page.WaitForTimeoutAsync(100);
-        }
-
-        (maxOpacity - minOpacity).ShouldBeGreaterThan(0.2);
+            """);
+        opacityDeltaSeen.ShouldBeTrue();
     }
 
     [Test, Retry(2)]

--- a/src/AcceptanceTests/Authentication/LoginLinkVisualTests.cs
+++ b/src/AcceptanceTests/Authentication/LoginLinkVisualTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using ClearMeasure.Bootcamp.UI.Shared.Components;
 using Microsoft.Playwright;
 using Shouldly;
@@ -18,6 +19,31 @@ public class LoginLinkVisualTests : AcceptanceTestBase
         var animationName = await loginLink.EvaluateAsync<string>(
             "el => getComputedStyle(el).animationName");
         animationName.ShouldNotBe("none");
+
+        var durationText = await loginLink.EvaluateAsync<string>(
+            "el => getComputedStyle(el).animationDuration");
+        ParseCssSeconds(durationText).ShouldBeGreaterThanOrEqualTo(1.5);
+
+        var minOpacity = 1.0;
+        var maxOpacity = 0.0;
+        for (var i = 0; i < 45; i++)
+        {
+            var opacity = await loginLink.EvaluateAsync<double>(
+                "el => parseFloat(getComputedStyle(el).opacity)");
+            if (opacity < minOpacity)
+            {
+                minOpacity = opacity;
+            }
+
+            if (opacity > maxOpacity)
+            {
+                maxOpacity = opacity;
+            }
+
+            await Page.WaitForTimeoutAsync(100);
+        }
+
+        (maxOpacity - minOpacity).ShouldBeGreaterThan(0.2);
     }
 
     [Test, Retry(2)]
@@ -93,5 +119,21 @@ public class LoginLinkVisualTests : AcceptanceTestBase
             await logoutLink.ClickAsync();
             await Page.WaitForURLAsync("**/");
         }
+    }
+
+    private static double ParseCssSeconds(string value)
+    {
+        var token = value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)[0];
+        if (token.EndsWith("ms", StringComparison.Ordinal))
+        {
+            return double.Parse(token[..^2], CultureInfo.InvariantCulture) / 1000.0;
+        }
+
+        if (token.EndsWith('s'))
+        {
+            return double.Parse(token[..^1], CultureInfo.InvariantCulture);
+        }
+
+        return double.Parse(token, CultureInfo.InvariantCulture);
     }
 }

--- a/src/UI.Shared/Components/LoginLink.razor.css
+++ b/src/UI.Shared/Components/LoginLink.razor.css
@@ -13,7 +13,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
 	.login-prompt-link {
-		animation: login-prompt-emphasis 0.85s ease-in-out infinite;
+		animation: login-prompt-emphasis 2.6s ease-in-out infinite;
 		will-change: transform, opacity, box-shadow, filter;
 	}
 }
@@ -27,29 +27,69 @@
 		filter: brightness(1);
 		text-shadow: 0 0 0 transparent;
 	}
-	40% {
+	12% {
 		opacity: 1;
-		transform: scale(1.08);
-		box-shadow: 0 0 0 10px rgba(221, 107, 32, 0.4), 0 0 0 3px rgba(255, 255, 255, 0.95), 0 8px 26px rgba(221, 107, 32, 0.7);
+		transform: scale(1.1);
+		box-shadow: 0 0 0 12px rgba(221, 107, 32, 0.45), 0 0 0 4px rgba(255, 255, 255, 0.95), 0 8px 28px rgba(221, 107, 32, 0.72);
 		border-color: #dd6b20;
-		filter: brightness(1.12);
-		text-shadow: 0 0 12px rgba(255, 255, 255, 0.95), 0 0 20px rgba(255, 200, 50, 0.9);
+		filter: brightness(1.15);
+		text-shadow: 0 0 14px rgba(255, 255, 255, 0.95), 0 0 22px rgba(255, 200, 50, 0.85);
 	}
-	48% {
-		opacity: 0.15;
-		transform: scale(0.92);
-		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.35), 0 2px 6px rgba(0, 0, 0, 0.2);
-		border-color: #9b2c2c;
-		filter: brightness(0.75);
+	18% {
+		opacity: 0.06;
+		transform: scale(0.9);
+		box-shadow: 0 0 0 2px rgba(74, 85, 104, 0.35), 0 2px 8px rgba(0, 0, 0, 0.25);
+		border-color: #744210;
+		filter: brightness(0.65);
 		text-shadow: none;
 	}
-	52% {
+	24% {
 		opacity: 1;
-		transform: scale(1.12);
-		box-shadow: 0 0 0 14px rgba(255, 214, 10, 0.5), 0 0 0 4px rgba(255, 255, 255, 1), 0 10px 32px rgba(221, 107, 32, 0.75);
+		transform: scale(1.08);
+		box-shadow: 0 0 0 10px rgba(255, 214, 10, 0.48), 0 0 0 3px rgba(255, 255, 255, 1), 0 10px 30px rgba(221, 107, 32, 0.78);
 		border-color: #c05621;
-		filter: brightness(1.2);
-		text-shadow: 0 0 14px rgba(255, 255, 255, 1), 0 0 24px rgba(255, 180, 0, 0.95);
+		filter: brightness(1.22);
+		text-shadow: 0 0 16px rgba(255, 255, 255, 1), 0 0 26px rgba(255, 180, 0, 0.9);
+	}
+	38% {
+		opacity: 1;
+		transform: scale(1);
+		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.85), 0 4px 18px rgba(221, 107, 32, 0.55);
+		border-color: #c05621;
+		filter: brightness(1);
+		text-shadow: 0 0 0 transparent;
+	}
+	50% {
+		opacity: 1;
+		transform: scale(1.1);
+		box-shadow: 0 0 0 12px rgba(221, 107, 32, 0.45), 0 0 0 4px rgba(255, 255, 255, 0.95), 0 8px 28px rgba(221, 107, 32, 0.72);
+		border-color: #dd6b20;
+		filter: brightness(1.15);
+		text-shadow: 0 0 14px rgba(255, 255, 255, 0.95), 0 0 22px rgba(255, 200, 50, 0.85);
+	}
+	56% {
+		opacity: 0.06;
+		transform: scale(0.9);
+		box-shadow: 0 0 0 2px rgba(74, 85, 104, 0.35), 0 2px 8px rgba(0, 0, 0, 0.25);
+		border-color: #744210;
+		filter: brightness(0.65);
+		text-shadow: none;
+	}
+	62% {
+		opacity: 1;
+		transform: scale(1.08);
+		box-shadow: 0 0 0 10px rgba(255, 214, 10, 0.48), 0 0 0 3px rgba(255, 255, 255, 1), 0 10px 30px rgba(221, 107, 32, 0.78);
+		border-color: #c05621;
+		filter: brightness(1.22);
+		text-shadow: 0 0 16px rgba(255, 255, 255, 1), 0 0 26px rgba(255, 180, 0, 0.9);
+	}
+	78% {
+		opacity: 1;
+		transform: scale(1);
+		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.85), 0 4px 18px rgba(221, 107, 32, 0.55);
+		border-color: #c05621;
+		filter: brightness(1);
+		text-shadow: 0 0 0 transparent;
 	}
 }
 


### PR DESCRIPTION
## Summary

The header **Login** link for anonymous users now uses a slower, more obvious **two-pulse** emphasis: each ~2.6s cycle includes two near-full opacity dips plus scale, glow, and brightness changes. `prefers-reduced-motion: reduce` still disables animation and keeps static high-contrast emphasis.

`NeedsRebootHealthCheckTests` mutates a static server flag; with parallel child tests another fixture could reset it mid-run. The class is marked `[NonParallelizable]` so those checks run sequentially (fixes ARM acceptance flake).

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/Components/LoginLink.razor.css` | Lengthened animation to 2.6s; keyframes repeat two blink sequences per cycle; deeper minimum opacity (~0.06). |
| `src/AcceptanceTests/Authentication/LoginLinkVisualTests.cs` | Assert `animationDuration` ≥ 1.5s; single `EvaluateAsync` polls opacity in the browser with `requestAnimationFrame` until delta > 0.2 (or 4.5s cap). |
| `src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs` | `[NonParallelizable]` to avoid races on static `NeedsReboot`. |

## Testing

- `DATABASE_ENGINE=SQLite` — `PrivateBuild.ps1` completed successfully (unit + integration).
- CI runs full acceptance suite including ARM.

Closes #1721