### PR TITLE
New API endpoint GET /api/tools/random for configurable random data generation (#1731)

### DIFF
--- a/src/UI/Api/Controllers/ToolsRandomController.cs
+++ b/src/UI/Api/Controllers/ToolsRandomController.cs
@@ -1,0 +1,101 @@
+using System.Text;
+using System.Text.Json.Serialization;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates non-cryptographic random samples for scripts and integrations. Do not use outputs as secrets.
+/// String values use <see cref="Random"/> over the alphanumeric ASCII alphabet (length 24).
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/random")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/random")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsRandomController(Random? random = null) : ControllerBase
+{
+    private const int AlphanumericLength = 24;
+    private const string AlphanumericAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    private readonly Random _random = random ?? Random.Shared;
+
+    /// <summary>
+    /// Returns a random value according to <paramref name="type"/>:
+    /// <c>number</c> (32-bit signed int), <c>string</c> (alphanumeric), <c>uuid</c>, or <c>color</c> (#RRGGBB).
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get([FromQuery] string type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return Problem(
+                detail: "Query parameter 'type' is required. Use number, string, uuid, or color.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var normalized = type.Trim();
+        ToolsRandomResponse? payload = null;
+
+        if (string.Equals(normalized, "number", StringComparison.OrdinalIgnoreCase))
+        {
+            payload = new ToolsRandomResponse("number", _random.Next());
+        }
+        else if (string.Equals(normalized, "string", StringComparison.OrdinalIgnoreCase))
+        {
+            payload = new ToolsRandomResponse("string", NextAlphanumeric(_random, AlphanumericLength));
+        }
+        else if (string.Equals(normalized, "uuid", StringComparison.OrdinalIgnoreCase))
+        {
+            payload = new ToolsRandomResponse("uuid", Guid.NewGuid().ToString("D"));
+        }
+        else if (string.Equals(normalized, "color", StringComparison.OrdinalIgnoreCase))
+        {
+            payload = new ToolsRandomResponse("color", NextCssHexColor(_random));
+        }
+
+        if (payload == null)
+        {
+            return Problem(
+                detail: $"Unsupported type '{type}'. Use number, string, uuid, or color.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+
+    private static string NextAlphanumeric(Random random, int length)
+    {
+        var sb = new StringBuilder(length);
+        for (var i = 0; i < length; i++)
+        {
+            sb.Append(AlphanumericAlphabet[random.Next(AlphanumericAlphabet.Length)]);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string NextCssHexColor(Random random) =>
+        string.Create(7, random.Next(0, 0x1000000), static (chars, rgb) =>
+        {
+            chars[0] = '#';
+            _ = rgb.TryFormat(chars[1..], out _, "x6");
+        });
+
+    /// <summary>
+    /// JSON body for <c>GET /api/tools/random</c>. <see cref="Value"/> is a number for type <c>number</c> or a string otherwise.
+    /// </summary>
+    public sealed record ToolsRandomResponse(
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("value")] object Value);
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and tools/random endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionOrTimePath(value) || IsPublicToolsRandomPath(value))
         {
             return false;
         }
@@ -86,6 +86,32 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    internal static bool IsPublicToolsRandomPath(string pathValue)
+    {
+        var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 3 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("random", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("random", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         return false;

--- a/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
+++ b/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsRandomControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJsonNumber_When_TypeIsNumber()
+    {
+        var stubRandom = new StubRandom { NextInt32Result = 424242 };
+        var controller = CreateController(stubRandom);
+
+        var result = controller.Get("number");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("number");
+        doc.RootElement.GetProperty("value").GetInt32().ShouldBe(424242);
+    }
+
+    [Test]
+    public void Get_Should_ReturnFixedAlphanumeric_When_TypeIsStringAndRandomReturnsZero()
+    {
+        var stubRandom = new StubRandom { NextBoundedResult = 0 };
+        var controller = CreateController(stubRandom);
+
+        var result = controller.Get("string");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("string");
+        doc.RootElement.GetProperty("value").GetString().ShouldBe(new string('A', 24));
+    }
+
+    [Test]
+    public void Get_Should_ReturnUuidFormat_When_TypeIsUuid()
+    {
+        var controller = CreateController(new StubRandom());
+
+        var result = controller.Get("uuid");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("uuid");
+        var value = doc.RootElement.GetProperty("value").GetString();
+        value.ShouldNotBeNull();
+        Guid.TryParseExact(value, "D", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_Should_ReturnCssHex_When_TypeIsColor()
+    {
+        var stubRandom = new StubRandom { NextMinMaxResult = 0xAbCdEf };
+        var controller = CreateController(stubRandom);
+
+        var result = controller.Get("color");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("color");
+        doc.RootElement.GetProperty("value").GetString().ShouldBe("#abcdef");
+    }
+
+    [TestCase("NUMBER")]
+    [TestCase("Uuid")]
+    public void Get_Should_AcceptTypeCaseInsensitively(string type)
+    {
+        var stubRandom = new StubRandom { NextInt32Result = 1, NextBoundedResult = 0, NextMinMaxResult = 0 };
+        var controller = CreateController(stubRandom);
+
+        var result = controller.Get(type);
+
+        result.ShouldBeOfType<ContentResult>();
+        ((ContentResult)result).StatusCode.ShouldBe(200);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_TypeMissing()
+    {
+        var controller = CreateController(new StubRandom());
+
+        var result = controller.Get(null!);
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_TypeUnknown()
+    {
+        var controller = CreateController(new StubRandom());
+
+        var result = controller.Get("binary");
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesEtag()
+    {
+        var stubRandom = new StubRandom { NextInt32Result = 99 };
+        var controller = CreateController(stubRandom);
+        var first = controller.Get("number");
+        var content = first.ShouldBeOfType<ContentResult>();
+        var etag = controller.Response.Headers.ETag.ToString();
+        etag.ShouldNotBeNullOrEmpty();
+
+        var secondContext = new DefaultHttpContext();
+        secondContext.Request.Headers.IfNoneMatch = etag;
+        var controller2 = new ToolsRandomController(stubRandom)
+        {
+            ControllerContext = new ControllerContext { HttpContext = secondContext }
+        };
+
+        var second = controller2.Get("number");
+
+        second.ShouldBeOfType<StatusCodeResult>();
+        ((StatusCodeResult)second).StatusCode.ShouldBe(304);
+    }
+
+    private static ToolsRandomController CreateController(Random random)
+    {
+        return new ToolsRandomController(random)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+    }
+
+    private sealed class StubRandom : Random
+    {
+        public int NextInt32Result { get; init; }
+        public int NextBoundedResult { get; init; }
+        public int NextMinMaxResult { get; init; }
+
+        public override int Next() => NextInt32Result;
+
+        public override int Next(int maxValue) => NextBoundedResult % maxValue;
+
+        public override int Next(int minValue, int maxValue) => NextMinMaxResult;
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -12,6 +12,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/tools/random", true)]
+    [TestCase("/api/v1.0/tools/random", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/tools/random?type=...` for anonymous, rate-limited random samples: `number` (32-bit int), `string` (24 alphanumeric chars via `Random`), `uuid` (`Guid` "D"), `color` (`#RRGGBB`). Uses `Problem()` with HTTP 400 for missing or unsupported `type`. Weak ETag + `If-None-Match` → 304 via `ConditionalGetEtag`, consistent with other public JSON GETs.

Extends API key middleware so `/api/tools/random` and `/api/v1.0/tools/random` skip `X-Api-Key` when API key auth is enabled.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/ToolsRandomController.cs` | New controller + `ToolsRandomResponse` DTO |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | `IsPublicToolsRandomPath` and `ShouldValidate` integration |
| `src/UnitTests/UI.Api/ToolsRandomControllerTests.cs` | Controller tests (200 shapes, 400, 304) |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Public-path test cases |

## Testing

- `dotnet test src/UnitTests` (filtered during dev; full suite in `PrivateBuild.ps1`)
- `pwsh -File ./PrivateBuild.ps1` — build, 250 unit tests, SQL container, migrations, 100 integration tests — all passed

Closes #1731

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-522f9ade-6066-4c07-b5de-2336763e9042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-522f9ade-6066-4c07-b5de-2336763e9042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

