### PR TITLE
Cursor HTML Body Test - Add error logging middleware (#2158)

### DIFF
--- a/src/UI/Server/Middleware/GlobalExceptionLoggingMiddleware.cs
+++ b/src/UI/Server/Middleware/GlobalExceptionLoggingMiddleware.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics;
+using ClearMeasure.Bootcamp.ServiceDefaults;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Middleware;
+
+/// <summary>
+/// Logs unhandled exceptions on the originating pipeline pass before the exception handler writes the response.
+/// Must run inside the same <see cref="Microsoft.AspNetCore.Builder.ExceptionHandlerExtensions.UseExceptionHandler"/> branch as downstream endpoints so exceptions are observed; re-throws to preserve existing problem-details behavior.
+/// </summary>
+public sealed class GlobalExceptionLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionLoggingMiddleware> _logger;
+
+    public GlobalExceptionLoggingMiddleware(
+        RequestDelegate next,
+        ILogger<GlobalExceptionLoggingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            var activityId = Activity.Current?.Id;
+            string? correlationId = null;
+            if (context.Items.TryGetValue(CorrelationIdConstants.HttpContextItemKey, out var corrItem)
+                && corrItem is string corr)
+            {
+                correlationId = corr;
+            }
+
+            _logger.LogError(
+                ex,
+                "Unhandled exception for {Method} {Path} TraceIdentifier {TraceIdentifier} ActivityId {ActivityId} CorrelationId {CorrelationId}",
+                context.Request.Method,
+                context.Request.Path.Value,
+                context.TraceIdentifier,
+                activityId,
+                correlationId);
+            throw;
+        }
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -136,10 +136,16 @@ app.UseCorrelationId();
 
 app.UseWhen(
     context => ProblemDetailsPaths.IsMachineOriented(context.Request.Path),
-    branch => branch.UseExceptionHandler(new ExceptionHandlerOptions
+    branch =>
     {
-        ExceptionHandler = context => ProblemDetailsExceptionHandler.HandleAsync(context, app.Environment)
-    }));
+        // UseExceptionHandler is outer (registered first): inbound order ExceptionHandler -> GlobalExceptionLoggingMiddleware -> main.
+        // Exceptions from the endpoint unwind to GlobalExceptionLoggingMiddleware first (log + rethrow), then ExceptionHandler catches.
+        branch.UseExceptionHandler(new ExceptionHandlerOptions
+        {
+            ExceptionHandler = context => ProblemDetailsExceptionHandler.HandleAsync(context, app.Environment)
+        });
+        branch.UseMiddleware<GlobalExceptionLoggingMiddleware>();
+    });
 
 if (app.Environment.IsDevelopment())
 {
@@ -147,7 +153,12 @@ if (app.Environment.IsDevelopment())
 }
 else
 {
-    app.UseExceptionHandler("/Error");
+    // Do not register the HTML /Error handler for /api or /mcp; those paths use the machine-oriented
+    // exception handler above. A blanket UseExceptionHandler("/Error") here would sit inside that
+    // branch's continuation and catch API exceptions first (returning HTML).
+    app.UseWhen(
+        context => !ProblemDetailsPaths.IsMachineOriented(context.Request.Path),
+        branch => branch.UseExceptionHandler("/Error"));
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
@@ -210,6 +221,9 @@ if (string.Equals(app.Environment.EnvironmentName, "Testing", StringComparison.O
                 return Results.Ok();
             })
         .WithRequestTimeout(TimeSpan.FromMilliseconds(500));
+    app.MapGet(
+        "/api/_test/exception-probe",
+        (HttpContext _) => throw new InvalidOperationException("GlobalExceptionLoggingMiddleware test probe"));
 }
 
 app.UseRequestBodyBuffering();

--- a/src/UnitTests/UI.Server/GlobalExceptionLoggingWebApplicationFactory.cs
+++ b/src/UnitTests/UI.Server/GlobalExceptionLoggingWebApplicationFactory.cs
@@ -1,0 +1,92 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+/// <summary>
+/// UI.Server test host with an in-memory logger sink for global exception logging assertions.
+/// </summary>
+public sealed class GlobalExceptionLoggingWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    public List<StubLogEntry> CapturedLogs { get; } = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", WebApplicationTestingDatabase.SqliteSharedMemoryConnectionString);
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = WebApplicationTestingDatabase.SqliteSharedMemoryConnectionString,
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = ""
+            });
+        });
+        builder.ConfigureLogging(logging =>
+        {
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddProvider(new StubListLoggerProvider(CapturedLogs));
+        });
+    }
+}
+
+internal sealed class StubListLoggerProvider : ILoggerProvider
+{
+    private readonly List<StubLogEntry> _entries;
+
+    public StubListLoggerProvider(List<StubLogEntry> entries) => _entries = entries;
+
+    public ILogger CreateLogger(string categoryName) => new StubLogger(categoryName, _entries);
+
+    public void Dispose()
+    {
+    }
+}
+
+internal sealed class StubLogger : ILogger
+{
+    private readonly string _categoryName;
+    private readonly List<StubLogEntry> _entries;
+
+    public StubLogger(string categoryName, List<StubLogEntry> entries)
+    {
+        _categoryName = categoryName;
+        _entries = entries;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        _entries.Add(new StubLogEntry
+        {
+            Category = _categoryName,
+            LogLevel = logLevel,
+            Exception = exception,
+            Message = formatter(state, exception)
+        });
+    }
+}
+
+public sealed class StubLogEntry
+{
+    public required string Category { get; init; }
+    public required LogLevel LogLevel { get; init; }
+    public Exception? Exception { get; init; }
+    public required string Message { get; init; }
+}

--- a/src/UnitTests/UI.Server/GlobalExceptionLoggingWebTests.cs
+++ b/src/UnitTests/UI.Server/GlobalExceptionLoggingWebTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.ServiceDefaults;
+using ClearMeasure.Bootcamp.UI.Server;
+using ClearMeasure.Bootcamp.UI.Server.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class GlobalExceptionLoggingWebTests
+{
+    private const string ExceptionProbePath = "/api/_test/exception-probe";
+    private const string ProbeExceptionMessage = "GlobalExceptionLoggingMiddleware test probe";
+
+    [Test]
+    public async Task Should_LogUnhandledException_And_ReturnProblemJson_When_ApiThrows()
+    {
+        await using var factory = new GlobalExceptionLoggingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(ExceptionProbePath);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/problem+json");
+
+        var errors = factory.CapturedLogs.Where(e =>
+            e.LogLevel == LogLevel.Error
+            && e.Category == typeof(GlobalExceptionLoggingMiddleware).FullName).ToList();
+        errors.Count.ShouldBeGreaterThanOrEqualTo(1);
+        var entry = errors.First(e => e.Exception is InvalidOperationException);
+        entry.Message.ShouldContain("/api/_test/exception-probe");
+        entry.Message.ShouldContain("GET");
+        entry.Exception!.Message.ShouldBe(ProbeExceptionMessage);
+    }
+
+    [Test]
+    public async Task Should_PreserveExceptionHandlerBehavior_When_MiddlewareLogs()
+    {
+        await using var factory = new GlobalExceptionLoggingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        for (var i = 0; i < 2; i++)
+        {
+            var response = await client.GetAsync(ExceptionProbePath);
+            response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+            var mediaType = response.Content.Headers.ContentType?.MediaType;
+            mediaType.ShouldNotBeNull();
+            mediaType!.ShouldContain("application/problem+json");
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            doc.RootElement.GetProperty("status").GetInt32().ShouldBe(StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    [Test]
+    public async Task Should_IncludeSafeCorrelationContext_InStructuredLog_When_UnhandledException()
+    {
+        var expectedCorrelationId = Guid.NewGuid().ToString("D");
+        await using var factory = new GlobalExceptionLoggingWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(CorrelationIdConstants.HeaderName, expectedCorrelationId);
+
+        await client.GetAsync(ExceptionProbePath);
+
+        var errors = factory.CapturedLogs.Where(e =>
+            e.LogLevel == LogLevel.Error
+            && e.Category == typeof(GlobalExceptionLoggingMiddleware).FullName).ToList();
+        errors.Count.ShouldBe(1);
+        errors[0].Message.ShouldContain(expectedCorrelationId);
+    }
+
+    [Test]
+    public async Task Should_NotEmitRawSecrets_InCapturedLogs_When_ApiThrows()
+    {
+        const string secret = "super-secret-token";
+        await using var factory = new GlobalExceptionLoggingWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", secret);
+
+        await client.GetAsync(ExceptionProbePath);
+
+        var combined = string.Join(
+            "|",
+            factory.CapturedLogs.Select(e => e.Message + (e.Exception?.ToString() ?? "")));
+        combined.ShouldNotContain(secret);
+    }
+
+    [Test]
+    public async Task Should_NotDuplicateErrorLogs_When_ProblemDetailsHandlerUnchanged()
+    {
+        await using var factory = new GlobalExceptionLoggingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        await client.GetAsync(ExceptionProbePath);
+
+        var middlewareErrors = factory.CapturedLogs.Count(e =>
+            e.LogLevel == LogLevel.Error
+            && e.Category == typeof(GlobalExceptionLoggingMiddleware).FullName);
+        middlewareErrors.ShouldBe(1);
+
+        var problemHandlerErrors = factory.CapturedLogs.Count(e =>
+            e.LogLevel == LogLevel.Error
+            && e.Category == typeof(ProblemDetailsExceptionHandler).FullName);
+        problemHandlerErrors.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GlobalExceptionLoggingMiddleware` for machine-oriented HTTP paths (`/api`, `/mcp`): on unhandled exceptions it emits structured `LogError` with method, path, `TraceIdentifier`, `Activity.Current?.Id`, and correlation id from `HttpContext.Items`, then re-throws so existing `ProblemDetailsExceptionHandler` behavior is unchanged.

Registers the middleware inside the same `UseWhen` branch as the machine-oriented `UseExceptionHandler`, with `UseExceptionHandler` registered first so it wraps the inner pipeline (correct catch/rethrow ordering).

Fixes a regression risk for non-Development environments: `UseExceptionHandler("/Error")` is now applied only when the path is **not** machine-oriented, so the HTML error page handler no longer intercepts API exceptions ahead of problem+json (this was breaking `Testing` and would affect staging/production API error bodies).

Adds `GET /api/_test/exception-probe` (Testing environment only) and hosted factory tests with a stub `ILoggerProvider` sink.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Server/Middleware/GlobalExceptionLoggingMiddleware.cs` | New middleware |
| `src/UI/Server/Program.cs` | Branch wiring, Testing probe, gated `/Error` handler |
| `src/UnitTests/UI.Server/GlobalExceptionLoggingWebApplicationFactory.cs` | Test host + log capture |
| `src/UnitTests/UI.Server/GlobalExceptionLoggingWebTests.cs` | Integration-style assertions |

## Testing

- `dotnet test src/UnitTests` (Release), including new `GlobalExceptionLoggingWebTests`
- `PrivateBuild.ps1` (unit + integration + migrations)

Closes #2158
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3d405e6-87fd-4fc6-b946-665bbb689432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3d405e6-87fd-4fc6-b946-665bbb689432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

