### PR TITLE
Make the login button blink obviously (#5532)

### DIFF
--- a/src/UI.Shared/Components/LoginLink.razor.css
+++ b/src/UI.Shared/Components/LoginLink.razor.css
@@ -13,67 +13,123 @@
 
 @media (prefers-reduced-motion: no-preference) {
 	.login-prompt-link {
-		animation: login-prompt-emphasis 1.35s ease-in-out infinite;
-		will-change: transform, opacity, box-shadow, filter;
+		animation: login-prompt-emphasis 1.1s ease-in-out infinite;
+		will-change: transform, opacity, box-shadow;
 	}
 }
 
 @keyframes login-prompt-emphasis {
-	0%, 100% {
+	0%, 8% {
 		opacity: 1;
 		transform: scale(1);
-		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 0 rgba(255, 255, 255, 0.85), 0 4px 18px rgba(221, 107, 32, 0.55);
+		box-shadow: 0 0 0 0 rgba(221, 107, 32, 0.95), 0 0 0 3px rgba(255, 255, 255, 0.9), 0 4px 18px rgba(221, 107, 32, 0.55);
 		border-color: #c05621;
 		filter: brightness(1);
-		text-shadow: 0 0 0 transparent;
+		text-shadow: 0 0 8px rgba(255, 255, 255, 0.85);
 	}
-	12% {
+	14%, 22% {
+		opacity: 0;
+		transform: scale(0.88);
+		box-shadow: 0 0 0 0 transparent, 0 2px 6px rgba(0, 0, 0, 0.2);
+		border-color: #744210;
+		filter: brightness(0.5);
+		text-shadow: none;
+	}
+	30% {
 		opacity: 1;
-		transform: scale(1.1);
-		box-shadow: 0 0 0 12px rgba(221, 107, 32, 0.45), 0 0 0 4px rgba(255, 255, 255, 0.95), 0 8px 28px rgba(221, 107, 32, 0.72);
+		transform: scale(1.12);
+		box-shadow: 0 0 0 14px rgba(255, 214, 10, 0.5), 0 0 0 5px rgba(255, 255, 255, 1), 0 10px 32px rgba(221, 107, 32, 0.85);
 		border-color: #dd6b20;
+		filter: brightness(1.2);
+		text-shadow: 0 0 14px rgba(255, 255, 255, 1), 0 0 26px rgba(255, 200, 50, 1);
+	}
+	48%, 56% {
+		opacity: 0;
+		transform: scale(0.88);
+		box-shadow: 0 0 0 0 transparent, 0 2px 6px rgba(0, 0, 0, 0.2);
+		border-color: #744210;
+		filter: brightness(0.5);
+		text-shadow: none;
+	}
+	64% {
+		opacity: 1;
+		transform: scale(1.12);
+		box-shadow: 0 0 0 14px rgba(255, 214, 10, 0.5), 0 0 0 5px rgba(255, 255, 255, 1), 0 10px 32px rgba(221, 107, 32, 0.85);
+		border-color: #dd6b20;
+		filter: brightness(1.2);
+		text-shadow: 0 0 14px rgba(255, 255, 255, 1), 0 0 26px rgba(255, 200, 50, 1);
+	}
+	82%, 100% {
+		opacity: 1;
+		transform: scale(1.02);
+		box-shadow: 0 0 0 6px rgba(221, 107, 32, 0.35), 0 0 0 2px rgba(255, 255, 255, 0.85), 0 6px 22px rgba(221, 107, 32, 0.6);
+		border-color: #c05621;
+		filter: brightness(1.05);
+		text-shadow: 0 0 6px rgba(255, 255, 255, 0.75);
+	}
+}
+
+:global(html[data-theme="dark"]) .login-prompt-link {
+	color: #0f172a;
+	background: linear-gradient(135deg, #fef08a 0%, #fbbf24 40%, #f59e0b 100%);
+	border-color: #b45309;
+	box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.95), 0 4px 16px rgba(0, 0, 0, 0.45);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	:global(html[data-theme="dark"]) .login-prompt-link {
+		animation: login-prompt-emphasis-dark 1.1s ease-in-out infinite;
+	}
+}
+
+@keyframes login-prompt-emphasis-dark {
+	0%, 8% {
+		opacity: 1;
+		transform: scale(1);
+		box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.95), 0 0 0 3px rgba(254, 252, 232, 0.95), 0 4px 20px rgba(0, 0, 0, 0.5);
+		border-color: #b45309;
+		filter: brightness(1.05);
+		text-shadow: 0 0 10px rgba(254, 252, 232, 0.9);
+	}
+	14%, 22% {
+		opacity: 0;
+		transform: scale(0.88);
+		box-shadow: 0 0 0 0 transparent, 0 2px 8px rgba(0, 0, 0, 0.55);
+		border-color: #78350f;
+		filter: brightness(0.45);
+		text-shadow: none;
+	}
+	30% {
+		opacity: 1;
+		transform: scale(1.12);
+		box-shadow: 0 0 0 14px rgba(253, 224, 71, 0.45), 0 0 0 5px rgba(254, 252, 232, 1), 0 10px 36px rgba(251, 191, 36, 0.55);
+		border-color: #d97706;
 		filter: brightness(1.15);
-		text-shadow: 0 0 12px rgba(255, 255, 255, 0.95), 0 0 22px rgba(255, 200, 50, 0.95);
+		text-shadow: 0 0 16px rgba(254, 252, 232, 1), 0 0 28px rgba(253, 224, 71, 1);
 	}
-	18%, 22% {
-		opacity: 0.06;
-		transform: scale(0.9);
-		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.4), 0 2px 8px rgba(0, 0, 0, 0.25);
-		border-color: #9b2c2c;
-		filter: brightness(0.65);
+	48%, 56% {
+		opacity: 0;
+		transform: scale(0.88);
+		box-shadow: 0 0 0 0 transparent, 0 2px 8px rgba(0, 0, 0, 0.55);
+		border-color: #78350f;
+		filter: brightness(0.45);
 		text-shadow: none;
 	}
-	28% {
+	64% {
 		opacity: 1;
-		transform: scale(1.14);
-		box-shadow: 0 0 0 16px rgba(255, 214, 10, 0.55), 0 0 0 5px rgba(255, 255, 255, 1), 0 12px 36px rgba(221, 107, 32, 0.8);
-		border-color: #c05621;
-		filter: brightness(1.25);
-		text-shadow: 0 0 16px rgba(255, 255, 255, 1), 0 0 28px rgba(255, 180, 0, 1);
+		transform: scale(1.12);
+		box-shadow: 0 0 0 14px rgba(253, 224, 71, 0.45), 0 0 0 5px rgba(254, 252, 232, 1), 0 10px 36px rgba(251, 191, 36, 0.55);
+		border-color: #d97706;
+		filter: brightness(1.15);
+		text-shadow: 0 0 16px rgba(254, 252, 232, 1), 0 0 28px rgba(253, 224, 71, 1);
 	}
-	44% {
+	82%, 100% {
 		opacity: 1;
-		transform: scale(1.06);
-		box-shadow: 0 0 0 8px rgba(221, 107, 32, 0.38), 0 0 0 3px rgba(255, 255, 255, 0.9), 0 6px 22px rgba(221, 107, 32, 0.62);
-		border-color: #dd6b20;
-		filter: brightness(1.1);
-		text-shadow: 0 0 10px rgba(255, 255, 255, 0.9), 0 0 18px rgba(255, 200, 50, 0.85);
-	}
-	52%, 56% {
-		opacity: 0.06;
-		transform: scale(0.9);
-		box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.4), 0 2px 8px rgba(0, 0, 0, 0.25);
-		border-color: #9b2c2c;
-		filter: brightness(0.65);
-		text-shadow: none;
-	}
-	62% {
-		opacity: 1;
-		transform: scale(1.14);
-		box-shadow: 0 0 0 16px rgba(255, 214, 10, 0.55), 0 0 0 5px rgba(255, 255, 255, 1), 0 12px 36px rgba(221, 107, 32, 0.8);
-		border-color: #c05621;
-		filter: brightness(1.25);
-		text-shadow: 0 0 16px rgba(255, 255, 255, 1), 0 0 28px rgba(255, 180, 0, 1);
+		transform: scale(1.02);
+		box-shadow: 0 0 0 6px rgba(251, 191, 36, 0.4), 0 0 0 2px rgba(254, 252, 232, 0.9), 0 6px 24px rgba(0, 0, 0, 0.45);
+		border-color: #b45309;
+		filter: brightness(1.05);
+		text-shadow: 0 0 8px rgba(254, 252, 232, 0.85);
 	}
 }
 
@@ -94,5 +150,12 @@
 		background: #fefcbf;
 		border: 3px solid #c05621;
 		box-shadow: 0 0 0 4px rgba(221, 107, 32, 0.45), 0 4px 12px rgba(0, 0, 0, 0.12);
+	}
+
+	:global(html[data-theme="dark"]) .login-prompt-link {
+		color: #0f172a;
+		background: #fef08a;
+		border: 3px solid #b45309;
+		box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.5), 0 4px 14px rgba(0, 0, 0, 0.35);
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The header **Login** CTA (`LoginLink`) now uses a faster, higher-contrast animation: two clear **off** beats per cycle (`opacity: 0`) with scale change so the control reads as an obvious blink. `will-change` is limited to `transform`, `opacity`, and `box-shadow`. Dark theme adds `:global(html[data-theme="dark"])` base styles and a dedicated `login-prompt-emphasis-dark` keyframe set so the CTA stays visible on the dark header. Reduced-motion users keep a strong static treatment (including dark theme) with `animation: none` and non-`none` `box-shadow`.

## Files changed

| File | Change |
|------|--------|
| `src/UI.Shared/Components/LoginLink.razor.css` | Reworked light-theme keyframes, added dark-theme overrides and keyframes, reduced-motion dark static styles |

## Testing

- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: build, 260 unit tests, 108 integration tests — all green.
- Filtered unit tests earlier: `LoginLinkTests` + `MainLayoutTests` — green.

Closes #5532
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-572e6f63-9104-4bf4-bd90-78f389c3576f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-572e6f63-9104-4bf4-bd90-78f389c3576f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

