### PR TITLE
New API endpoint POST /api/tools/hash for computing SHA-256 hashes of text input (#5571)

### DIFF
--- a/src/IntegrationTests/Api/ToolsHashIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ToolsHashIntegrationTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ToolsHashIntegrationTests
+{
+    private const string ExpectedSha256Abc =
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    private ToolsHashWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new ToolsHashWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200_WithCorrectSha256_ForKnownInput_OnUnversionedRoute()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new ToolsHashRequest { Text = "abc" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await AssertSha256Async(response, ExpectedSha256Abc);
+        var json = await response.Content.ReadAsStringAsync();
+        json.ShouldNotContain("\"md5\"");
+        json.ShouldNotContain("\"sha1\"");
+    }
+
+    [Test]
+    public async Task Should_Return200_WithCorrectSha256_OnVersionedRoute()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/v1.0/tools/hash", new ToolsHashRequest { Text = "abc" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await AssertSha256Async(response, ExpectedSha256Abc);
+    }
+
+    [Test]
+    public async Task Should_OmitLegacyHashes_ByDefault_When_FlagFalseOrAbsent()
+    {
+        var response = await _client!.PostAsJsonAsync(
+            "/api/tools/hash",
+            new ToolsHashRequest { Text = "abc", IncludeLegacyHashes = false });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("md5", out _).ShouldBeFalse();
+        doc.RootElement.TryGetProperty("sha1", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_IncludeMd5AndSha1_When_LegacyFlagTrue()
+    {
+        var response = await _client!.PostAsJsonAsync(
+            "/api/tools/hash",
+            new ToolsHashRequest { Text = "abc", IncludeLegacyHashes = true });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ToolsHashResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Sha256.ShouldBe(ExpectedSha256Abc);
+        payload.Md5.ShouldBe("900150983cd24fb0d6963f7d28e17f72");
+        payload.Sha1.ShouldBe("a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    [Test]
+    public async Task Should_Return400_When_TextMissing()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new { });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var hasValidationErrors = root.TryGetProperty("errors", out _);
+        var hasProblemShape = root.TryGetProperty("title", out _) && root.TryGetProperty("status", out _);
+        (hasValidationErrors || hasProblemShape).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return415_When_NonJsonContentType()
+    {
+        using var content = new StringContent("hello", Encoding.UTF8, "text/plain");
+        var response = await _client!.PostAsync("/api/tools/hash", content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Test]
+    public async Task Should_RequireApiKey_When_Enabled_And_PathNotPublic()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.PostAsJsonAsync("/api/tools/hash", new ToolsHashRequest { Text = "x" });
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(ApiKeyConstants.HeaderName, ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.PostAsJsonAsync("/api/tools/hash", new ToolsHashRequest { Text = "abc" });
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await AssertSha256Async(ok, ExpectedSha256Abc);
+    }
+
+    private static async Task AssertSha256Async(HttpResponseMessage response, string expectedHex)
+    {
+        using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.GetProperty("sha256").GetString().ShouldBe(expectedHex);
+    }
+}

--- a/src/IntegrationTests/Api/ToolsHashWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/ToolsHashWebApplicationFactory.cs
@@ -1,0 +1,31 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server for <c>POST /api/tools/hash</c> integration tests.
+/// </summary>
+public sealed class ToolsHashWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = ""
+            });
+        });
+    }
+}

--- a/src/UI/Api/Controllers/ToolsHashController.cs
+++ b/src/UI/Api/Controllers/ToolsHashController.cs
@@ -1,0 +1,49 @@
+using System.Net.Mime;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Computes cryptographic digests of a UTF-8 string for scripts and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/hash")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/hash")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsHashController : ControllerBase
+{
+    /// <summary>
+    /// Returns SHA-256 (and optionally MD5 and SHA-1) of the request <c>text</c> as UTF-8 bytes.
+    /// </summary>
+    [HttpPost]
+    [RequestSizeLimit(10 * 1024 * 1024)]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [AllowAnonymous]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(ToolsHashResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status415UnsupportedMediaType)]
+    public IActionResult Post([FromBody] ToolsHashRequest? request)
+    {
+        if (request is null)
+        {
+            return Problem(
+                detail: "A JSON body with a text property is required.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var text = request.Text!;
+        var response = ToolsHashDigest.Compute(text, request.IncludeLegacyHashes);
+        return Ok(response);
+    }
+}

--- a/src/UI/Api/ToolsHashDigest.cs
+++ b/src/UI/Api/ToolsHashDigest.cs
@@ -1,0 +1,30 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Computes UTF-8 string digests for the tools hash API.
+/// </summary>
+internal static class ToolsHashDigest
+{
+    internal static ToolsHashResponse Compute(string text, bool includeLegacyHashes)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text);
+        var sha256Hex = ToHexLower(SHA256.HashData(bytes));
+
+        if (!includeLegacyHashes)
+        {
+            return new ToolsHashResponse { Sha256 = sha256Hex };
+        }
+
+        return new ToolsHashResponse
+        {
+            Sha256 = sha256Hex,
+            Md5 = ToHexLower(MD5.HashData(bytes)),
+            Sha1 = ToHexLower(SHA1.HashData(bytes))
+        };
+    }
+
+    private static string ToHexLower(byte[] hash) => Convert.ToHexString(hash).ToLowerInvariant();
+}

--- a/src/UI/Api/ToolsHashModels.cs
+++ b/src/UI/Api/ToolsHashModels.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Request body for <c>POST /api/tools/hash</c>.
+/// </summary>
+public sealed class ToolsHashRequest
+{
+    /// <summary>
+    /// Input text hashed as UTF-8 bytes. Required; an empty string yields well-defined digests.
+    /// </summary>
+    [Required(ErrorMessage = "The text field is required.")]
+    public string? Text { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, weak MD5 and SHA-1 digests are included in the response.
+    /// </summary>
+    public bool IncludeLegacyHashes { get; set; }
+}
+
+/// <summary>
+/// Digest values returned from <c>POST /api/tools/hash</c>.
+/// </summary>
+public sealed class ToolsHashResponse
+{
+    /// <summary>
+    /// Lowercase hexadecimal SHA-256 digest of <see cref="ToolsHashRequest.Text"/> as UTF-8.
+    /// </summary>
+    public required string Sha256 { get; init; }
+
+    /// <summary>
+    /// Lowercase hexadecimal MD5 digest when legacy hashes were requested; otherwise omitted from JSON.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Md5 { get; init; }
+
+    /// <summary>
+    /// Lowercase hexadecimal SHA-1 digest when legacy hashes were requested; otherwise omitted from JSON.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Sha1 { get; init; }
+}

--- a/src/UnitTests/Api/ToolsHashDigestTests.cs
+++ b/src/UnitTests/Api/ToolsHashDigestTests.cs
@@ -1,0 +1,37 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.Api;
+
+[TestFixture]
+public class ToolsHashDigestTests
+{
+    [Test]
+    public void Should_ReturnExpectedSha256_When_TextIsAbc()
+    {
+        var result = ToolsHashDigest.Compute("abc", includeLegacyHashes: false);
+
+        result.Sha256.ShouldBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+        result.Md5.ShouldBeNull();
+        result.Sha1.ShouldBeNull();
+    }
+
+    [Test]
+    public void Should_ReturnLowercaseHex_When_LegacyRequested()
+    {
+        var result = ToolsHashDigest.Compute("abc", includeLegacyHashes: true);
+
+        result.Md5.ShouldBe("900150983cd24fb0d6963f7d28e17f72");
+        result.Sha1.ShouldBe("a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    [Test]
+    public void Should_ReturnWellDefinedDigests_When_TextIsEmpty()
+    {
+        var result = ToolsHashDigest.Compute("", includeLegacyHashes: true);
+
+        result.Sha256.ShouldBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        result.Md5.ShouldBe("d41d8cd98f00b204e9800998ecf8427e");
+        result.Sha1.ShouldBe("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -17,6 +17,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
     [TestCase("/api/WeatherForecast", false)]
+    [TestCase("/api/tools/hash", false)]
+    [TestCase("/api/v1.0/tools/hash", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {
         var options = new ApiKeyAuthenticationOptions { Enabled = true, ValidationKey = "secret" };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `POST /api/tools/hash` and `POST /api/v1.0/tools/hash` so callers can send JSON `{ "text": "..." }` and receive a lowercase hexadecimal SHA-256 digest of the UTF-8 bytes of `text`. Optional weak digests (MD5, SHA-1) are returned only when `includeLegacyHashes` is `true`; otherwise those properties are omitted from the JSON response. The route uses the same rate limiting and API key behavior as other non-public `/api/*` endpoints.

Closes #5571

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/ToolsHashController.cs` | New API controller: POST, JSON consumes, 10 MB body limit, validation / problem responses |
| `src/UI/Api/ToolsHashModels.cs` | Request/response DTOs with XML documentation |
| `src/UI/Api/ToolsHashDigest.cs` | SHA-256 / optional MD5+SHA-1 over UTF-8, lowercase hex |
| `src/UnitTests/Api/ToolsHashDigestTests.cs` | Known-vector unit tests for digest output |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Test cases for `/api/tools/hash` paths (key required when middleware enabled) |
| `src/IntegrationTests/Api/ToolsHashWebApplicationFactory.cs` | Test host factory with API key disabled |
| `src/IntegrationTests/Api/ToolsHashIntegrationTests.cs` | HTTP tests: both routes, legacy flag, 400, 415, API key when enabled |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — succeeded (266 unit tests, 115 integration tests).
- Targeted runs: `ToolsHashDigestTests`, `ToolsHashIntegrationTests`, updated `ApiKeyAuthenticationMiddlewareTests` rows.

## Submitter checklist

- [x] Issue is clearly tagged
- [x] Branch is feature-complete for #5571
- [x] Expect the approval checklist to be satisfied after review

---

Submitter checklist
- [ ] Issue is clearly tagged
- [ ] Narrate status of the branch (feature complete, incremental build, etc)
- [ ] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e34c4796-e420-4df8-9bfa-723b75c2d56c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e34c4796-e420-4df8-9bfa-723b75c2d56c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

