### PR TITLE
Force capitalize all names in the login drop-down (#5531)

### DIFF
--- a/src/UnitTests/UI.Shared/LoginDisplayNameFormatterTests.cs
+++ b/src/UnitTests/UI.Shared/LoginDisplayNameFormatterTests.cs
@@ -29,4 +29,10 @@ public class LoginDisplayNameFormatterTests
     {
         LoginDisplayNameFormatter.FormatForLoginDropdown(string.Empty).ShouldBe(string.Empty);
     }
+
+    [Test]
+    public void FormatForLoginDropdown_WhitespaceOnly_PreservesLengthAndCaseMapsToUpperInvariant()
+    {
+        LoginDisplayNameFormatter.FormatForLoginDropdown("  \t ").ShouldBe("  \t ".ToUpperInvariant());
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The login page **Select Church Member** list already formats visible labels via `LoginDisplayNameFormatter.FormatForLoginDropdown` (uppercase with `ToUpperInvariant`) so locally stored mixed-case names match mainframe all-caps names; option **values** remain employee usernames. This PR adds the **optional whitespace-only** unit test called out in the #5531 test design checklist.

## Files changed

| File | Change |
|------|--------|
| `src/UnitTests/UI.Shared/LoginDisplayNameFormatterTests.cs` | New test `FormatForLoginDropdown_WhitespaceOnly_*` documenting edge-case behavior for whitespace-only full names. |

## Testing

- `dotnet test` filtered to `LoginDisplayNameFormatterTests` (Release).
- Full `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: build, 261 unit tests, 108 integration tests — all passed.

Closes #5531
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1442036-8c6a-4606-9c3c-193847fa09db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1442036-8c6a-4606-9c3c-193847fa09db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

