### PR TITLE
Add a simple /api/ping endpoint that returns pong (#5472)

### DIFF
--- a/src/UI/Api/Controllers/PingController.cs
+++ b/src/UI/Api/Controllers/PingController.cs
@@ -1,0 +1,32 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal plain-text probe for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/ping")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/ping")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class PingController : ControllerBase
+{
+    /// <summary>
+    /// Returns the literal response body <c>pong</c> for reachability checks.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        new ContentResult
+        {
+            Content = "pong",
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = StatusCodes.Status200OK
+        };
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version and time endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -77,7 +77,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         {
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -85,7 +86,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         {
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/PingControllerTests.cs
+++ b/src/UnitTests/UI.Api/PingControllerTests.cs
@@ -1,0 +1,27 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class PingControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnPlainTextPong()
+    {
+        var controller = new PingController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        content.Content.ShouldBe("pong");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -14,6 +14,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
+    [TestCase("/api/ping", true)]
+    [TestCase("/api/v1.0/ping", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds anonymous `GET /api/ping` and `GET /api/v1.0/ping` that return HTTP 200 with plain text body `pong` and `Content-Type: text/plain; charset=utf-8`, matching the pattern used by `TimeController`. When API key middleware is enabled, `/api/ping` and versioned ping paths are treated as public (no key), consistent with `/api/time`.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/PingController.cs` | New controller with dual routes, rate limiting, `[AllowAnonymous]`. |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Allow `ping` alongside `version` and `time` for optional API key bypass. |
| `src/UnitTests/UI.Api/PingControllerTests.cs` | Unit test for response status, content type, and body. |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Cases for `/api/ping` and `/api/v1.0/ping` as public paths. |

## Testing

- Ran `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: build succeeded; unit tests (260) and integration tests (108) passed.

Closes #5472
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bed9644a-0ebd-4c89-88eb-f3d978aa7e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bed9644a-0ebd-4c89-88eb-f3d978aa7e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

