### PR TITLE
New API endpoint GET /api/health/detailed for component-level health reporting (#5205)

### DIFF
--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and detailed health probe endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionOrTimePath(value) || IsPublicDetailedHealthPath(value))
         {
             return false;
         }
@@ -86,6 +86,35 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> for <c>/api/health/detailed</c> and <c>/api/v{version}/health/detailed</c> so orchestration probes do not require the API key.
+    /// </summary>
+    internal static bool IsPublicDetailedHealthPath(string pathValue)
+    {
+        var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 3 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("health", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("detailed", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("health", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("detailed", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         return false;

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -7,6 +7,8 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
 public class ApiKeyAuthenticationMiddlewareTests
 {
     [TestCase("/api/health", false)]
+    [TestCase("/api/health/detailed", true)]
+    [TestCase("/api/v1.0/health/detailed", true)]
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -19,6 +19,19 @@ public class ApiKeyAuthenticationWebTests
     }
 
     [Test]
+    public async Task Should_Return200_When_ApiHealthDetailedCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/health/detailed");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/health/detailed");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
     public async Task Should_Return200_When_ApiHealthCalledWithValidKey()
     {
         await using var factory = new ApiKeyProtectedWebApplicationFactory();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `GET /api/health/detailed` and `GET /api/v1.0/health/detailed` endpoints were already implemented (`DetailedHealthController`, `DetailedHealthReportProvider`, integration tests). This change closes the gap called out in the issue: when optional API key authentication is enabled, **detailed** health probes can run without the shared key (same operational expectation as anonymous load balancers), while **`GET /api/health`** remains protected.

## Files changed

- `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` — Treat `/api/health/detailed` and `/api/v{version}/health/detailed` as public paths (skip validation when API key is enabled).
- `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` — New `ShouldValidate` cases for the detailed paths.
- `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` — Web test asserting 200 without API key for both unversioned and versioned detailed URLs.

## Testing

- `dotnet test` filter `ApiKeyAuthentication` (middleware + web tests).
- Full `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: unit tests (260) and integration tests (108) all passed.

Closes #5205

---

**Note:** AI Factory work-item journal comments could not be posted: ngrok URL returned `ERR_NGROK_8012` (upstream unreachable).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-627a072c-afc2-414b-95fb-064a0fca13b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-627a072c-afc2-414b-95fb-064a0fca13b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

