### PR TITLE
New API endpoint GET /api/health/detailed for component-level health reporting (#5033)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -86,6 +86,46 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_Return200AndJson_When_GetDetailedHealth_V1Path()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/health/detailed");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("overallStatus", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("checkedAtUtc", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("components", out var components).ShouldBeTrue();
+        components.ValueKind.ShouldBe(JsonValueKind.Array);
+        components.GetArrayLength().ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Should_ReturnSameShape_When_GetDetailedHealth_LegacyAndV1Paths()
+    {
+        var legacy = await _client!.GetAsync("/api/health/detailed");
+        var v1 = await _client.GetAsync("/api/v1.0/health/detailed");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var legacyReport = await legacy.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var v1Report = await v1.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        legacyReport.ShouldNotBeNull();
+        v1Report.ShouldNotBeNull();
+        legacyReport!.OverallStatus.ShouldBe(v1Report!.OverallStatus);
+        legacyReport.CheckedAtUtc.ShouldBe(v1Report.CheckedAtUtc, tolerance: TimeSpan.FromSeconds(2));
+        legacyReport.Components.Select(c => c.Name).OrderBy(n => n).ToList()
+            .ShouldBeEquivalentTo(v1Report.Components.Select(c => c.Name).OrderBy(n => n).ToList());
+    }
+
+    [Test]
     public async Task Should_ExposeOverallStatus_WorstCase_When_ComponentsMixed()
     {
         var response = await _client!.GetAsync("/api/health/detailed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #5033 asked for `GET /api/health/detailed` with per-component JSON. That surface was already implemented in `DetailedHealthController` (`UI.Api`), hosted from `UI.Server` with the same contract as `GET /api/v1.0/health/detailed`. This change closes the remaining verification gap from the technical design: explicit integration coverage for the **versioned** detailed health path and parity checks against the legacy `/api/health/detailed` route.

## Files changed

| File | Change |
|------|--------|
| `src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs` | Added tests for `GET /api/v1.0/health/detailed` (200 + JSON shape) and comparison of legacy vs v1 responses (overall status, `checkedAtUtc` within 2 seconds, same component names). |

## Testing

- `dotnet test src/IntegrationTests --configuration Release --filter "FullyQualifiedName~DetailedHealthEndpointIntegrationTests"`
- Full `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: clean, restore, Release build, all unit tests (257), all integration tests (110).
- GitHub Actions **Build** workflow on `cursor/5033-development`: completed **success**.

Closes #5033
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-332e2bd2-c0fb-4bf2-8249-819e0675490c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-332e2bd2-c0fb-4bf2-8249-819e0675490c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

