### PR TITLE
New API endpoint GET /api/metrics/summary for application runtime metrics (#5034)

### DIFF
--- a/src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs
@@ -1,0 +1,172 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using ClearMeasure.Bootcamp.UI.Shared;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class MetricsSummaryEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_WithExpectedTopLevelProperties_When_GetMetricsSummaryUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("totalRequestsServed", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("workingSetBytes", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("gcTotalMemoryBytes", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("gcCollections", out var gc).ShouldBeTrue();
+        gc.TryGetProperty("gen0", out _).ShouldBeTrue();
+        gc.TryGetProperty("gen1", out _).ShouldBeTrue();
+        gc.TryGetProperty("gen2", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_WithExpectedTopLevelProperties_When_GetMetricsSummaryVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("totalRequestsServed", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_AlignUptime_WithSimpleHealthSemantics_When_GetMetricsSummary()
+    {
+        var before = DateTime.UtcNow;
+        var metricsResponse = await _client!.GetAsync("/api/metrics/summary");
+        var after = DateTime.UtcNow;
+        metricsResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await metricsResponse.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        var health = SimpleHealthResponseBuilder.Build(TimeProvider.System);
+        (after - before).ShouldBeLessThan(TimeSpan.FromSeconds(30));
+        payload!.Uptime.ShouldBeLessThanOrEqualTo(health.Uptime + TimeSpan.FromSeconds(2));
+        payload.Uptime.ShouldBeGreaterThanOrEqualTo(health.Uptime - TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
+    public async Task Should_ExposeNonNegativeNumericMetrics_When_GetMetricsSummary()
+    {
+        var response = await _client!.GetAsync("/api/metrics/summary");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.TotalRequestsServed.ShouldBeGreaterThanOrEqualTo(0);
+        payload.WorkingSetBytes.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcTotalMemoryBytes.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollections.Gen0.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollections.Gen1.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollections.Gen2.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_IncrementRequestCounter_ForRequestsMatchingDocumentedScope_When_MultipleGets()
+    {
+        await using var factory = new DiagnosticsWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var first = await client.GetAsync("/api/metrics/summary");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var firstPayload = await first.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        firstPayload.ShouldNotBeNull();
+
+        await client.GetAsync("/api/metrics/summary");
+        await client.GetAsync("/api/metrics/summary");
+
+        var last = await client.GetAsync("/api/metrics/summary");
+        last.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var lastPayload = await last.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        lastPayload.ShouldNotBeNull();
+
+        lastPayload!.TotalRequestsServed.ShouldBeGreaterThan(firstPayload!.TotalRequestsServed);
+        (lastPayload.TotalRequestsServed - firstPayload.TotalRequestsServed).ShouldBeGreaterThanOrEqualTo(3);
+    }
+
+    [Test]
+    public async Task Should_Return401_When_ApiKeyRequiredAndHeaderMissing()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/metrics/summary");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/metrics/summary");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiKeyProvidedAndRequired()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await client.GetAsync("/api/metrics/summary");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await client.GetAsync("/api/v1.0/metrics/summary");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return304Or200ConsistentWithConditionalGetEtag_When_IfNoneMatch()
+    {
+        var response = await _client!.GetAsync("/api/metrics/summary");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var etagValues = response.Headers.ETag;
+        etagValues.ShouldNotBeNull();
+        var etag = etagValues!.ToString();
+        etag.ShouldNotBeNullOrWhiteSpace();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/metrics/summary");
+        request.Headers.IfNoneMatch.ParseAdd(etag);
+        var conditional = await _client.SendAsync(request);
+        conditional.StatusCode.ShouldBeOneOf(HttpStatusCode.NotModified, HttpStatusCode.OK);
+    }
+}

--- a/src/UI/Api/Controllers/MetricsSummaryController.cs
+++ b/src/UI/Api/Controllers/MetricsSummaryController.cs
@@ -1,0 +1,38 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes per-process runtime metrics (uptime, request totals, memory, GC) for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/metrics")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/metrics")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class MetricsSummaryController(
+    TimeProvider timeProvider,
+    IApplicationRuntimeMetricsSnapshot metricsSnapshot) : ControllerBase
+{
+    /// <summary>
+    /// Returns uptime (same semantics as <see cref="SimpleHealthResponseBuilder"/>), total requests served,
+    /// working set and GC heap snapshot, and GC collection counts for generations 0–2.
+    /// </summary>
+    [HttpGet("summary")]
+    public IActionResult GetSummary()
+    {
+        var payload = metricsSnapshot.Build(timeProvider);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+        {
+            return StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/IApplicationRuntimeMetricsSnapshot.cs
+++ b/src/UI/Api/IApplicationRuntimeMetricsSnapshot.cs
@@ -1,0 +1,20 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Records HTTP requests handled by the host and exposes a point-in-time snapshot for
+/// <c>GET /api/metrics/summary</c> and <c>GET /api/v1.0/metrics/summary</c>.
+/// </summary>
+public interface IApplicationRuntimeMetricsSnapshot
+{
+    /// <summary>
+    /// Increments the per-process counter for requests that reached the host pipeline
+    /// (see <see cref="MetricsSummaryResponse.TotalRequestsServed"/>).
+    /// </summary>
+    void RecordRequest();
+
+    /// <summary>
+    /// Builds the JSON payload: uptime uses the same calculation as <see cref="SimpleHealthResponseBuilder"/>;
+    /// memory and GC values reflect the current process at call time.
+    /// </summary>
+    MetricsSummaryResponse Build(TimeProvider timeProvider);
+}

--- a/src/UI/Api/MetricsSummaryModels.cs
+++ b/src/UI/Api/MetricsSummaryModels.cs
@@ -1,0 +1,19 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/metrics/summary</c> and <c>GET /api/v1.0/metrics/summary</c>.
+/// Values are per process (not cluster-aggregated). <see cref="TotalRequestsServed"/> counts every HTTP
+/// request that reached <see cref="IApplicationRuntimeMetricsSnapshot.RecordRequest"/> after routing
+/// (entire app, including static files and Blazor, excluding requests that fail before the middleware runs).
+/// </summary>
+public sealed record MetricsSummaryResponse(
+    TimeSpan Uptime,
+    long TotalRequestsServed,
+    long WorkingSetBytes,
+    long GcTotalMemoryBytes,
+    GcCollectionCounts GcCollections);
+
+/// <summary>
+/// GC collection counts from <see cref="GC.CollectionCount"/> for generations 0–2 at snapshot time.
+/// </summary>
+public sealed record GcCollectionCounts(int Gen0, int Gen1, int Gen2);

--- a/src/UI/Server/ApplicationRuntimeMetricsCollector.cs
+++ b/src/UI/Server/ApplicationRuntimeMetricsCollector.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+using ClearMeasure.Bootcamp.UI.Api;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Thread-safe per-process HTTP request counter and runtime metrics snapshot for the metrics summary API.
+/// </summary>
+public sealed class ApplicationRuntimeMetricsCollector : IApplicationRuntimeMetricsSnapshot
+{
+    private long _totalRequests;
+
+    /// <inheritdoc />
+    public void RecordRequest() => Interlocked.Increment(ref _totalRequests);
+
+    /// <inheritdoc />
+    public MetricsSummaryResponse Build(TimeProvider timeProvider)
+    {
+        var uptime = SimpleHealthResponseBuilder.Build(timeProvider).Uptime;
+        var workingSet = Process.GetCurrentProcess().WorkingSet64;
+        var gcMemory = GC.GetTotalMemory(false);
+        var gc = new GcCollectionCounts(
+            GC.CollectionCount(0),
+            GC.CollectionCount(1),
+            GC.CollectionCount(2));
+        return new MetricsSummaryResponse(
+            uptime,
+            Interlocked.Read(ref _totalRequests),
+            workingSet,
+            gcMemory,
+            gc);
+    }
+}

--- a/src/UI/Server/Middleware/HttpRequestMetricsMiddleware.cs
+++ b/src/UI/Server/Middleware/HttpRequestMetricsMiddleware.cs
@@ -1,0 +1,15 @@
+using ClearMeasure.Bootcamp.UI.Api;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Middleware;
+
+/// <summary>
+/// Increments the application-wide HTTP request counter once per request after routing.
+/// </summary>
+public sealed class HttpRequestMetricsMiddleware(RequestDelegate next)
+{
+    public Task InvokeAsync(HttpContext context, IApplicationRuntimeMetricsSnapshot metrics)
+    {
+        metrics.RecordRequest();
+        return next(context);
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -162,6 +162,8 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseMiddleware<HttpRequestMetricsMiddleware>();
+
 app.UseWhen(
     context => ApiRateLimitingExtensions.ShouldApplyToPath(context.Request.Path),
     branch => branch.UseRequestTimeouts());

--- a/src/UI/Server/UIServiceRegistry.cs
+++ b/src/UI/Server/UIServiceRegistry.cs
@@ -73,5 +73,6 @@ public class UiServiceRegistry : ServiceRegistry
             .AddCheck<NeedsRebootHealthCheck>("NeedsReboot");
 
         this.AddSingleton<IDetailedHealthReportProvider, DetailedHealthReportProvider>();
+        this.AddSingleton<IApplicationRuntimeMetricsSnapshot, ApplicationRuntimeMetricsCollector>();
     }
 }

--- a/src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs
+++ b/src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class MetricsSummaryControllerTests
+{
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class StubMetricsSnapshot(MetricsSummaryResponse response) : IApplicationRuntimeMetricsSnapshot
+    {
+        public void RecordRequest()
+        {
+        }
+
+        public MetricsSummaryResponse Build(TimeProvider timeProvider) => response;
+    }
+
+    [Test]
+    public void GetSummary_Should_ReturnJson_WithExpectedFields_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+        var stubPayload = new MetricsSummaryResponse(
+            TimeSpan.FromHours(2),
+            42,
+            9_000_000,
+            8_000_000,
+            new GcCollectionCounts(10, 3, 1));
+        var controller = new MetricsSummaryController(clock, new StubMetricsSnapshot(stubPayload))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.GetSummary();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<MetricsSummaryResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Uptime.ShouldBe(TimeSpan.FromHours(2));
+        payload.TotalRequestsServed.ShouldBe(42);
+        payload.WorkingSetBytes.ShouldBe(9_000_000);
+        payload.GcTotalMemoryBytes.ShouldBe(8_000_000);
+        payload.GcCollections.Gen0.ShouldBe(10);
+        payload.GcCollections.Gen1.ShouldBe(3);
+        payload.GcCollections.Gen2.ShouldBe(1);
+    }
+
+    [Test]
+    public void GetSummary_Should_Return304_When_IfNoneMatchMatchesEtag()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+        var stubPayload = new MetricsSummaryResponse(
+            TimeSpan.FromMinutes(5),
+            1,
+            100,
+            200,
+            new GcCollectionCounts(1, 0, 0));
+        var httpContext = new DefaultHttpContext();
+        var controller = new MetricsSummaryController(clock, new StubMetricsSnapshot(stubPayload))
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+
+        var first = controller.GetSummary();
+        var etag = httpContext.Response.Headers.ETag.ToString();
+        etag.ShouldNotBeNullOrWhiteSpace();
+
+        httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.IfNoneMatch = etag;
+        controller = new MetricsSummaryController(clock, new StubMetricsSnapshot(stubPayload))
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+
+        var second = controller.GetSummary();
+        second.ShouldBeOfType<StatusCodeResult>();
+        ((StatusCodeResult)second).StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/metrics/summary", false)]
+    [TestCase("/api/v1.0/metrics/summary", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/metrics/summary` and `GET /api/v1.0/metrics/summary` returning per-process JSON: uptime (same path as `SimpleHealthResponseBuilder`), total HTTP requests served, working set and GC heap bytes, and GC collection counts for generations 0–2. A singleton `ApplicationRuntimeMetricsCollector` implements `IApplicationRuntimeMetricsSnapshot`; `HttpRequestMetricsMiddleware` (after `UseRouting`) increments the counter for every request that reaches the pipeline. The controller uses weak ETags with `If-None-Match` → 304 when the serialized payload matches, mirroring `DetailedHealthController`. `[EnableRateLimiting(ApiRateLimiting.PolicyName)]` matches other `/api/*` JSON surfaces.

Closes #5034

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/IApplicationRuntimeMetricsSnapshot.cs` | Abstraction for recording requests and building the summary DTO |
| `src/UI/Api/MetricsSummaryModels.cs` | `MetricsSummaryResponse` and `GcCollectionCounts` records + XML contract |
| `src/UI/Api/Controllers/MetricsSummaryController.cs` | Versioned and unversioned routes, rate limiting, conditional GET |
| `src/UI/Server/ApplicationRuntimeMetricsCollector.cs` | Thread-safe counter and snapshot implementation |
| `src/UI/Server/Middleware/HttpRequestMetricsMiddleware.cs` | Increments counter per request |
| `src/UI/Server/Program.cs` | Registers middleware after routing |
| `src/UI/Server/UIServiceRegistry.cs` | DI registration for collector |
| `src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs` | Controller JSON and 304 behavior with stubs |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Metrics paths require API key when middleware enabled |
| `src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs` | WebApplicationFactory coverage per test design |

## Testing

- `export DATABASE_ENGINE=SQLite && pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — succeeded (261 unit tests, 116 integration tests).
- Targeted runs before full build: `MetricsSummaryControllerTests`, `ApiKeyAuthenticationMiddlewareTests` filter; `MetricsSummaryEndpointIntegrationTests` filter.

## Notes

- Work item journal comments via AI Factory API failed: ngrok endpoint returned ERR_NGROK_3200 (offline) for POST `/comments`; no label changes attempted.
- GitHub issue labels include **AI Factory** only (no Auto Merge label in context). Per workflow, Phase 6/7 (merge, base-branch build, Ready To Move) are skipped; PR remains for human review and merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e7e0d96-bbfb-41b2-bde4-11677b0760ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e7e0d96-bbfb-41b2-bde4-11677b0760ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

