### PR TITLE
Make the login button blink obviously (#5031)

### DIFF
--- a/src/UI.Shared/Components/LoginLink.razor
+++ b/src/UI.Shared/Components/LoginLink.razor
@@ -1,4 +1,4 @@
-<a class="login-prompt-link" data-testid="@Elements.LoginLink" href="/login">Login</a>
+<a class="login-prompt-link" data-testid="@Elements.LoginLink" href="/login" aria-label="Sign in to the church portal">Login</a>
 
 @code
 {

--- a/src/UI.Shared/Components/LoginLink.razor.css
+++ b/src/UI.Shared/Components/LoginLink.razor.css
@@ -5,15 +5,15 @@
 	border-radius: 10px;
 	padding: 0.5rem 1rem;
 	transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, opacity 0.15s ease;
-	color: #1a365d;
-	background: linear-gradient(135deg, #fefcbf 0%, #fbd38d 45%, #f6ad55 100%);
+	color: #1a202c;
+	background: linear-gradient(135deg, #fffff0 0%, #feebc8 35%, #fbd38d 70%, #f6ad55 100%);
 	border: 3px solid #c05621;
-	box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.9), 0 4px 14px rgba(221, 107, 32, 0.45);
+	box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.9), 0 4px 16px rgba(221, 107, 32, 0.55);
 }
 
 @media (prefers-reduced-motion: no-preference) {
 	.login-prompt-link {
-		animation: login-prompt-emphasis 1.35s ease-in-out infinite;
+		animation: login-prompt-emphasis 1s ease-in-out infinite;
 		will-change: transform, opacity, box-shadow, filter;
 	}
 }
@@ -22,58 +22,83 @@
 	0%, 100% {
 		opacity: 1;
 		transform: scale(1);
-		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.85), 0 4px 18px rgba(221, 107, 32, 0.55);
+		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.9), 0 4px 18px rgba(221, 107, 32, 0.55);
 		border-color: #c05621;
-		filter: brightness(1);
+		filter: brightness(1.05);
 		text-shadow: 0 0 0 transparent;
 	}
-	12% {
+	10% {
 		opacity: 1;
-		transform: scale(1.1);
-		box-shadow: 0 0 0 12px rgba(221, 107, 32, 0.45), 0 0 0 4px rgba(255, 255, 255, 0.95), 0 8px 28px rgba(221, 107, 32, 0.72);
+		transform: scale(1.12);
+		box-shadow: 0 0 0 14px rgba(221, 107, 32, 0.5), 0 0 0 5px rgba(255, 255, 255, 1), 0 10px 32px rgba(221, 107, 32, 0.78);
 		border-color: #dd6b20;
-		filter: brightness(1.15);
-		text-shadow: 0 0 12px rgba(255, 255, 255, 0.95), 0 0 22px rgba(255, 200, 50, 0.95);
+		filter: brightness(1.2);
+		text-shadow: 0 0 14px rgba(255, 255, 255, 1), 0 0 26px rgba(255, 214, 10, 1);
 	}
-	18%, 22% {
-		opacity: 0.06;
-		transform: scale(0.9);
-		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.4), 0 2px 8px rgba(0, 0, 0, 0.25);
+	/* Short “off” blinks so the CTA reads as flashing, not stuck dim */
+	16%, 17% {
+		opacity: 0.04;
+		transform: scale(0.92);
+		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.45), 0 2px 10px rgba(0, 0, 0, 0.3);
 		border-color: #9b2c2c;
-		filter: brightness(0.65);
+		filter: brightness(0.55);
 		text-shadow: none;
 	}
-	28% {
+	24% {
 		opacity: 1;
-		transform: scale(1.14);
-		box-shadow: 0 0 0 16px rgba(255, 214, 10, 0.55), 0 0 0 5px rgba(255, 255, 255, 1), 0 12px 36px rgba(221, 107, 32, 0.8);
+		transform: scale(1.15);
+		box-shadow: 0 0 0 18px rgba(255, 214, 10, 0.6), 0 0 0 6px rgba(255, 255, 255, 1), 0 14px 40px rgba(221, 107, 32, 0.85);
 		border-color: #c05621;
-		filter: brightness(1.25);
-		text-shadow: 0 0 16px rgba(255, 255, 255, 1), 0 0 28px rgba(255, 180, 0, 1);
+		filter: brightness(1.28);
+		text-shadow: 0 0 18px rgba(255, 255, 255, 1), 0 0 32px rgba(255, 180, 0, 1);
 	}
-	44% {
+	38% {
+		opacity: 1;
+		transform: scale(1.05);
+		box-shadow: 0 0 0 10px rgba(221, 107, 32, 0.42), 0 0 0 4px rgba(255, 255, 255, 0.95), 0 8px 26px rgba(221, 107, 32, 0.65);
+		border-color: #dd6b20;
+		filter: brightness(1.12);
+		text-shadow: 0 0 12px rgba(255, 255, 255, 0.95), 0 0 22px rgba(255, 200, 50, 0.9);
+	}
+	46%, 47% {
+		opacity: 0.04;
+		transform: scale(0.92);
+		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.45), 0 2px 10px rgba(0, 0, 0, 0.3);
+		border-color: #9b2c2c;
+		filter: brightness(0.55);
+		text-shadow: none;
+	}
+	54% {
+		opacity: 1;
+		transform: scale(1.15);
+		box-shadow: 0 0 0 18px rgba(255, 214, 10, 0.6), 0 0 0 6px rgba(255, 255, 255, 1), 0 14px 40px rgba(221, 107, 32, 0.85);
+		border-color: #c05621;
+		filter: brightness(1.28);
+		text-shadow: 0 0 18px rgba(255, 255, 255, 1), 0 0 32px rgba(255, 180, 0, 1);
+	}
+	70% {
 		opacity: 1;
 		transform: scale(1.06);
-		box-shadow: 0 0 0 8px rgba(221, 107, 32, 0.38), 0 0 0 3px rgba(255, 255, 255, 0.9), 0 6px 22px rgba(221, 107, 32, 0.62);
+		box-shadow: 0 0 0 12px rgba(221, 107, 32, 0.45), 0 0 0 4px rgba(255, 255, 255, 0.95), 0 8px 28px rgba(221, 107, 32, 0.68);
 		border-color: #dd6b20;
-		filter: brightness(1.1);
-		text-shadow: 0 0 10px rgba(255, 255, 255, 0.9), 0 0 18px rgba(255, 200, 50, 0.85);
+		filter: brightness(1.15);
+		text-shadow: 0 0 12px rgba(255, 255, 255, 0.95), 0 0 22px rgba(255, 200, 50, 0.9);
 	}
-	52%, 56% {
-		opacity: 0.06;
-		transform: scale(0.9);
-		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.4), 0 2px 8px rgba(0, 0, 0, 0.25);
+	78%, 79% {
+		opacity: 0.04;
+		transform: scale(0.92);
+		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.45), 0 2px 10px rgba(0, 0, 0, 0.3);
 		border-color: #9b2c2c;
-		filter: brightness(0.65);
+		filter: brightness(0.55);
 		text-shadow: none;
 	}
-	62% {
+	88% {
 		opacity: 1;
-		transform: scale(1.14);
-		box-shadow: 0 0 0 16px rgba(255, 214, 10, 0.55), 0 0 0 5px rgba(255, 255, 255, 1), 0 12px 36px rgba(221, 107, 32, 0.8);
+		transform: scale(1.1);
+		box-shadow: 0 0 0 14px rgba(221, 107, 32, 0.48), 0 0 0 5px rgba(255, 255, 255, 1), 0 10px 32px rgba(221, 107, 32, 0.75);
 		border-color: #c05621;
-		filter: brightness(1.25);
-		text-shadow: 0 0 16px rgba(255, 255, 255, 1), 0 0 28px rgba(255, 180, 0, 1);
+		filter: brightness(1.18);
+		text-shadow: 0 0 14px rgba(255, 255, 255, 1), 0 0 26px rgba(255, 214, 10, 1);
 	}
 }
 

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -577,3 +577,22 @@
 :global(html[data-theme="dark"]) .auth-section ::deep a:not(.login-prompt-link):focus {
     outline-color: #90cdf4;
 }
+
+/* Header login CTA: stay vivid on dark chrome (scoped; does not override reduced-motion rules in LoginLink.razor.css) */
+:global(html[data-theme="dark"]) .auth-section ::deep .login-prompt-link {
+    color: #1a202c;
+    background: linear-gradient(135deg, #fffef5 0%, #feebc8 40%, #fbd38d 75%, #ed8936 100%);
+    border-color: #ed8936;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.35), 0 0 0 0 rgba(237, 137, 54, 0.9), 0 4px 20px rgba(0, 0, 0, 0.45);
+}
+
+@media (max-width: 768px) {
+    .auth-section ::deep .login-prompt-link {
+        min-height: 44px;
+        min-width: 44px;
+        box-sizing: border-box;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+}

--- a/src/UnitTests/UI.Shared/Components/LoginLinkTests.cs
+++ b/src/UnitTests/UI.Shared/Components/LoginLinkTests.cs
@@ -24,6 +24,7 @@ public class LoginLinkTests
         var anchor = component.Find("a");
         anchor.GetAttribute("href").ShouldBe("/login");
         anchor.GetAttribute("data-testid").ShouldBe(nameof(LoginLink.Elements.LoginLink));
+        anchor.GetAttribute("aria-label").ShouldBe("Sign in to the church portal");
         anchor.ClassList.ShouldContain("login-prompt-link");
         anchor.TextContent.ShouldBe("Login");
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Anonymous header **Login** CTA (`LoginLink`) now uses a faster, higher-contrast pulse with **short, sharp opacity dips** so the control reads as an obvious blink rather than a long near-invisible dwell. Added **`aria-label`** for screen readers. **Dark theme** gets explicit warm-gradient styling so the CTA stays vivid on the dark auth chrome. **Narrow viewports** (`max-width: 768px`) enforce a **44px minimum** tap target on the link.

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/Components/LoginLink.razor` | `aria-label="Sign in to the church portal"` on the anchor |
| `src/UI.Shared/Components/LoginLink.razor.css` | `login-prompt-emphasis` keyframes: 1s period, 0.04 opacity blinks, stronger glow/scale peaks; brighter base gradient |
| `src/UI.Shared/MainLayout.razor.css` | Dark-theme `.login-prompt-link` overrides; narrow-viewport min touch size |
| `src/UnitTests/UI.Shared/Components/LoginLinkTests.cs` | Assert `aria-label` |

## Testing

- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` (Release): build, unit tests, integration tests — all green.
- `dotnet test src/AcceptanceTests --configuration Debug --filter "FullyQualifiedName~LoginLinkVisualTests"` after `playwright.ps1 install chromium` — 4/4 passed.

Closes #5031
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a0c81ab-b404-4a1a-ab70-61a1b1f93b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a0c81ab-b404-4a1a-ab70-61a1b1f93b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

