### PR TITLE
E2E Test - Provider Agnostic Fix (#1959)

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -38,6 +38,10 @@ public abstract class AcceptanceTestBase
     protected virtual bool SkipScreenshotsForSpeed { get; set; } = ServerFixture.SkipScreenshotsForSpeed;
     public IBus Bus => TestHost.GetRequiredService<IBus>();
 
+    /// <summary>
+    /// Skips when LLM credentials are missing. Use for tests that call <c>SendPrompt</c> or other model-orchestrated flows.
+    /// MCP tool-only acceptance tests should not call this method.
+    /// </summary>
     protected static async Task SkipIfNoChatClient()
     {
         var factory = TestHost.GetRequiredService<ChatClientFactory>();
@@ -48,6 +52,11 @@ public abstract class AcceptanceTestBase
             Assert.Ignore(availability.Message);
         }
     }
+
+    /// <summary>
+    /// Same as <see cref="SkipIfNoChatClient"/>; prefer this name in tests that require LLM orchestration (not direct MCP tools only).
+    /// </summary>
+    protected static Task SkipIfLlmOrchestrationUnavailable() => SkipIfNoChatClient();
 
     private string TestId => TestContext.CurrentContext.Test.ID;
     

--- a/src/AcceptanceTests/McpServer/McpChatConversationTests.cs
+++ b/src/AcceptanceTests/McpServer/McpChatConversationTests.cs
@@ -33,7 +33,7 @@ public class McpChatConversationTests : AcceptanceTestBase
 	{
 		if (!_helper!.Connected)
 			Assert.Inconclusive("MCP HTTP server is not available");
-		await SkipIfNoChatClient();
+		await SkipIfLlmOrchestrationUnavailable();
 	}
 
 	[Test, Retry(2)]

--- a/src/AcceptanceTests/McpServer/McpHttpServerAcceptanceTests.cs
+++ b/src/AcceptanceTests/McpServer/McpHttpServerAcceptanceTests.cs
@@ -1,6 +1,6 @@
+using ClearMeasure.Bootcamp.AcceptanceTests.WorkItemTracking;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.IntegrationTests;
-using ClearMeasure.Bootcamp.LlmGateway;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
 using Shouldly;
 
@@ -16,7 +16,7 @@ public class McpHttpServerAcceptanceTests : AcceptanceTestBase
     [OneTimeSetUp]
     public async Task McpSetUp()
     {
-        _helper = new McpTestHelper(TestHost.GetRequiredService<ChatClientFactory>());
+        _helper = new McpTestHelper();
         await _helper.ConnectAsync();
     }
 
@@ -51,8 +51,8 @@ public class McpHttpServerAcceptanceTests : AcceptanceTestBase
     [Test]
     public async Task ShouldListWorkOrdersViaHttp()
     {
-        var text = await _helper!.CallToolDirectly("list-work-orders",
-            new Dictionary<string, object?>());
+        var tracking = new McpWorkItemTrackingService(_helper!);
+        var text = await tracking.ListWorkOrdersAsync();
 
         text.ShouldNotBeNullOrEmpty();
         text.ShouldContain("Number");
@@ -65,13 +65,11 @@ public class McpHttpServerAcceptanceTests : AcceptanceTestBase
         var employees = await bus.Send(new EmployeeGetAllQuery());
         var creator = employees.First(e => e.Roles.Any(r => r.CanCreateWorkOrder));
 
-        var text = await _helper!.CallToolDirectly("create-work-order",
-            new Dictionary<string, object?>
-            {
-                ["title"] = "HTTP transport test",
-                ["description"] = "Created via HTTP MCP transport",
-                ["creatorUsername"] = creator.UserName!
-            });
+        var tracking = new McpWorkItemTrackingService(_helper!);
+        var text = await tracking.CreateDraftWorkOrderAsync(
+            "HTTP transport test",
+            "Created via HTTP MCP transport",
+            creator.UserName!);
 
         text.ShouldContain("HTTP transport test");
         text.ShouldContain("Draft");
@@ -84,11 +82,8 @@ public class McpHttpServerAcceptanceTests : AcceptanceTestBase
         var employees = await bus.Send(new EmployeeGetAllQuery());
         var known = employees.First();
 
-        var text = await _helper!.CallToolDirectly("get-employee",
-            new Dictionary<string, object?>
-            {
-                ["username"] = known.UserName!
-            });
+        var tracking = new McpWorkItemTrackingService(_helper!);
+        var text = await tracking.GetEmployeeAsync(known.UserName!);
 
         text.ShouldNotBeNullOrEmpty();
         text.ShouldContain(known.UserName!);

--- a/src/AcceptanceTests/McpServer/McpServerAcceptanceTests.cs
+++ b/src/AcceptanceTests/McpServer/McpServerAcceptanceTests.cs
@@ -1,7 +1,7 @@
+using ClearMeasure.Bootcamp.AcceptanceTests.WorkItemTracking;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Queries;
 using ClearMeasure.Bootcamp.IntegrationTests;
-using ClearMeasure.Bootcamp.LlmGateway;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
 using Shouldly;
 
@@ -17,7 +17,7 @@ public class McpServerAcceptanceTests : AcceptanceTestBase
     [OneTimeSetUp]
     public async Task McpSetUp()
     {
-        _helper = new McpTestHelper(TestHost.GetRequiredService<ChatClientFactory>());
+        _helper = new McpTestHelper();
         await _helper.ConnectAsync();
     }
 
@@ -55,13 +55,11 @@ public class McpServerAcceptanceTests : AcceptanceTestBase
         var employees = await bus.Send(new EmployeeGetAllQuery());
         var creator = employees.First(e => e.Roles.Any(r => r.CanCreateWorkOrder));
 
-        var result = await _helper!.CallToolDirectly("create-work-order",
-            new Dictionary<string, object?>
-            {
-                ["title"] = "Direct MCP tool test",
-                ["description"] = "Created via direct tool call",
-                ["creatorUsername"] = creator.UserName!
-            });
+        var tracking = new McpWorkItemTrackingService(_helper!);
+        var result = await tracking.CreateDraftWorkOrderAsync(
+            "Direct MCP tool test",
+            "Created via direct tool call",
+            creator.UserName!);
 
         result.ShouldContain("Direct MCP tool test");
         result.ShouldContain("Draft");

--- a/src/AcceptanceTests/McpServer/McpServerLlmAcceptanceTests.cs
+++ b/src/AcceptanceTests/McpServer/McpServerLlmAcceptanceTests.cs
@@ -32,7 +32,7 @@ public class McpServerLlmAcceptanceTests : AcceptanceTestBase
     {
         if (!_helper!.Connected)
             Assert.Inconclusive("MCP server is not available");
-        await SkipIfNoChatClient();
+        await SkipIfLlmOrchestrationUnavailable();
     }
 
     [Test, Retry(2)]

--- a/src/AcceptanceTests/McpServer/McpTestHelper.cs
+++ b/src/AcceptanceTests/McpServer/McpTestHelper.cs
@@ -12,7 +12,7 @@ namespace ClearMeasure.Bootcamp.AcceptanceTests.McpServer;
 /// Provides MCP tool invocation and LLM chat helpers for acceptance tests.
 /// Connects to the MCP HTTP endpoint hosted by UI.Server at /mcp.
 /// </summary>
-public class McpTestHelper(ChatClientFactory factory) : IAsyncDisposable
+public class McpTestHelper(ChatClientFactory? factory = null) : IAsyncDisposable
 {
     private McpClient? _client;
     private IList<McpClientTool>? _tools;
@@ -55,6 +55,12 @@ public class McpTestHelper(ChatClientFactory factory) : IAsyncDisposable
 
     public async Task<ChatResponse> SendPrompt(string prompt)
     {
+        if (factory is null)
+        {
+            throw new InvalidOperationException(
+                "McpTestHelper was constructed without ChatClientFactory; SendPrompt requires LLM configuration.");
+        }
+
         var chatClient = await factory.GetChatClient();
         var messages = new List<ChatMessage>
         {

--- a/src/AcceptanceTests/McpServer/McpWorkOrderLifecycleLlmTests.cs
+++ b/src/AcceptanceTests/McpServer/McpWorkOrderLifecycleLlmTests.cs
@@ -1,3 +1,4 @@
+using ClearMeasure.Bootcamp.AcceptanceTests.WorkItemTracking;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Queries;
 using ClearMeasure.Bootcamp.IntegrationTests;
@@ -32,7 +33,7 @@ public class McpWorkOrderLifecycleLlmTests : AcceptanceTestBase
     {
         if (!_helper!.Connected)
             Assert.Inconclusive("MCP server is not available");
-        await SkipIfNoChatClient();
+        await SkipIfLlmOrchestrationUnavailable();
     }
 
     [Test, Retry(2)]
@@ -45,23 +46,18 @@ public class McpWorkOrderLifecycleLlmTests : AcceptanceTestBase
             e.Roles.Any(r => r.CanFulfillWorkOrder) && e.UserName != creator.UserName);
 
         // Create and assign via direct tool calls for reliability
-        var createResult = await _helper!.CallToolDirectly("create-work-order",
-            new Dictionary<string, object?>
-            {
-                ["title"] = "LLM lifecycle test",
-                ["description"] = "Testing full lifecycle via LLM",
-                ["creatorUsername"] = creator.UserName!
-            });
+        var tracking = new McpWorkItemTrackingService(_helper!);
+        var createResult = await tracking.CreateDraftWorkOrderAsync(
+            "LLM lifecycle test",
+            "Testing full lifecycle via LLM",
+            creator.UserName!);
         var workOrderNumber = McpTestHelper.ExtractJsonValue(createResult, "Number");
 
-        await _helper!.CallToolDirectly("execute-work-order-command",
-            new Dictionary<string, object?>
-            {
-                ["workOrderNumber"] = workOrderNumber,
-                ["commandName"] = "DraftToAssignedCommand",
-                ["executingUsername"] = creator.UserName!,
-                ["assigneeUsername"] = assignee.UserName!
-            });
+        await tracking.ExecuteWorkOrderCommandAsync(
+            workOrderNumber,
+            "DraftToAssignedCommand",
+            creator.UserName!,
+            assignee.UserName!);
 
         // Ask the LLM to begin and complete the work order
         var response = await _helper!.SendPrompt(

--- a/src/AcceptanceTests/McpServer/McpWorkOrderLifecycleTests.cs
+++ b/src/AcceptanceTests/McpServer/McpWorkOrderLifecycleTests.cs
@@ -1,7 +1,7 @@
+using ClearMeasure.Bootcamp.AcceptanceTests.WorkItemTracking;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Queries;
 using ClearMeasure.Bootcamp.IntegrationTests;
-using ClearMeasure.Bootcamp.LlmGateway;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
 using Shouldly;
 
@@ -17,7 +17,7 @@ public class McpWorkOrderLifecycleTests : AcceptanceTestBase
     [OneTimeSetUp]
     public async Task McpSetUp()
     {
-        _helper = new McpTestHelper(TestHost.GetRequiredService<ChatClientFactory>());
+        _helper = new McpTestHelper();
         await _helper.ConnectAsync();
     }
 
@@ -45,13 +45,11 @@ public class McpWorkOrderLifecycleTests : AcceptanceTestBase
             e.Roles.Any(r => r.CanFulfillWorkOrder) && e.UserName != creator.UserName);
 
         // Step 1: Create a draft work order
-        var createResult = await _helper!.CallToolDirectly("create-work-order",
-            new Dictionary<string, object?>
-            {
-                ["title"] = "Lifecycle test work order",
-                ["description"] = "Testing full lifecycle via direct MCP tool calls",
-                ["creatorUsername"] = creator.UserName!
-            });
+        var tracking = new McpWorkItemTrackingService(_helper!);
+        var createResult = await tracking.CreateDraftWorkOrderAsync(
+            "Lifecycle test work order",
+            "Testing full lifecycle via direct MCP tool calls",
+            creator.UserName!);
 
         createResult.ShouldContain("Lifecycle test work order");
         createResult.ShouldContain("Draft");
@@ -59,47 +57,34 @@ public class McpWorkOrderLifecycleTests : AcceptanceTestBase
         workOrderNumber.ShouldNotBeNullOrEmpty("Work order number should be returned");
 
         // Step 2: Assign the work order (Draft -> Assigned)
-        var assignResult = await _helper!.CallToolDirectly("execute-work-order-command",
-            new Dictionary<string, object?>
-            {
-                ["workOrderNumber"] = workOrderNumber,
-                ["commandName"] = "DraftToAssignedCommand",
-                ["executingUsername"] = creator.UserName!,
-                ["assigneeUsername"] = assignee.UserName!
-            });
+        var assignResult = await tracking.ExecuteWorkOrderCommandAsync(
+            workOrderNumber,
+            "DraftToAssignedCommand",
+            creator.UserName!,
+            assignee.UserName!);
 
         assignResult.ShouldContain("Assigned");
         assignResult.ShouldContain(assignee.GetFullName());
 
         // Step 3: Begin work (Assigned -> InProgress)
-        var beginResult = await _helper!.CallToolDirectly("execute-work-order-command",
-            new Dictionary<string, object?>
-            {
-                ["workOrderNumber"] = workOrderNumber,
-                ["commandName"] = "AssignedToInProgressCommand",
-                ["executingUsername"] = assignee.UserName!
-            });
+        var beginResult = await tracking.ExecuteWorkOrderCommandAsync(
+            workOrderNumber,
+            "AssignedToInProgressCommand",
+            assignee.UserName!);
 
         beginResult.ShouldContain("In Progress");
 
         // Step 4: Complete work (InProgress -> Complete)
-        var completeResult = await _helper!.CallToolDirectly("execute-work-order-command",
-            new Dictionary<string, object?>
-            {
-                ["workOrderNumber"] = workOrderNumber,
-                ["commandName"] = "InProgressToCompleteCommand",
-                ["executingUsername"] = assignee.UserName!
-            });
+        var completeResult = await tracking.ExecuteWorkOrderCommandAsync(
+            workOrderNumber,
+            "InProgressToCompleteCommand",
+            assignee.UserName!);
 
         completeResult.ShouldContain("Complete");
         completeResult.ShouldContain("CompletedDate");
 
         // Step 5: Verify final state via get-work-order
-        var getResult = await _helper!.CallToolDirectly("get-work-order",
-            new Dictionary<string, object?>
-            {
-                ["workOrderNumber"] = workOrderNumber
-            });
+        var getResult = await tracking.GetWorkOrderAsync(workOrderNumber);
 
         getResult.ShouldContain("Complete");
         getResult.ShouldContain("Lifecycle test work order");

--- a/src/AcceptanceTests/WorkItemTracking/IWorkItemTrackingService.cs
+++ b/src/AcceptanceTests/WorkItemTracking/IWorkItemTrackingService.cs
@@ -1,0 +1,21 @@
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkItemTracking;
+
+/// <summary>
+/// Test-layer abstraction for work-order operations used by E2E tests so scenarios do not depend on MCP tool names or transport details.
+/// </summary>
+public interface IWorkItemTrackingService
+{
+    Task<string> CreateDraftWorkOrderAsync(string title, string description, string creatorUsername,
+        string? roomNumber = null, CancellationToken cancellationToken = default);
+
+    Task<string> ExecuteWorkOrderCommandAsync(string workOrderNumber, string commandName, string executingUsername,
+        string? assigneeUsername = null, CancellationToken cancellationToken = default);
+
+    Task<string> GetWorkOrderAsync(string workOrderNumber, CancellationToken cancellationToken = default);
+
+    Task<string> ListWorkOrdersAsync(CancellationToken cancellationToken = default);
+
+    Task<string> ListEmployeesAsync(CancellationToken cancellationToken = default);
+
+    Task<string> GetEmployeeAsync(string username, CancellationToken cancellationToken = default);
+}

--- a/src/AcceptanceTests/WorkItemTracking/McpWorkItemTrackingService.cs
+++ b/src/AcceptanceTests/WorkItemTracking/McpWorkItemTrackingService.cs
@@ -1,0 +1,72 @@
+using ClearMeasure.Bootcamp.AcceptanceTests.McpServer;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkItemTracking;
+
+/// <summary>
+/// <see cref="IWorkItemTrackingService"/> implementation that delegates to MCP tools on the connected <see cref="McpTestHelper"/>.
+/// </summary>
+public sealed class McpWorkItemTrackingService(McpTestHelper helper) : IWorkItemTrackingService
+{
+    public Task<string> CreateDraftWorkOrderAsync(string title, string description, string creatorUsername,
+        string? roomNumber = null, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var args = new Dictionary<string, object?>
+        {
+            ["title"] = title,
+            ["description"] = description,
+            ["creatorUsername"] = creatorUsername
+        };
+        if (!string.IsNullOrEmpty(roomNumber))
+        {
+            args["roomNumber"] = roomNumber;
+        }
+
+        return helper.CallToolDirectly("create-work-order", args);
+    }
+
+    public Task<string> ExecuteWorkOrderCommandAsync(string workOrderNumber, string commandName,
+        string executingUsername, string? assigneeUsername = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var args = new Dictionary<string, object?>
+        {
+            ["workOrderNumber"] = workOrderNumber,
+            ["commandName"] = commandName,
+            ["executingUsername"] = executingUsername
+        };
+        if (!string.IsNullOrEmpty(assigneeUsername))
+        {
+            args["assigneeUsername"] = assigneeUsername;
+        }
+
+        return helper.CallToolDirectly("execute-work-order-command", args);
+    }
+
+    public Task<string> GetWorkOrderAsync(string workOrderNumber, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return helper.CallToolDirectly("get-work-order",
+            new Dictionary<string, object?> { ["workOrderNumber"] = workOrderNumber });
+    }
+
+    public Task<string> ListWorkOrdersAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return helper.CallToolDirectly("list-work-orders", new Dictionary<string, object?>());
+    }
+
+    public Task<string> ListEmployeesAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return helper.CallToolDirectly("list-employees", new Dictionary<string, object?>());
+    }
+
+    public Task<string> GetEmployeeAsync(string username, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return helper.CallToolDirectly("get-employee",
+            new Dictionary<string, object?> { ["username"] = username });
+    }
+}

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -6,7 +6,7 @@ using Shouldly;
 namespace ClearMeasure.Bootcamp.IntegrationTests.DataAccess.Mappings;
 
 [TestFixture]
-public class WorkOrderMappingTests
+public class WorkOrderMappingTests : IntegratedTestBase
 {
     [Test]
     public void ShouldMapWorkOrderBasicProperties()
@@ -226,6 +226,7 @@ public class WorkOrderMappingTests
     [Category("SqlServerOnly")]
     public void ShouldRespectMaxLengthConstraints()
     {
+        SkipWhenSqliteEngine();
         new DatabaseTests().Clean();
 
         var creator = new Employee("creator1", "John", "Doe", "john@example.com");
@@ -252,6 +253,7 @@ public class WorkOrderMappingTests
     [Category("SqlServerOnly")]
     public void ShouldSupportMaxLengthTitle()
     {
+        SkipWhenSqliteEngine();
         new DatabaseTests().Clean();
 
         var creator = new Employee("creator1", "John", "Doe", "john@example.com");

--- a/src/IntegrationTests/IntegratedTestBase.cs
+++ b/src/IntegrationTests/IntegratedTestBase.cs
@@ -1,9 +1,22 @@
 ﻿using ClearMeasure.Bootcamp.UnitTests;
+using NUnit.Framework;
 
 namespace ClearMeasure.Bootcamp.IntegrationTests;
 
 public class IntegratedTestBase
 {
+    /// <summary>
+    /// Skips when <c>DATABASE_ENGINE=SQLite</c>. Use with <c>[Category("SqlServerOnly")]</c> tests that SQLite CI still discovers.
+    /// </summary>
+    protected static void SkipWhenSqliteEngine()
+    {
+        if (string.Equals(Environment.GetEnvironmentVariable("DATABASE_ENGINE"), "SQLite",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Ignore("Test requires SQL Server; skipped when DATABASE_ENGINE is SQLite.");
+        }
+    }
+
     protected TK Faker<TK>()
     {
         return TestHost.Faker<TK>();

--- a/src/IntegrationTests/LlmGateway/ApplicationChatHandlerTests.cs
+++ b/src/IntegrationTests/LlmGateway/ApplicationChatHandlerTests.cs
@@ -104,6 +104,7 @@ public class ApplicationChatHandlerTests : LlmTestBase
     [Category("SqlServerOnly")]
     public async Task Handle_CreateAndAssignWorkOrder_AssignsWorkOrderForWilieAndThenShelvesIt()
     {
+        SkipWhenSqliteEngine();
         new ZDataLoader().LoadData();
 
         var workOrderNumber = await ExecuteAsync(

--- a/src/LlmGateway/ChatClientConfig.cs
+++ b/src/LlmGateway/ChatClientConfig.cs
@@ -2,6 +2,12 @@ namespace ClearMeasure.Bootcamp.LlmGateway;
 
 public class ChatClientConfig
 {
+    /// <summary>
+    /// Optional provider mode: null, empty, or <c>AzureOpenAI</c> (default) uses Azure OpenAI;
+    /// <c>OpenAICompatible</c> uses an OpenAI-compatible HTTP API (same API key, base URL, and model settings).
+    /// </summary>
+    public string? AiOpenAiProvider { get; set; }
+
     public required string? AiOpenAiApiKey { get; set; }
     public required string? AiOpenAiUrl { get; set; }
     public required string? AiOpenAiModel { get; set; }

--- a/src/LlmGateway/ChatClientFactory.cs
+++ b/src/LlmGateway/ChatClientFactory.cs
@@ -2,12 +2,16 @@ using Azure;
 using Azure.AI.OpenAI;
 using ClearMeasure.Bootcamp.Core;
 using Microsoft.Extensions.AI;
+using OpenAI;
 using OpenAI.Chat;
+using System.ClientModel;
 
 namespace ClearMeasure.Bootcamp.LlmGateway;
 
 public class ChatClientFactory(IBus bus)
 {
+    private const string OpenAiCompatibleProvider = "OpenAICompatible";
+
     public async Task<ChatClientAvailabilityResult> IsChatClientAvailable()
     {
         var config = await bus.Send(new ChatClientConfigQuery());
@@ -19,8 +23,11 @@ public class ChatClientFactory(IBus bus)
 
         if (missing.Count > 0)
         {
+            var modeHint = IsOpenAiCompatibleMode(config)
+                ? " (OpenAI-compatible mode: set AI_OpenAI_Provider=OpenAICompatible and use a base URL such as https://api.openai.com/v1)"
+                : " (Azure OpenAI: set AI_OpenAI_Url to the resource endpoint, e.g. https://your-resource.openai.azure.com)";
             return new ChatClientAvailabilityResult(false,
-                $"Chat client is not configured. Set the following environment variables: {string.Join(", ", missing)}");
+                $"Chat client is not configured. Set the following environment variables: {string.Join(", ", missing)}{modeHint}");
         }
 
         return new ChatClientAvailabilityResult(true, "Chat client is configured");
@@ -32,10 +39,15 @@ public class ChatClientFactory(IBus bus)
         var apiKey = config.AiOpenAiApiKey
             ?? throw new InvalidOperationException("AI_OpenAI_ApiKey is not configured.");
 
-        IChatClient innerClient = BuildAzureOpenAiChatClient(config, apiKey);
+        IChatClient innerClient = IsOpenAiCompatibleMode(config)
+            ? BuildOpenAiCompatibleChatClient(config, apiKey)
+            : BuildAzureOpenAiChatClient(config, apiKey);
 
         return new TracingChatClient(innerClient);
     }
+
+    private static bool IsOpenAiCompatibleMode(ChatClientConfig config) =>
+        string.Equals(config.AiOpenAiProvider, OpenAiCompatibleProvider, StringComparison.OrdinalIgnoreCase);
 
     private static IChatClient BuildAzureOpenAiChatClient(ChatClientConfig config, string apiKey)
     {
@@ -47,6 +59,21 @@ public class ChatClientFactory(IBus bus)
         var openAiClient = new AzureOpenAIClient(uri, credential);
 
         ChatClient chatClient = openAiClient.GetChatClient(openAiModel);
+        return chatClient.AsIChatClient()
+            .AsBuilder()
+            .UseFunctionInvocation()
+            .Build();
+    }
+
+    private static IChatClient BuildOpenAiCompatibleChatClient(ChatClientConfig config, string apiKey)
+    {
+        var baseUrl = config.AiOpenAiUrl ?? throw new InvalidOperationException();
+        var model = config.AiOpenAiModel ?? throw new InvalidOperationException();
+        var credential = new ApiKeyCredential(apiKey);
+
+        var options = new OpenAIClientOptions { Endpoint = new Uri(baseUrl) };
+        var client = new OpenAIClient(credential, options);
+        var chatClient = client.GetChatClient(model);
         return chatClient.AsIChatClient()
             .AsBuilder()
             .UseFunctionInvocation()

--- a/src/UI/Server/ChatClientConfigQueryHandler.cs
+++ b/src/UI/Server/ChatClientConfigQueryHandler.cs
@@ -1,5 +1,4 @@
 ﻿using ClearMeasure.Bootcamp.LlmGateway;
-using ClearMeasure.Bootcamp.UI.Client;
 using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -11,16 +10,20 @@ public class ChatClientConfigQueryHandler(IConfiguration configuration, ILogger<
     public Task<ChatClientConfig> Handle(ChatClientConfigQuery request, CancellationToken cancellationToken)
     {
         var apiKey = configuration.GetValue<string>("AI_OpenAI_ApiKey");
-        logger?.LogDebug($"AI_OpenAI_ApiKey found as {apiKey}");
         var openAiUrl = configuration.GetValue<string>("AI_OpenAI_Url");
-        logger?.LogDebug($"AI_OpenAI_Url found as {apiKey}");
         var openAiModel = configuration.GetValue<string>("AI_OpenAI_Model");
-        logger?.LogDebug($"AI_OpenAI_Model found as {apiKey}");
+        var provider = configuration.GetValue<string>("AI_OpenAI_Provider");
+        logger.LogDebug("AI_OpenAI_Provider: {Provider}, AI_OpenAI_Url configured: {HasUrl}, AI_OpenAI_Model configured: {HasModel}, AI_OpenAI_ApiKey configured: {HasKey}",
+            string.IsNullOrEmpty(provider) ? "(default Azure)" : provider,
+            !string.IsNullOrEmpty(openAiUrl),
+            !string.IsNullOrEmpty(openAiModel),
+            !string.IsNullOrEmpty(apiKey));
 
         return Task.FromResult(new ChatClientConfig
         {
-            AiOpenAiApiKey = apiKey, 
-            AiOpenAiUrl = openAiUrl, 
+            AiOpenAiProvider = provider,
+            AiOpenAiApiKey = apiKey,
+            AiOpenAiUrl = openAiUrl,
             AiOpenAiModel = openAiModel
         });
     }

--- a/src/UnitTests/LlmGateway/ChatClientFactoryTests.cs
+++ b/src/UnitTests/LlmGateway/ChatClientFactoryTests.cs
@@ -1,0 +1,81 @@
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.LlmGateway;
+using MediatR;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.LlmGateway;
+
+[TestFixture]
+public class ChatClientFactoryTests
+{
+    [Test]
+    public async Task IsChatClientAvailable_WhenApiKeyMissing_ReturnsUnavailable()
+    {
+        var factory = new ChatClientFactory(new StubConfigBus(Config(apiKey: null)));
+        var result = await factory.IsChatClientAvailable();
+
+        result.IsAvailable.ShouldBeFalse();
+        result.Message.ShouldContain("AI_OpenAI_ApiKey");
+    }
+
+    [Test]
+    public async Task IsChatClientAvailable_WhenAllAzureSettingsPresent_ReturnsAvailable()
+    {
+        var factory = new ChatClientFactory(new StubConfigBus(Config()));
+        var result = await factory.IsChatClientAvailable();
+
+        result.IsAvailable.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task IsChatClientAvailable_WhenOpenAiCompatibleAndComplete_ReturnsAvailable()
+    {
+        var factory = new ChatClientFactory(new StubConfigBus(Config(provider: "OpenAICompatible")));
+        var result = await factory.IsChatClientAvailable();
+
+        result.IsAvailable.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task IsChatClientAvailable_WhenIncomplete_MentionsAzureAndCompatibleHints()
+    {
+        var factory = new ChatClientFactory(new StubConfigBus(Config(url: null)));
+        var azure = await factory.IsChatClientAvailable();
+        azure.IsAvailable.ShouldBeFalse();
+        azure.Message.ShouldContain("Azure OpenAI");
+
+        var factoryCompatible = new ChatClientFactory(new StubConfigBus(Config(provider: "OpenAICompatible", url: null)));
+        var compatible = await factoryCompatible.IsChatClientAvailable();
+        compatible.IsAvailable.ShouldBeFalse();
+        compatible.Message.ShouldContain("OpenAI-compatible");
+    }
+
+    private static ChatClientConfig Config(
+        string? apiKey = "key",
+        string? url = "https://example.openai.azure.com",
+        string? model = "gpt-4o",
+        string? provider = null) =>
+        new()
+        {
+            AiOpenAiProvider = provider,
+            AiOpenAiApiKey = apiKey,
+            AiOpenAiUrl = url,
+            AiOpenAiModel = model
+        };
+
+    private sealed class StubConfigBus(ChatClientConfig config) : IBus
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request)
+        {
+            if (request is ChatClientConfigQuery)
+            {
+                return Task.FromResult((TResponse)(object)config);
+            }
+
+            throw new NotSupportedException();
+        }
+
+        public Task<object?> Send(object request) => throw new NotSupportedException();
+        public Task Publish(INotification notification) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

End-to-end MCP acceptance tests now drive work-order operations through a test-layer `IWorkItemTrackingService` so scenarios are not tied to raw MCP tool names. Tool-only fixtures construct `McpTestHelper` without `ChatClientFactory`, so missing `AI_OpenAI_*` credentials do not affect deterministic MCP tool tests. LLM-orchestrated tests use `SkipIfLlmOrchestrationUnavailable()` (alias of `SkipIfNoChatClient`) for clearer intent.

`ChatClientFactory` supports an optional **OpenAI-compatible** mode when `AI_OpenAI_Provider=OpenAICompatible`: the same `AI_OpenAI_ApiKey`, `AI_OpenAI_Url` (base URL, e.g. `https://api.openai.com/v1`), and `AI_OpenAI_Model` are used with the OpenAI .NET client (transitive via existing packages). Default behavior remains Azure OpenAI when the provider is unset.

**SQLite CI:** The **Integration Build (SQLite)** job failed on commit `6ee02795` because `ShouldRespectMaxLengthConstraints` (and other `[Category("SqlServerOnly")]` tests) still ran under SQLite: `build.ps1` uses `--filter Category!=SqlServerOnly`, which does not exclude NUnit categories. Commit `2eae3333` adds `SkipWhenSqliteEngine()` on `IntegratedTestBase` and calls it from SqlServer-only tests so they `Assert.Ignore` when `DATABASE_ENGINE=SQLite` (no `build.ps1` change).

## Files changed

| Area | File | Change |
|------|------|--------|
| Acceptance | `src/AcceptanceTests/WorkItemTracking/IWorkItemTrackingService.cs` | New interface for create/command/get/list work orders and employees |
| Acceptance | `src/AcceptanceTests/WorkItemTracking/McpWorkItemTrackingService.cs` | MCP tool implementation |
| Acceptance | `McpWorkOrderLifecycleTests.cs`, `McpHttpServerAcceptanceTests.cs`, `McpServerAcceptanceTests.cs`, `McpWorkOrderLifecycleLlmTests.cs` | Use tracking service; tool-only helpers omit factory |
| Acceptance | `McpTestHelper.cs` | Optional `ChatClientFactory`; `SendPrompt` requires factory |
| Acceptance | `McpServerLlmAcceptanceTests.cs`, `McpChatConversationTests.cs` | Call `SkipIfLlmOrchestrationUnavailable()` |
| Acceptance | `AcceptanceTestBase.cs` | Document `SkipIfNoChatClient`; add alias |
| LlmGateway | `ChatClientConfig.cs` | `AiOpenAiProvider` |
| LlmGateway | `ChatClientFactory.cs` | OpenAI-compatible branch; richer unavailable messages |
| UI.Server | `ChatClientConfigQueryHandler.cs` | Read `AI_OpenAI_Provider`; fix debug logging |
| UnitTests | `src/UnitTests/LlmGateway/ChatClientFactoryTests.cs` | Availability tests for Azure vs compatible mode |
| IntegrationTests | `IntegratedTestBase.cs`, `WorkOrderMappingTests.cs`, `ApplicationChatHandlerTests.cs` | Skip SqlServer-only tests when engine is SQLite |

## Testing

- `dotnet build src/ChurchBulletin.sln --configuration Release`
- `dotnet test src/UnitTests --configuration Release` (256 passed)
- `DATABASE_ENGINE=SQLite dotnet test src/IntegrationTests --configuration Release` (97 passed, 3 skipped)

## Pipeline / env vars

**Azure OpenAI (default)** — unset `AI_OpenAI_Provider` or leave empty:

- `AI_OpenAI_ApiKey`, `AI_OpenAI_Url` (Azure resource endpoint), `AI_OpenAI_Model` (deployment name)

**OpenAI-compatible API** — set:

- `AI_OpenAI_Provider=OpenAICompatible`
- `AI_OpenAI_ApiKey`, `AI_OpenAI_Url` (e.g. `https://api.openai.com/v1`), `AI_OpenAI_Model`

MCP tool-only acceptance tests do not require LLM configuration.

Closes #1959
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-859913a2-f8dc-489b-a1b1-24175612ac3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-859913a2-f8dc-489b-a1b1-24175612ac3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

