### PR TITLE
Add work order instructions as a new field (#5268)

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -311,6 +311,7 @@ public abstract class AcceptanceTestBase
         order.Number = null;
         var testTitle = order.Title;
         var testDescription = order.Description;
+        var testInstructions = order.Instructions;
         var testRoomNumber = order.RoomNumber;
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -324,6 +325,7 @@ public abstract class AcceptanceTestBase
         order.Number = newWorkOrderNumber;
         await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
         await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), testInstructions);
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
         await TakeScreenshotAsync(2, "FormFilled");
 

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -49,6 +49,9 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         var descriptionField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Description));
         await Expect(descriptionField).ToHaveValueAsync(order.Description!);
 
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions!);
+
         var roomNumberField = Page.GetByTestId(nameof(WorkOrderManage.Elements.RoomNumber));
         await Expect(roomNumberField).ToHaveValueAsync(order.RoomNumber!);
 

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSpeechTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSpeechTests.cs
@@ -58,6 +58,20 @@ public class WorkOrderSpeechTests : AcceptanceTestBase
     }
 
     [Test, Retry(2)]
+    public async Task ShouldClickSpeakInstructionsButtonWithoutError()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Input(nameof(WorkOrderManage.Elements.Instructions), "Test speech instructions");
+        await Click(nameof(WorkOrderManage.Elements.SpeakInstructions));
+
+        await Expect(Page).ToHaveURLAsync(new Regex("/workorder/manage/"));
+    }
+
+    [Test, Retry(2)]
     public async Task ShouldShowSpeakButtonsOnReadOnlyWorkOrder()
     {
         await LoginAsCurrentUser();
@@ -77,5 +91,6 @@ public class WorkOrderSpeechTests : AcceptanceTestBase
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.ReadOnlyMessage))).ToBeVisibleAsync();
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.SpeakTitle))).ToBeVisibleAsync();
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.SpeakDescription))).ToBeVisibleAsync();
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.SpeakInstructions))).ToBeVisibleAsync();
     }
 }

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions = "";
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(300);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION
+GO
+PRINT N'Adding [Instructions] to [dbo].[WorkOrder]'
+GO
+ALTER TABLE [dbo].[WorkOrder] ADD [Instructions] NVARCHAR(4000) NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/IntegrationTests/Api/GrpcWorkOrderIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GrpcWorkOrderIntegrationTests.cs
@@ -71,6 +71,7 @@ public class GrpcWorkOrderIntegrationTests
                 Number = "GRPC-001",
                 Title = "Test title",
                 Description = "Test description",
+                Instructions = "Bring spare bulbs",
                 RoomNumber = "101",
                 Status = WorkOrderStatus.Draft,
                 Creator = creator,
@@ -87,6 +88,7 @@ public class GrpcWorkOrderIntegrationTests
         reply.WorkOrder.Number.ShouldBe("GRPC-001");
         reply.WorkOrder.Title.ShouldBe("Test title");
         reply.WorkOrder.Description.ShouldBe("Test description");
+        reply.WorkOrder.Instructions.ShouldBe("Bring spare bulbs");
         reply.WorkOrder.RoomNumber.ShouldBe("101");
         reply.WorkOrder.StatusKey.ShouldBe(WorkOrderStatus.Draft.Key);
         reply.WorkOrder.CreatorUsername.ShouldBe("grpc-creator");

--- a/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForSaveTests.cs
+++ b/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForSaveTests.cs
@@ -39,6 +39,7 @@ public class StateCommandHandlerForSaveTests : IntegratedTestBase
         var order = context3.Find<WorkOrder>(result.WorkOrder.Id) ?? throw new InvalidOperationException();
         order.CreatedDate.ShouldBe(TestHost.TestTime.DateTime);
         order.Title.ShouldBe(workOrder.Title);
+        order.Instructions.ShouldBe(workOrder.Instructions);
     }
 
     [Test]

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -19,6 +19,7 @@ public class WorkOrderMappingTests
             Number = "WO-01",
             Title = "Fix lighting",
             Description = "Replace broken light bulbs in conference room",
+            Instructions = "Use ladder from storage",
             RoomNumber = "CR-101",
             Status = WorkOrderStatus.Draft,
             Creator = creator
@@ -43,6 +44,7 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Number.ShouldBe("WO-01");
         rehydratedWorkOrder.Title.ShouldBe("Fix lighting");
         rehydratedWorkOrder.Description.ShouldBe("Replace broken light bulbs in conference room");
+        rehydratedWorkOrder.Instructions.ShouldBe("Use ladder from storage");
         rehydratedWorkOrder.RoomNumber.ShouldBe("CR-101");
         rehydratedWorkOrder.Status.ShouldBe(WorkOrderStatus.Draft);
         rehydratedWorkOrder.Creator.ShouldNotBeNull();

--- a/src/IntegrationTests/TestHost.cs
+++ b/src/IntegrationTests/TestHost.cs
@@ -176,8 +176,9 @@ public static class TestHost
                     ([System.ComponentModel.Description("Title")] string title,
                      [System.ComponentModel.Description("Description")] string description,
                      [System.ComponentModel.Description("Creator username")] string creatorUsername,
-                     [System.ComponentModel.Description("Optional room number")] string? roomNumber = null)
-                        => WorkOrderTools.CreateWorkOrder(CreateScopedBus(), CreateScopedNumberGenerator(), title, description, creatorUsername, roomNumber),
+                     [System.ComponentModel.Description("Optional room number")] string? roomNumber = null,
+                     [System.ComponentModel.Description("Optional execution instructions")] string? instructions = null)
+                        => WorkOrderTools.CreateWorkOrder(CreateScopedBus(), CreateScopedNumberGenerator(), title, description, creatorUsername, roomNumber, instructions),
                     "CreateWorkOrder",
                     "Creates a new draft work order."),
                 AIFunctionFactory.Create(

--- a/src/LlmGateway/WorkOrderTool.cs
+++ b/src/LlmGateway/WorkOrderTool.cs
@@ -9,7 +9,7 @@ namespace ClearMeasure.Bootcamp.LlmGateway;
 public class WorkOrderTool(IBus bus)
 {
     [Description("Retrieves a specific work order by its unique number. " +
-                 "Returns the full work order including title, description, room number, status, " +
+                 "Returns the full work order including title, description, instructions (execution guidance), room number, status, " +
                  "the employee who created it (creator), and the employee it is assigned to (assignee). " +
                  "Use this when the user asks about a specific work order, its details, status, or who is involved.")]
     public async Task<WorkOrder?> GetWorkOrderByNumber(

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -44,14 +44,15 @@ public class WorkOrderTools
             new JsonSerializerOptions { WriteIndented = true });
     }
 
-    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts a room number for the location.")]
+    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts a room number and optional execution instructions.")]
     public static async Task<string> CreateWorkOrder(
         IBus bus,
         IWorkOrderNumberGenerator numberGenerator,
         [Description("Title of the work order")] string title,
         [Description("Description of the work order")] string description,
         [Description("Username of the employee creating the work order")] string creatorUsername,
-        [Description("Optional room number or location for the work order")] string? roomNumber = null)
+        [Description("Optional room number or location for the work order")] string? roomNumber = null,
+        [Description("Optional execution instructions for the assignee")] string? instructions = null)
     {
         try
         {
@@ -65,6 +66,7 @@ public class WorkOrderTools
             {
                 Title = title,
                 Description = description,
+                Instructions = instructions,
                 Creator = creator,
                 Status = WorkOrderStatus.Draft,
                 Number = numberGenerator.GenerateNumber(),
@@ -195,6 +197,7 @@ public class WorkOrderTools
         wo.Number,
         wo.Title,
         wo.Description,
+        wo.Instructions,
         Status = wo.Status.FriendlyName,
         wo.RoomNumber,
         Creator = wo.Creator?.GetFullName(),

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    [StringLength(4000)] public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -58,6 +58,15 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
+                        <button type="button" data-testid="@Elements.SpeakInstructions" class="btn btn-sm btn-outline-secondary" aria-label="Speak instructions" title="Speak instructions" @onclick="SpeakInstructionsAsync">&#x1F50A;</button>
+                    </div>
+                    <div class="form-text text-muted">Max 4000 characters</div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -145,6 +154,7 @@
         Title,
         AssigneeFullName,
         RoomNumber,
+        Instructions,
         Description,
         AssignedDate,
         CompletedDate,
@@ -162,6 +172,7 @@
         AttachmentUploadedBy,
         AttachmentUploadedDate,
         SpeakTitle,
-        SpeakDescription
+        SpeakDescription,
+        SpeakInstructions
     }
 }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -92,6 +92,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate?.ToString("G", CultureInfo.CurrentCulture),
             AssignedDate = workOrder.AssignedDate?.ToString("G", CultureInfo.CurrentCulture),
@@ -131,6 +132,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()
@@ -150,6 +152,11 @@ public partial class WorkOrderManage : AppComponentBase
     private async Task SpeakDescriptionAsync()
     {
         await SpeakTextAsync(Model.Description);
+    }
+
+    private async Task SpeakInstructionsAsync()
+    {
+        await SpeakTextAsync(Model.Instructions);
     }
 
     private async Task SpeakTextAsync(string? text)

--- a/src/UI/Server/Generated/Protos/Workorders.cs
+++ b/src/UI/Server/Generated/Protos/Workorders.cs
@@ -29,21 +29,21 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             "aW5nUmVwbHkSDwoHbWVzc2FnZRgBIAEoCSItChtHZXRXb3JrT3JkZXJCeU51",
             "bWJlclJlcXVlc3QSDgoGbnVtYmVyGAEgASgJIkYKGUdldFdvcmtPcmRlckJ5",
             "TnVtYmVyUmVwbHkSKQoKd29ya19vcmRlchgBIAEoCzIVLndvcmtvcmRlcnMu",
-            "V29ya09yZGVyIpMDCglXb3JrT3JkZXISDgoGbnVtYmVyGAEgASgJEg0KBXRp",
+            "V29ya09yZGVyIqkDCglXb3JrT3JkZXISDgoGbnVtYmVyGAEgASgJEg0KBXRp",
             "dGxlGAIgASgJEhMKC2Rlc2NyaXB0aW9uGAMgASgJEhMKC3Jvb21fbnVtYmVy",
             "GAQgASgJEhIKCnN0YXR1c19rZXkYBSABKAkSGAoQY3JlYXRvcl91c2VybmFt",
             "ZRgGIAEoCRIZChFhc3NpZ25lZV91c2VybmFtZRgHIAEoCRI6ChFhc3NpZ25l",
             "ZF9kYXRlX3V0YxgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBI",
             "AIgBARI5ChBjcmVhdGVkX2RhdGVfdXRjGAkgASgLMhouZ29vZ2xlLnByb3Rv",
             "YnVmLlRpbWVzdGFtcEgBiAEBEjsKEmNvbXBsZXRlZF9kYXRlX3V0YxgKIAEo",
-            "CzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIAogBAUIUChJfYXNzaWdu",
-            "ZWRfZGF0ZV91dGNCEwoRX2NyZWF0ZWRfZGF0ZV91dGNCFQoTX2NvbXBsZXRl",
-            "ZF9kYXRlX3V0YzKsAQoKV29ya09yZGVycxI2CgRQaW5nEhcud29ya29yZGVy",
-            "cy5QaW5nUmVxdWVzdBoVLndvcmtvcmRlcnMuUGluZ1JlcGx5EmYKFEdldFdv",
-            "cmtPcmRlckJ5TnVtYmVyEicud29ya29yZGVycy5HZXRXb3JrT3JkZXJCeU51",
-            "bWJlclJlcXVlc3QaJS53b3Jrb3JkZXJzLkdldFdvcmtPcmRlckJ5TnVtYmVy",
-            "UmVwbHlCJ6oCJENsZWFyTWVhc3VyZS5Cb290Y2FtcC5VSS5TZXJ2ZXIuR3Jw",
-            "Y2IGcHJvdG8z"));
+            "CzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIAogBARIUCgxpbnN0cnVj",
+            "dGlvbnMYCyABKAlCFAoSX2Fzc2lnbmVkX2RhdGVfdXRjQhMKEV9jcmVhdGVk",
+            "X2RhdGVfdXRjQhUKE19jb21wbGV0ZWRfZGF0ZV91dGMyrAEKCldvcmtPcmRl",
+            "cnMSNgoEUGluZxIXLndvcmtvcmRlcnMuUGluZ1JlcXVlc3QaFS53b3Jrb3Jk",
+            "ZXJzLlBpbmdSZXBseRJmChRHZXRXb3JrT3JkZXJCeU51bWJlchInLndvcmtv",
+            "cmRlcnMuR2V0V29ya09yZGVyQnlOdW1iZXJSZXF1ZXN0GiUud29ya29yZGVy",
+            "cy5HZXRXb3JrT3JkZXJCeU51bWJlclJlcGx5QieqAiRDbGVhck1lYXN1cmUu",
+            "Qm9vdGNhbXAuVUkuU2VydmVyLkdycGNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -51,7 +51,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.PingReply), global::ClearMeasure.Bootcamp.UI.Server.Grpc.PingReply.Parser, new[]{ "Message" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberRequest), global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberRequest.Parser, new[]{ "Number" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberReply), global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberReply.Parser, new[]{ "WorkOrder" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder), global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder.Parser, new[]{ "Number", "Title", "Description", "RoomNumber", "StatusKey", "CreatorUsername", "AssigneeUsername", "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, new[]{ "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder), global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder.Parser, new[]{ "Number", "Title", "Description", "RoomNumber", "StatusKey", "CreatorUsername", "AssigneeUsername", "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc", "Instructions" }, new[]{ "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, null, null, null)
           }));
     }
     #endregion
@@ -867,6 +867,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       assignedDateUtc_ = other.assignedDateUtc_ != null ? other.assignedDateUtc_.Clone() : null;
       createdDateUtc_ = other.createdDateUtc_ != null ? other.createdDateUtc_.Clone() : null;
       completedDateUtc_ = other.completedDateUtc_ != null ? other.completedDateUtc_.Clone() : null;
+      instructions_ = other.instructions_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -996,6 +997,18 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       }
     }
 
+    /// <summary>Field number for the "instructions" field.</summary>
+    public const int InstructionsFieldNumber = 11;
+    private string instructions_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Instructions {
+      get { return instructions_; }
+      set {
+        instructions_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -1021,6 +1034,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       if (!object.Equals(AssignedDateUtc, other.AssignedDateUtc)) return false;
       if (!object.Equals(CreatedDateUtc, other.CreatedDateUtc)) return false;
       if (!object.Equals(CompletedDateUtc, other.CompletedDateUtc)) return false;
+      if (Instructions != other.Instructions) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -1038,6 +1052,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       if (assignedDateUtc_ != null) hash ^= AssignedDateUtc.GetHashCode();
       if (createdDateUtc_ != null) hash ^= CreatedDateUtc.GetHashCode();
       if (completedDateUtc_ != null) hash ^= CompletedDateUtc.GetHashCode();
+      if (Instructions.Length != 0) hash ^= Instructions.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -1096,6 +1111,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
         output.WriteRawTag(82);
         output.WriteMessage(CompletedDateUtc);
       }
+      if (Instructions.Length != 0) {
+        output.WriteRawTag(90);
+        output.WriteString(Instructions);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1146,6 +1165,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
         output.WriteRawTag(82);
         output.WriteMessage(CompletedDateUtc);
       }
+      if (Instructions.Length != 0) {
+        output.WriteRawTag(90);
+        output.WriteString(Instructions);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1185,6 +1208,9 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       }
       if (completedDateUtc_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(CompletedDateUtc);
+      }
+      if (Instructions.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Instructions);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -1236,6 +1262,9 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
           CompletedDateUtc = new global::Google.Protobuf.WellKnownTypes.Timestamp();
         }
         CompletedDateUtc.MergeFrom(other.CompletedDateUtc);
+      }
+      if (other.Instructions.Length != 0) {
+        Instructions = other.Instructions;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -1305,6 +1334,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             input.ReadMessage(CompletedDateUtc);
             break;
           }
+          case 90: {
+            Instructions = input.ReadString();
+            break;
+          }
         }
       }
     #endif
@@ -1371,6 +1404,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
               CompletedDateUtc = new global::Google.Protobuf.WellKnownTypes.Timestamp();
             }
             input.ReadMessage(CompletedDateUtc);
+            break;
+          }
+          case 90: {
+            Instructions = input.ReadString();
             break;
           }
         }

--- a/src/UI/Server/Grpc/WorkOrdersGrpcService.cs
+++ b/src/UI/Server/Grpc/WorkOrdersGrpcService.cs
@@ -42,6 +42,7 @@ public class WorkOrdersGrpcService(IBus bus) : WorkOrders.WorkOrdersBase
             Number = source.Number ?? "",
             Title = source.Title ?? "",
             Description = source.Description ?? "",
+            Instructions = source.Instructions ?? "",
             RoomNumber = source.RoomNumber ?? "",
             StatusKey = source.Status.Key,
             CreatorUsername = source.Creator?.UserName ?? "",

--- a/src/UI/Server/Protos/workorders.proto
+++ b/src/UI/Server/Protos/workorders.proto
@@ -36,4 +36,5 @@ message WorkOrder {
   optional google.protobuf.Timestamp assigned_date_utc = 8;
   optional google.protobuf.Timestamp created_date_utc = 9;
   optional google.protobuf.Timestamp completed_date_utc = 10;
+  string instructions = 11;
 }

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -40,6 +41,7 @@ public class WorkOrderTests
         workOrder.Id = guid;
         workOrder.Title = "Title";
         workOrder.Description = "Description";
+        workOrder.Instructions = "Turn off power first";
         workOrder.Status = WorkOrderStatus.Complete;
         workOrder.Number = "Number";
         workOrder.Creator = creator;
@@ -48,6 +50,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(guid));
         Assert.That(workOrder.Title, Is.EqualTo("Title"));
         Assert.That(workOrder.Description, Is.EqualTo("Description"));
+        Assert.That(workOrder.Instructions, Is.EqualTo("Turn off power first"));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Complete));
         Assert.That(workOrder.Number, Is.EqualTo("Number"));
         Assert.That(workOrder.Creator, Is.EqualTo(creator));
@@ -70,6 +73,15 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('y', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions.Length, Is.EqualTo(4000));
     }
 
     [Test]

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageSpeechTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageSpeechTests.cs
@@ -49,6 +49,35 @@ public class WorkOrderManageSpeechTests
     }
 
     [Test]
+    public void ShouldRenderSpeakInstructionsButton()
+    {
+        using var ctx = new TestContext();
+
+        var user = new Employee("jpalermo", "Jeffrey", "Palermo", "jp@example.com");
+        user.Id = Guid.NewGuid();
+
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IWorkOrderBuilder>(new StubWorkOrderBuilder());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
+        ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
+        ctx.Services.AddSpeechSynthesis();
+
+        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.SpeakInstructions}']");
+            element.ShouldNotBeNull();
+            element.TagName.ShouldBe("BUTTON", StringCompareShould.IgnoreCase);
+            element.GetAttribute("type").ShouldBe("button");
+        });
+    }
+
+    [Test]
     public void ShouldRenderSpeakDescriptionButton()
     {
         using var ctx = new TestContext();


### PR DESCRIPTION
## Summary

Adds an optional **Instructions** field to work orders for execution guidance separate from **Description**. The maintain form shows a multiline Instructions control between Description and Room, with the same styling, read-only behavior, character limit (4000), TTS button parity, and automation test ids. The field persists through EF, DbUp migration `028`, gRPC `GetWorkOrderByNumber`, and MCP create/detail payloads.

## Files changed

| Area | Files |
|------|--------|
| Domain | `WorkOrder.cs` — Instructions with truncation |
| Database | `028_AddInstructionsToWorkOrder.sql` |
| EF | `WorkOrderMap.cs` |
| UI | `WorkOrderManage.razor`, `.razor.cs`, `WorkOrderManageModel.cs` |
| gRPC | `workorders.proto`, `Workorders.cs` (regenerated), `WorkOrdersGrpcService.cs` |
| MCP / LLM | `WorkOrderTools.cs`, `WorkOrderTool.cs`, `TestHost.cs` (AI tool delegate) |
| Tests | Unit, integration, acceptance updates |

## Testing

- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` — build, unit tests, integration tests: **passed**
- `dotnet test` UnitTests + IntegrationTests Release: **passed**
- Acceptance tests not executed in this environment (Playwright); acceptance test code updated for Instructions.

Closes #5268
