### PR TITLE
Test server-side body append - Feature #2 (#2155)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/DetailedHealthWebApplicationFactory.cs
@@ -26,8 +26,8 @@ public sealed class DetailedHealthWebApplicationFactory : WebApplicationFactory<
                 ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
                 ["ApiKeyAuthentication:Enabled"] = "false",
                 ["ApiKeyAuthentication:ValidationKey"] = "",
-                ["FeatureFlags:EnableExperimentalReporting"] = "false",
-                ["FeatureFlags:EnableOperatorDiagnosticsSample"] = "false"
+                ["FeatureFlags:SampleFeatureA"] = "false",
+                ["FeatureFlags:SampleFeatureB"] = "false"
             });
         });
     }

--- a/src/IntegrationTests/Api/DetailedHealthWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/DetailedHealthWebApplicationFactory.cs
@@ -25,7 +25,9 @@ public sealed class DetailedHealthWebApplicationFactory : WebApplicationFactory<
                 ["AI_OpenAI_Model"] = "",
                 ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
                 ["ApiKeyAuthentication:Enabled"] = "false",
-                ["ApiKeyAuthentication:ValidationKey"] = ""
+                ["ApiKeyAuthentication:ValidationKey"] = "",
+                ["FeatureFlags:EnableExperimentalReporting"] = "false",
+                ["FeatureFlags:EnableOperatorDiagnosticsSample"] = "false"
             });
         });
     }

--- a/src/IntegrationTests/Api/DiagnosticsApiKeyProtectedWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/DiagnosticsApiKeyProtectedWebApplicationFactory.cs
@@ -1,0 +1,34 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Same as <see cref="ApiKeyProtectedWebApplicationFactory"/> with feature flags for diagnostics tests.
+/// </summary>
+public sealed class DiagnosticsApiKeyProtectedWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "true",
+                ["ApiKeyAuthentication:ValidationKey"] = ApiKeyProtectedWebApplicationFactory.TestApiKey,
+                ["FeatureFlags:SampleFeatureA"] = "true",
+                ["FeatureFlags:SampleFeatureB"] = "false"
+            });
+        });
+    }
+}

--- a/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api;
-using ClearMeasure.Bootcamp.UI.Api.Controllers;
 using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UnitTests.UI.Server;
 using Microsoft.AspNetCore.Mvc.Testing;

--- a/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
@@ -2,8 +2,11 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
 using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Shouldly;
 
 namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
@@ -106,10 +109,39 @@ public class DiagnosticsEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_ExposeFeatureFlags_FromOverriddenConfiguration_When_GetDiagnostics()
+    {
+        await using var factory = new DiagnosticsWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["FeatureFlags:SampleFeatureA"] = "false",
+                    ["FeatureFlags:SampleFeatureB"] = "true"
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/diagnostics");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<DiagnosticsResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.FeatureFlags.SampleFeatureA.ShouldBeFalse();
+        payload.FeatureFlags.SampleFeatureB.ShouldBeTrue();
+    }
+
+    [Test]
     public async Task Should_NotConflictWithLegacyDiagnostics_When_RoutesRegistered()
     {
         var response = await _client!.GetAsync("/api/diagnostics");
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var legacyResponse = await _client.PostAsync("/_diagnostics/reset-db-connections", null);
+        legacyResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
 
     [Test]

--- a/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class DiagnosticsEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetDiagnosticsUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/diagnostics");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("environment", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetDiagnosticsVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/diagnostics");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("environment", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_ExposeEnvironment_FromHost_When_GetDiagnostics()
+    {
+        var response = await _client!.GetAsync("/api/diagnostics");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<DiagnosticsResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Environment.ShouldBe("Testing");
+    }
+
+    [Test]
+    public async Task Should_ExposeNonNegativeUptime_When_GetDiagnostics()
+    {
+        var before = DateTime.UtcNow;
+        var response = await _client!.GetAsync("/api/diagnostics");
+        var after = DateTime.UtcNow;
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<DiagnosticsResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Uptime.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        var health = SimpleHealthResponseBuilder.Build(TimeProvider.System);
+        (after - before).ShouldBeLessThan(TimeSpan.FromSeconds(30));
+        payload.Uptime.ShouldBeLessThanOrEqualTo(health.Uptime + TimeSpan.FromSeconds(2));
+        payload.Uptime.ShouldBeGreaterThanOrEqualTo(health.Uptime - TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
+    public async Task Should_ExposeFeatureFlags_FromConfiguration_When_GetDiagnostics()
+    {
+        var response = await _client!.GetAsync("/api/diagnostics");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<DiagnosticsResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.FeatureFlags.SampleFeatureA.ShouldBeTrue();
+        payload.FeatureFlags.SampleFeatureB.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_NotConflictWithLegacyDiagnostics_When_RoutesRegistered()
+    {
+        var response = await _client!.GetAsync("/api/diagnostics");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabledAndDiagnosticsProtected()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/diagnostics");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/diagnostics");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.GetAsync("/api/diagnostics");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/diagnostics");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/IntegrationTests/Api/DiagnosticsWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/DiagnosticsWebApplicationFactory.cs
@@ -1,0 +1,33 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server for <c>/api/diagnostics</c> integration tests with explicit feature-flag configuration.
+/// </summary>
+public sealed class DiagnosticsWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = "",
+                ["FeatureFlags:SampleFeatureA"] = "true",
+                ["FeatureFlags:SampleFeatureB"] = "false"
+            });
+        });
+    }
+}

--- a/src/UI/Api/Controllers/DiagnosticsController.cs
+++ b/src/UI/Api/Controllers/DiagnosticsController.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
 
 /// <summary>
-/// Exposes runtime diagnostics (environment, uptime, feature flags) for operations.
+/// Exposes runtime diagnostics (environment, uptime, feature flags) for operations and support.
 /// </summary>
 [ApiController]
 [ApiVersion("1.0")]
@@ -21,17 +21,24 @@ public class DiagnosticsController(
     IOptions<DiagnosticsFeatureFlagsOptions> featureFlagsOptions) : ControllerBase
 {
     /// <summary>
-    /// Returns environment name, process uptime (same semantics as <see cref="SimpleHealthResponseBuilder"/>),
-    /// and configured feature flags.
+    /// Returns environment name, process uptime (same semantics as <see cref="SimpleHealthResponseBuilder"/>), and configured feature flags.
     /// </summary>
     [HttpGet]
     public IActionResult Get()
     {
         var healthSlice = SimpleHealthResponseBuilder.Build(timeProvider);
         var payload = new DiagnosticsResponse(
-            hostEnvironment.EnvironmentName,
-            healthSlice.Uptime,
-            featureFlagsOptions.Value);
-        return new JsonResult(payload);
+            Environment: hostEnvironment.EnvironmentName,
+            Uptime: healthSlice.Uptime,
+            FeatureFlags: featureFlagsOptions.Value);
+        return ConditionalGetEtag.JsonContent(payload);
     }
 }
+
+/// <summary>
+/// JSON payload for <c>GET /api/diagnostics</c> and <c>GET /api/v1.0/diagnostics</c>.
+/// </summary>
+public sealed record DiagnosticsResponse(
+    string Environment,
+    TimeSpan Uptime,
+    DiagnosticsFeatureFlagsOptions FeatureFlags);

--- a/src/UI/Api/Controllers/DiagnosticsController.cs
+++ b/src/UI/Api/Controllers/DiagnosticsController.cs
@@ -34,11 +34,3 @@ public class DiagnosticsController(
         return ConditionalGetEtag.JsonContent(payload);
     }
 }
-
-/// <summary>
-/// JSON payload for <c>GET /api/diagnostics</c> and <c>GET /api/v1.0/diagnostics</c>.
-/// </summary>
-public sealed record DiagnosticsResponse(
-    string Environment,
-    TimeSpan Uptime,
-    DiagnosticsFeatureFlagsOptions FeatureFlags);

--- a/src/UI/Api/Controllers/DiagnosticsController.cs
+++ b/src/UI/Api/Controllers/DiagnosticsController.cs
@@ -1,0 +1,37 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes runtime diagnostics (environment, uptime, feature flags) for operations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/diagnostics")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/diagnostics")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class DiagnosticsController(
+    IHostEnvironment hostEnvironment,
+    TimeProvider timeProvider,
+    IOptions<DiagnosticsFeatureFlagsOptions> featureFlagsOptions) : ControllerBase
+{
+    /// <summary>
+    /// Returns environment name, process uptime (same semantics as <see cref="SimpleHealthResponseBuilder"/>),
+    /// and configured feature flags.
+    /// </summary>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var healthSlice = SimpleHealthResponseBuilder.Build(timeProvider);
+        var payload = new DiagnosticsResponse(
+            hostEnvironment.EnvironmentName,
+            healthSlice.Uptime,
+            featureFlagsOptions.Value);
+        return new JsonResult(payload);
+    }
+}

--- a/src/UI/Api/DiagnosticsFeatureFlagsOptions.cs
+++ b/src/UI/Api/DiagnosticsFeatureFlagsOptions.cs
@@ -1,0 +1,16 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Configuration-bound feature flags exposed on <c>GET /api/diagnostics</c>.
+/// </summary>
+public sealed class DiagnosticsFeatureFlagsOptions
+{
+    /// <summary>Configuration section name (root <c>FeatureFlags</c> in appsettings).</summary>
+    public const string SectionName = "FeatureFlags";
+
+    /// <summary>Sample flag for contract stability; replace or extend with product flags as needed.</summary>
+    public bool SampleFeatureA { get; set; }
+
+    /// <summary>Sample flag for contract stability; replace or extend with product flags as needed.</summary>
+    public bool SampleFeatureB { get; set; }
+}

--- a/src/UI/Api/DiagnosticsFeatureFlagsOptions.cs
+++ b/src/UI/Api/DiagnosticsFeatureFlagsOptions.cs
@@ -1,7 +1,7 @@
 namespace ClearMeasure.Bootcamp.UI.Api;
 
 /// <summary>
-/// Configuration-bound feature flags exposed on <c>GET /api/diagnostics</c>.
+/// Configuration-bound feature flags exposed on <c>GET /api/diagnostics</c> for deployment verification.
 /// </summary>
 public sealed class DiagnosticsFeatureFlagsOptions
 {

--- a/src/UI/Api/DiagnosticsModels.cs
+++ b/src/UI/Api/DiagnosticsModels.cs
@@ -1,0 +1,9 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/diagnostics</c> and <c>GET /api/v1.0/diagnostics</c>.
+/// </summary>
+public sealed record DiagnosticsResponse(
+    string Environment,
+    TimeSpan Uptime,
+    DiagnosticsFeatureFlagsOptions FeatureFlags);

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -54,10 +54,10 @@ builder.Services.AddApiRateLimiting(builder.Configuration);
 builder.Services.AddApiRequestTimeouts(builder.Configuration);
 builder.Services.Configure<ApiKeyAuthenticationOptions>(
     builder.Configuration.GetSection(ApiKeyAuthenticationOptions.SectionName));
-builder.Services.PostConfigure<ApiKeyAuthenticationOptions>(o =>
-    o.ValidationKey = string.IsNullOrWhiteSpace(o.ValidationKey) ? null : o.ValidationKey.Trim());
 builder.Services.Configure<DiagnosticsFeatureFlagsOptions>(
     builder.Configuration.GetSection(DiagnosticsFeatureFlagsOptions.SectionName));
+builder.Services.PostConfigure<ApiKeyAuthenticationOptions>(o =>
+    o.ValidationKey = string.IsNullOrWhiteSpace(o.ValidationKey) ? null : o.ValidationKey.Trim());
 builder.Services.AddRequestDecompression();
 builder.Services.Configure<RequestBodyBufferingOptions>(
     builder.Configuration.GetSection(RequestBodyBufferingOptions.SectionName));

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -56,6 +56,8 @@ builder.Services.Configure<ApiKeyAuthenticationOptions>(
     builder.Configuration.GetSection(ApiKeyAuthenticationOptions.SectionName));
 builder.Services.PostConfigure<ApiKeyAuthenticationOptions>(o =>
     o.ValidationKey = string.IsNullOrWhiteSpace(o.ValidationKey) ? null : o.ValidationKey.Trim());
+builder.Services.Configure<DiagnosticsFeatureFlagsOptions>(
+    builder.Configuration.GetSection(DiagnosticsFeatureFlagsOptions.SectionName));
 builder.Services.AddRequestDecompression();
 builder.Services.Configure<RequestBodyBufferingOptions>(
     builder.Configuration.GetSection(RequestBodyBufferingOptions.SectionName));

--- a/src/UI/Server/appsettings.Development.json
+++ b/src/UI/Server/appsettings.Development.json
@@ -44,5 +44,9 @@
   "RequestBodyBuffering": {
     "Enabled": true,
     "BufferThreshold": 1048576
+  },
+  "FeatureFlags": {
+    "SampleFeatureA": true,
+    "SampleFeatureB": false
   }
 }

--- a/src/UI/Server/appsettings.json
+++ b/src/UI/Server/appsettings.json
@@ -37,6 +37,10 @@
     "Enabled": false,
     "ValidationKey": ""
   },
+  "FeatureFlags": {
+    "SampleFeatureA": false,
+    "SampleFeatureB": false
+  },
   "Cors": {
     "Enabled": false,
     "AllowedOrigins": []

--- a/src/UnitTests/UI.Api/DiagnosticsControllerTests.cs
+++ b/src/UnitTests/UI.Api/DiagnosticsControllerTests.cs
@@ -1,0 +1,48 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class DiagnosticsControllerTests
+{
+    private sealed class StubHostEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+        public string ApplicationName { get; set; } = "";
+        public string ContentRootPath { get; set; } = "";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    [Test]
+    public void Get_Should_ReturnJson_WithEnvironmentUptimeAndFeatureFlags_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+        var stubEnv = new StubHostEnvironment("UnitTestEnv");
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+        var controller = new DiagnosticsController(
+            stubEnv,
+            clock,
+            Options.Create(flags));
+
+        var result = controller.Get();
+
+        var json = result.ShouldBeOfType<JsonResult>();
+        json.Value.ShouldBeOfType<DiagnosticsResponse>();
+        var payload = (DiagnosticsResponse)json.Value!;
+        payload.Environment.ShouldBe("UnitTestEnv");
+        payload.Uptime.ShouldBe(SimpleHealthResponseBuilder.Build(clock).Uptime);
+        payload.FeatureFlags.SampleFeatureA.ShouldBeTrue();
+        payload.FeatureFlags.SampleFeatureB.ShouldBeFalse();
+    }
+}

--- a/src/UnitTests/UI.Api/DiagnosticsControllerTests.cs
+++ b/src/UnitTests/UI.Api/DiagnosticsControllerTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api;
 using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -30,17 +32,21 @@ public class DiagnosticsControllerTests
         var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
         var stubEnv = new StubHostEnvironment("UnitTestEnv");
         var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
-        var controller = new DiagnosticsController(
-            stubEnv,
-            clock,
-            Options.Create(flags));
+        var controller = new DiagnosticsController(stubEnv, clock, Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
 
         var result = controller.Get();
 
-        var json = result.ShouldBeOfType<JsonResult>();
-        json.Value.ShouldBeOfType<DiagnosticsResponse>();
-        var payload = (DiagnosticsResponse)json.Value!;
-        payload.Environment.ShouldBe("UnitTestEnv");
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<DiagnosticsResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Environment.ShouldBe("UnitTestEnv");
         payload.Uptime.ShouldBe(SimpleHealthResponseBuilder.Build(clock).Uptime);
         payload.FeatureFlags.SampleFeatureA.ShouldBeTrue();
         payload.FeatureFlags.SampleFeatureB.ShouldBeFalse();

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -8,6 +8,8 @@ public class ApiKeyAuthenticationMiddlewareTests
 {
     [TestCase("/api/health", false)]
     [TestCase("/api/v1.0/health", false)]
+    [TestCase("/api/diagnostics", false)]
+    [TestCase("/api/v1.0/diagnostics", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -65,4 +65,29 @@ public class ApiKeyAuthenticationWebTests
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return401_When_ApiDiagnosticsCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/diagnostics");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiDiagnosticsCalledWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var response = await client.GetAsync("/api/v1.0/diagnostics");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -33,6 +33,33 @@ public class ApiKeyAuthenticationWebTests
     }
 
     [Test]
+    public async Task Should_Return401_When_ApiDiagnosticsCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/diagnostics");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiDiagnosticsCalledWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var unversioned = await client.GetAsync("/api/diagnostics");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/diagnostics");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
     public async Task Should_Return401_When_WrongKey()
     {
         await using var factory = new ApiKeyProtectedWebApplicationFactory();
@@ -62,31 +89,6 @@ public class ApiKeyAuthenticationWebTests
         using var client = factory.CreateClient();
 
         var response = await client.GetAsync("/api/time");
-
-        response.StatusCode.ShouldBe(HttpStatusCode.OK);
-    }
-
-    [Test]
-    public async Task Should_Return401_When_ApiDiagnosticsCalledWithoutKey()
-    {
-        await using var factory = new ApiKeyProtectedWebApplicationFactory();
-        using var client = factory.CreateClient();
-
-        var response = await client.GetAsync("/api/diagnostics");
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
-    }
-
-    [Test]
-    public async Task Should_Return200_When_ApiDiagnosticsCalledWithValidKey()
-    {
-        await using var factory = new ApiKeyProtectedWebApplicationFactory();
-        using var client = factory.CreateClient();
-        client.DefaultRequestHeaders.Add(
-            ApiKeyConstants.HeaderName,
-            ApiKeyProtectedWebApplicationFactory.TestApiKey);
-
-        var response = await client.GetAsync("/api/v1.0/diagnostics");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }


### PR DESCRIPTION
## Summary

Implements **GET `/api/diagnostics`** and **GET `/api/v1.0/diagnostics`** returning JSON with **environment name**, **uptime** (same calculation as `SimpleHealthResponseBuilder` / simple health), and **feature flags** from configuration (`FeatureFlags` section). When API key authentication is enabled, diagnostics requires the same `X-API-Key` header as other protected `/api/*` routes (not public like version/time).

## Files changed

| Area | File | Description |
|------|------|-------------|
| API | `src/UI/Api/Controllers/DiagnosticsController.cs` | New controller, dual routes, rate limiting |
| API | `src/UI/Api/DiagnosticsFeatureFlagsOptions.cs` | POCO + section name for feature flags |
| API | `src/UI/Api/DiagnosticsModels.cs` | `DiagnosticsResponse` record |
| Server | `src/UI/Server/Program.cs` | `Configure<DiagnosticsFeatureFlagsOptions>` |
| Config | `src/UI/Server/appsettings.json`, `appsettings.Development.json` | Sample `FeatureFlags` entries |
| Unit tests | `src/UnitTests/UI.Api/DiagnosticsControllerTests.cs` | Controller JSON shape and uptime alignment |
| Unit tests | `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | `/api/diagnostics` protected paths |
| Unit tests | `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | 401/200 with API key factory |
| Integration | `src/IntegrationTests/Api/DiagnosticsWebApplicationFactory.cs` | Test host + flag overrides |
| Integration | `src/IntegrationTests/Api/DiagnosticsApiKeyProtectedWebApplicationFactory.cs` | API key + flags |
| Integration | `src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs` | End-to-end diagnostics + API key |

## Testing

- `pwsh -File ./PrivateBuild.ps1` — succeeded (unit + integration, SQLite).
- Filtered runs: `DiagnosticsControllerTests`, `ApiKeyAuthenticationMiddlewareTests` / `ApiKeyAuthenticationWebTests` diagnostics cases, `DiagnosticsEndpointIntegrationTests`.

## Closes

Closes #2155
