### PR TITLE
Add a simple /api/ping endpoint that returns pong (#5118)

### DIFF
--- a/src/UI/Api/Controllers/PingController.cs
+++ b/src/UI/Api/Controllers/PingController.cs
@@ -1,0 +1,34 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Minimal liveness probe for integrations and pipeline validation.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/ping")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/ping")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class PingController : ControllerBase
+{
+    /// <summary>
+    /// Returns plain text <c>pong</c> when the API host is reachable.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        return new ContentResult
+        {
+            Content = "pong",
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = StatusCodes.Status200OK
+        };
+    }
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionTimeOrPingPath(value))
         {
             return false;
         }
@@ -65,7 +65,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicVersionTimeOrPingPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
@@ -77,7 +77,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         {
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -85,7 +86,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         {
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -14,6 +14,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/ping", true)]
+    [TestCase("/api/v1.0/ping", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -92,4 +92,15 @@ public class ApiKeyAuthenticationWebTests
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return200_When_PingWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/ping");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }

--- a/src/UnitTests/UI.Server/PingEndpointWebTests.cs
+++ b/src/UnitTests/UI.Server/PingEndpointWebTests.cs
@@ -1,0 +1,21 @@
+using System.Net;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class PingEndpointWebTests
+{
+    [Test]
+    public async Task Should_ReturnPongPlainText_When_GetApiPing()
+    {
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/ping");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe("text/plain");
+        (await response.Content.ReadAsStringAsync()).Trim().ShouldBe("pong");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/ping` and `GET /api/v1.0/ping` returning HTTP 200 with plain body `pong` and `Content-Type: text/plain; charset=utf-8`, following the same controller patterns as `TimeController` (API versioning, `[AllowAnonymous]`, `[EnableRateLimiting]`). Extends optional API key middleware so ping is public when API key validation is enabled, consistent with `/api/version` and `/api/time`.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/PingController.cs` | New controller with unversioned and versioned routes. |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Public-path logic includes `ping`; helper renamed to `IsPublicVersionTimeOrPingPath`. |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | `[TestCase]` rows for `/api/ping` and `/api/v1.0/ping`. |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Asserts 200 for ping without API key when protection is on. |
| `src/UnitTests/UI.Server/PingEndpointWebTests.cs` | Web factory test for status, body, and media type. |

## Testing

Ran `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1`: build succeeded; unit tests 261 passed; integration tests 108 passed.

Closes #5118
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f6e5ee-614d-430f-b122-2b574dc0fd9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f6e5ee-614d-430f-b122-2b574dc0fd9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

