### PR TITLE
Add navigate hide button (#5204)

### DIFF
--- a/src/AcceptanceTests/App/MainLayoutNavRailTests.cs
+++ b/src/AcceptanceTests/App/MainLayoutNavRailTests.cs
@@ -1,0 +1,30 @@
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UI.Shared;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
+
+[TestFixture]
+public class MainLayoutNavRailTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldToggleNavRail_AndUpdateAria_OnLandingPage()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+        await Expect(toggle).ToBeVisibleAsync();
+        await Expect(toggle).ToHaveAttributeAsync("aria-controls", "app-navigation-rail");
+        await Expect(toggle).ToHaveAttributeAsync("aria-expanded", "true");
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Expect(toggle).ToHaveAttributeAsync("aria-expanded", "false");
+
+        var app = Page.Locator(".modern-app").First;
+        await Expect(app).ToHaveClassAsync(new Regex("rail-collapsed"));
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Expect(toggle).ToHaveAttributeAsync("aria-expanded", "true");
+        await Expect(app).Not.ToHaveClassAsync(new Regex("rail-collapsed"));
+    }
+}


### PR DESCRIPTION
## Summary

The navigation rail toggle (header button, wide collapse / narrow overlay, ARIA, `mainLayoutNav.js`) is already implemented on `MainLayout` per issue #5204. This pull request adds a **Playwright smoke test** so the toggle stays covered end-to-end in CI.

## Files changed

| File | Change |
|------|--------|
| `src/AcceptanceTests/App/MainLayoutNavRailTests.cs` | New test: asserts `NavRailToggle` visibility, `aria-controls` / `aria-expanded`, collapse adds `rail-collapsed` on `.modern-app`, reopen restores state. |

## Testing

- Ran `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` (unit + integration): all green.
- The new acceptance test follows the same pattern as `CopyrightFooterTests` (landing page, `Click` helper, `Retry(2)`). Full acceptance suite was not re-run here because it depends on the hosted app fixture; CI runs acceptance tests when configured.

Closes #5204
