### PR TITLE
Board traversal test issue (#777)

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderSearchTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSearchTests.cs
@@ -381,17 +381,14 @@ public class WorkOrderSearchTests : AcceptanceTestBase
 
         await Click(nameof(NavMenu.Elements.MyWorkOrders));
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await creatorSelect.DblClickAsync();
-        await Expect(creatorSelect).ToHaveValueAsync(CurrentUser.UserName);
+        await Expect(creatorSelect).ToHaveValueAsync(CurrentUser.UserName, new() { Timeout = 30_000 });
 
         await Click(nameof(NavMenu.Elements.WorkOrdersAssignedToMe));
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await assigneeSelect.DblClickAsync();
-        await Expect(assigneeSelect).ToHaveValueAsync(CurrentUser.UserName);
+        await Expect(assigneeSelect).ToHaveValueAsync(CurrentUser.UserName, new() { Timeout = 30_000 });
 
         await Click(nameof(NavMenu.Elements.AllWorkOrdersInProgress));
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await statusSelect.DblClickAsync();
-        await Expect(statusSelect).ToHaveValueAsync(order1.Status.Key);
+        await Expect(statusSelect).ToHaveValueAsync(order1.Status.Key, new() { Timeout = 30_000 });
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The acceptance test `ShouldReloadParamsFromQueryStringWithNavigation` waited for filter `<select>` values to update after client-side navigation by double-clicking each control. Double-click is not a reliable interaction for `<select>` elements and can fail under load or with focus timing, which matches intermittent "board" (results grid) / navigation test failures.

The test now uses Playwright `Expect(...).ToHaveValueAsync` with a 30s timeout so the assertion retries until Blazor applies query parameters from the new route.

## Files changed

- `src/AcceptanceTests/WorkOrders/WorkOrderSearchTests.cs` — replace `DblClickAsync` + immediate assert with auto-retrying value assertions after each nav link click.

## Testing

- `DATABASE_ENGINE=SQLite` `./PrivateBuild.ps1` — unit and integration tests green (257 + 105).

Closes #777
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a19aef3-b062-4d01-9514-435285fc9ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a19aef3-b062-4d01-9514-435285fc9ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

