### PR TITLE
New API endpoint GET /api/features/flags for runtime feature flag status (#5280)

### DIFF
--- a/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
@@ -134,6 +134,54 @@ public class DiagnosticsEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_Return200AndJson_When_GetFeatureFlagsUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/features/flags");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetFeatureFlagsVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/features/flags");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_ExposeSameFeatureFlags_AsDiagnostics_When_GetFeatureFlags()
+    {
+        var diag = await _client!.GetAsync("/api/diagnostics");
+        var flags = await _client.GetAsync("/api/features/flags");
+        diag.StatusCode.ShouldBe(HttpStatusCode.OK);
+        flags.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var diagPayload = await diag.Content.ReadFromJsonAsync<DiagnosticsResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var flagsPayload = await flags.Content.ReadFromJsonAsync<RuntimeFeatureFlagsResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        diagPayload.ShouldNotBeNull();
+        flagsPayload.ShouldNotBeNull();
+        flagsPayload!.FeatureFlags.SampleFeatureA.ShouldBe(diagPayload!.FeatureFlags.SampleFeatureA);
+        flagsPayload.FeatureFlags.SampleFeatureB.ShouldBe(diagPayload.FeatureFlags.SampleFeatureB);
+    }
+
+    [Test]
     public async Task Should_NotConflictWithLegacyDiagnostics_When_RoutesRegistered()
     {
         var response = await _client!.GetAsync("/api/diagnostics");
@@ -154,6 +202,11 @@ public class DiagnosticsEndpointIntegrationTests
 
         var unauthVersioned = await client.GetAsync("/api/v1.0/diagnostics");
         unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var flagsUnauth = await client.GetAsync("/api/features/flags");
+        flagsUnauth.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var flagsVersionedUnauth = await client.GetAsync("/api/v1.0/features/flags");
+        flagsVersionedUnauth.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         using var withKey = factory.CreateClient();
         withKey.DefaultRequestHeaders.Add(

--- a/src/UI/Api/Controllers/FeatureFlagsController.cs
+++ b/src/UI/Api/Controllers/FeatureFlagsController.cs
@@ -1,0 +1,34 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes resolved configuration feature flags for runtime clients and operators.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/features/flags")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/features/flags")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class FeatureFlagsController(IOptions<DiagnosticsFeatureFlagsOptions> featureFlagsOptions) : ControllerBase
+{
+    /// <summary>
+    /// Returns the current <see cref="DiagnosticsFeatureFlagsOptions"/> bound from configuration.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var payload = new RuntimeFeatureFlagsResponse(featureFlagsOptions.Value);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/DiagnosticsFeatureFlagsOptions.cs
+++ b/src/UI/Api/DiagnosticsFeatureFlagsOptions.cs
@@ -1,7 +1,7 @@
 namespace ClearMeasure.Bootcamp.UI.Api;
 
 /// <summary>
-/// Configuration-bound feature flags exposed on <c>GET /api/diagnostics</c> for deployment verification.
+/// Configuration-bound feature flags exposed on <c>GET /api/diagnostics</c> and <c>GET /api/features/flags</c> for deployment verification.
 /// </summary>
 public sealed class DiagnosticsFeatureFlagsOptions
 {

--- a/src/UI/Api/FeatureFlagsModels.cs
+++ b/src/UI/Api/FeatureFlagsModels.cs
@@ -1,0 +1,6 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/features/flags</c> and <c>GET /api/v1.0/features/flags</c>.
+/// </summary>
+public sealed record RuntimeFeatureFlagsResponse(DiagnosticsFeatureFlagsOptions FeatureFlags);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and feature-flag endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionTimeOrFeatureFlagsPath(value))
         {
             return false;
         }
@@ -65,7 +65,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicVersionTimeOrFeatureFlagsPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
@@ -84,8 +84,25 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
             var leaf = segments[2];
-            return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+            if (leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
+                || leaf.Equals("time", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (segments.Length >= 4
+                && leaf.Equals("features", StringComparison.OrdinalIgnoreCase)
+                && segments[3].Equals("flags", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("features", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("flags", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         return false;

--- a/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagsControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJson_WithFeatureFlags_When_Called()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+        var controller = new FeatureFlagsController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<RuntimeFeatureFlagsResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.FeatureFlags.SampleFeatureA.ShouldBeTrue();
+        payload.FeatureFlags.SampleFeatureB.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesEtag()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = false, SampleFeatureB = true };
+        var controller = new FeatureFlagsController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var first = controller.Get();
+        var firstContent = first.ShouldBeOfType<ContentResult>();
+        var etag = controller.Response.Headers.ETag.ToString();
+        etag.ShouldNotBeNullOrWhiteSpace();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.IfNoneMatch = etag;
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        controller.Response.Headers.Clear();
+
+        var second = controller.Get();
+
+        second.ShouldBeOfType<StatusCodeResult>();
+        ((StatusCodeResult)second).StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -14,6 +14,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/features/flags", true)]
+    [TestCase("/api/v1.0/features/flags", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **GET `/api/features/flags`** and **GET `/api/v1.0/features/flags`** returning the same configuration-bound feature flags as the diagnostics payload (`featureFlags` object), with weak **ETag** and **304 Not Modified** when `If-None-Match` matches. When optional API-key middleware is enabled, these routes are treated as **public** (no key required), consistent with `/api/version` and `/api/time`, so clients can read flag state without the diagnostics bundle.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/FeatureFlagsController.cs` | New controller, rate-limited, anonymous GET |
| `src/UI/Api/FeatureFlagsModels.cs` | `RuntimeFeatureFlagsResponse` record |
| `src/UI/Api/DiagnosticsFeatureFlagsOptions.cs` | XML doc mentions new endpoint |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Skip API key for `/api/features/flags` and versioned path |
| `src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs` | Unit tests for JSON and 304 |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Path cases for public skip |
| `src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs` | HTTP tests + API-key scenario |

## Testing

- `dotnet test` UnitTests (Release): all passed
- `dotnet test` IntegrationTests filtered to `DiagnosticsEndpointIntegrationTests` with `DATABASE_ENGINE=SQLite`: passed
- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: build, unit tests, integration tests green

Closes #5280
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-065f8e0a-d186-46b2-b361-edefd9e39282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-065f8e0a-d186-46b2-b361-edefd9e39282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

