### PR TITLE
New API endpoint GET /api/version for build and deployment metadata (#5036)

### DIFF
--- a/src/UI/Api/Controllers/VersionController.cs
+++ b/src/UI/Api/Controllers/VersionController.cs
@@ -31,9 +31,11 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
         var assembly = Assembly.GetExecutingAssembly();
         var assemblyVersion = assembly.GetName().Version?.ToString();
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var configuration = assembly.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration;
         var payload = new VersionMetadataResponse(
             AssemblyVersion: assemblyVersion,
             InformationalVersion: informationalVersion,
+            Configuration: configuration,
             Environment: hostEnvironment.EnvironmentName,
             MachineName: Environment.MachineName,
             FrameworkDescription: RuntimeInformation.FrameworkDescription);
@@ -47,10 +49,12 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
 
 /// <summary>
 /// JSON payload for <c>GET /api/version</c> and <c>GET /api/v1.0/version</c>.
+/// Includes <see cref="Configuration"/> (Debug/Release) from <see cref="AssemblyConfigurationAttribute"/> when emitted by the build.
 /// </summary>
 public record VersionMetadataResponse(
     string? AssemblyVersion,
     string? InformationalVersion,
+    string? Configuration,
     string? Environment,
     string MachineName,
     string FrameworkDescription);

--- a/src/UI/Api/UI.Api.csproj
+++ b/src/UI/Api/UI.Api.csproj
@@ -7,6 +7,8 @@
 		<AssemblyName>ClearMeasure.Bootcamp.$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>ClearMeasure.Bootcamp.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<Configurations>Debug;Release;exclude-maui.slnf</Configurations>
+		<Deterministic>true</Deterministic>
+		<IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/UnitTests/UI.Api/VersionControllerTests.cs
+++ b/src/UnitTests/UI.Api/VersionControllerTests.cs
@@ -32,6 +32,7 @@ public class VersionControllerTests
         payload.ShouldNotBeNull();
         payload!.AssemblyVersion.ShouldNotBeNullOrEmpty();
         payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+        payload.Configuration.ShouldNotBeNullOrEmpty();
         payload.Environment.ShouldBe("TestEnvironment");
         payload.MachineName.ShouldBe(Environment.MachineName);
         payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -77,9 +77,11 @@ public class ApiKeyAuthenticationWebTests
         await using var factory = new ApiKeyProtectedWebApplicationFactory();
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/api/v1.0/version");
+        var unversioned = await client.GetAsync("/api/version");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var versioned = await client.GetAsync("/api/v1.0/version");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
 
     [Test]

--- a/src/UnitTests/UI.Server/VersionMetadataEndpointTests.cs
+++ b/src/UnitTests/UI.Server/VersionMetadataEndpointTests.cs
@@ -1,0 +1,127 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Server.RateLimiting;
+using ClearMeasure.Bootcamp.UnitTests.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class VersionMetadataEndpointTests
+{
+    private static IReadOnlyDictionary<string, string?> StrictVersionLimitSettings() =>
+        new Dictionary<string, string?>
+        {
+            ["ApiRateLimiting:Enabled"] = "true",
+            ["ApiRateLimiting:PermitLimit"] = "1",
+            ["ApiRateLimiting:WindowSeconds"] = "2",
+            ["ApiRateLimiting:SegmentsPerWindow"] = "2",
+            ["ApiRateLimiting:QueueLimit"] = "0",
+            ["ApiRateLimiting:ApiKeyHeaderName"] = "X-API-Key"
+        };
+
+    [Test]
+    public async Task Should_Return200AndJsonContract_When_GetVersionUnversioned()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/version");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        root.GetProperty("assemblyVersion").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("informationalVersion").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("configuration").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("environment").GetString().ShouldBe("Testing");
+        root.GetProperty("machineName").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("frameworkDescription").GetString().ShouldNotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task Should_Return200AndMatchingMetadata_When_GetVersionVersionedAndUnversioned()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var unversioned = await client.GetAsync("/api/version");
+        using var versioned = await client.GetAsync("/api/v1.0/version");
+
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var a = await unversioned.Content.ReadAsStringAsync();
+        var b = await versioned.Content.ReadAsStringAsync();
+        using var docA = JsonDocument.Parse(a);
+        using var docB = JsonDocument.Parse(b);
+
+        foreach (var name in new[]
+                 {
+                     "assemblyVersion", "informationalVersion", "configuration", "environment", "machineName",
+                     "frameworkDescription"
+                 })
+        {
+            docA.RootElement.GetProperty(name).GetRawText().ShouldBe(docB.RootElement.GetProperty(name).GetRawText());
+        }
+    }
+
+    [Test]
+    public async Task Should_IndicateOutputCache_When_SecondRequestWithinPolicyWindow()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var first = await client.GetAsync("/api/version");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        first.Headers.Age.ShouldBeNull();
+
+        using var second = await client.GetAsync("/api/version");
+        second.StatusCode.ShouldBe(HttpStatusCode.OK);
+        second.Headers.Age.ShouldNotBeNull();
+        second.Headers.Age!.Value.TotalSeconds.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_EnforceRateLimitPolicy_When_RepeatedGetsToVersionUnderTightLimiter()
+    {
+        await using var factory = new TunableApiRateLimitWebApplicationFactory(StrictVersionLimitSettings());
+        using var client = factory.CreateClient();
+
+        (await client.GetAsync("/api/version")).StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var limited = await client.GetAsync("/api/version");
+        limited.StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+        limited.Headers.TryGetValues("Retry-After", out var ra).ShouldBeTrue();
+        ra!.First().ShouldBe("2");
+        limited.Content.Headers.ContentType?.MediaType.ShouldBe("text/plain");
+        (await limited.Content.ReadAsStringAsync()).ShouldBe("Too many requests. Please try again later.");
+    }
+
+    [Test]
+    public async Task Should_ExposeRateLimitHeaders_When_GetVersionUnderTunableLimiter()
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["ApiRateLimiting:Enabled"] = "true",
+            ["ApiRateLimiting:PermitLimit"] = "5",
+            ["ApiRateLimiting:WindowSeconds"] = "2",
+            ["ApiRateLimiting:SegmentsPerWindow"] = "2",
+            ["ApiRateLimiting:QueueLimit"] = "0",
+            ["ApiRateLimiting:ApiKeyHeaderName"] = "X-API-Key"
+        };
+        await using var factory = new TunableApiRateLimitWebApplicationFactory(settings);
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/version");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues(RateLimitingMiddleware.HeaderLimit, out var limit).ShouldBeTrue();
+        response.Headers.TryGetValues(RateLimitingMiddleware.HeaderRemaining, out var remaining).ShouldBeTrue();
+        limit!.First().ShouldBe("5");
+        int.Parse(remaining!.First(), NumberFormatInfo.InvariantInfo).ShouldBeGreaterThanOrEqualTo(0);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the `/api/version` contract for issue #5036 by adding **build configuration** (`configuration` in JSON) from `AssemblyConfigurationAttribute`, and tightening **UI.Api** build metadata so **informational version** includes source revision when the repo is built from Git (SDK defaults, no new packages).

`GET /api/version` and `GET /api/v1.0/version` remain aligned; additive JSON field only.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/VersionController.cs` | Populate `Configuration`; document `VersionMetadataResponse`. |
| `src/UI/Api/UI.Api.csproj` | `Deterministic` + `IncludeSourceRevisionInInformationalVersion` for richer informational versions in CI. |
| `src/UnitTests/UI.Server/VersionMetadataEndpointTests.cs` | New: unversioned JSON contract, parity with v1.0 path, output cache `Age`, strict rate limit 429 on `/api/version`, rate-limit headers. |
| `src/UnitTests/UI.Api/VersionControllerTests.cs` | Assert `configuration` non-empty on direct controller test. |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Assert `/api/version` returns 200 without API key when middleware enabled (in addition to v1.0). |

## Testing

- `DATABASE_ENGINE=SQLite` + `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — **green** (262 unit tests, 108 integration tests).

## Notes

- Journal comments to the AI Factory work item API returned **404** from the configured base URL; unable to post phase comments from this environment.

Closes #5036
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61a29c23-25c7-4816-9fdf-86df6e2f8626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61a29c23-25c7-4816-9fdf-86df6e2f8626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

