### PR TITLE
New API endpoint GET /api/tools/random for configurable random data generation (#5574)

### DIFF
--- a/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ToolsRandomEndpointIntegrationTests
+{
+    private WebApplicationFactory<UiServerWebApplicationMarker>? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new ToolsRandomWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200_When_GetToolsRandomUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?kind=int&min=0&max=2");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.GetProperty("kind").GetString().ShouldBe("int");
+        doc.RootElement.TryGetProperty("value", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200_When_GetToolsRandomVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/tools/random?kind=guid");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.GetProperty("kind").GetString().ShouldBe("guid");
+    }
+
+    [Test]
+    public async Task Should_Return400_When_GetToolsRandomInvalidKind()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?kind=invalid");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+}

--- a/src/IntegrationTests/Api/ToolsRandomWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/ToolsRandomWebApplicationFactory.cs
@@ -1,0 +1,31 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server for <c>/api/tools/random</c> integration tests.
+/// </summary>
+public sealed class ToolsRandomWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = ""
+            });
+        });
+    }
+}

--- a/src/UI/Api/Controllers/ToolsRandomController.cs
+++ b/src/UI/Api/Controllers/ToolsRandomController.cs
@@ -1,0 +1,136 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Returns configurable pseudo-random data for tests, demos, and tooling (no cryptographic guarantees).
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/random")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/random")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsRandomController : ControllerBase
+{
+    private static readonly Random RandomSource = Random.Shared;
+
+    /// <summary>
+    /// Generates a random value according to <paramref name="kind"/> and query parameters.
+    /// </summary>
+    /// <param name="kind">
+    /// <c>int</c> (default), <c>long</c>, <c>guid</c>, <c>string</c>, or <c>bytes</c>.
+    /// </param>
+    /// <param name="min">Inclusive lower bound for <c>int</c> / <c>long</c> (defaults apply when omitted).</param>
+    /// <param name="max">Exclusive upper bound for <c>int</c> / <c>long</c>.</param>
+    /// <param name="length">Length for <c>string</c> or <c>bytes</c> (default 16, max 4096).</param>
+    /// <param name="charset">Character set for <c>string</c>; defaults to alphanumeric ASCII.</param>
+    /// <param name="encoding"><c>base64</c> or <c>hex</c> for <c>bytes</c> output.</param>
+    [HttpGet]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get(
+        [FromQuery] string? kind = null,
+        [FromQuery] string? min = null,
+        [FromQuery] string? max = null,
+        [FromQuery] string? length = null,
+        [FromQuery] string? charset = null,
+        [FromQuery] string? encoding = null)
+    {
+        if (!ToolsRandomGenerator.TryParseKind(kind, out var parsedKind))
+            return Problem(detail: $"Unknown kind '{kind}'. Supported: int, long, guid, string, bytes.", statusCode: StatusCodes.Status400BadRequest);
+
+        return parsedKind switch
+        {
+            RandomKind.Int => GetInt(min, max),
+            RandomKind.Long => GetLong(min, max),
+            RandomKind.Guid => OkJson(new { kind = "guid", value = ToolsRandomGenerator.NextGuid(RandomSource).ToString("D") }),
+            RandomKind.String => GetString(length, charset),
+            RandomKind.Bytes => GetBytes(length, encoding),
+            _ => Problem(detail: "Unsupported kind.", statusCode: StatusCodes.Status400BadRequest)
+        };
+    }
+
+    private IActionResult GetInt(string? minRaw, string? maxRaw)
+    {
+        if (!ToolsRandomGenerator.TryParseIntBounds(minRaw, maxRaw, out var minInclusive, out var maxExclusive, out var error))
+            return Problem(detail: error, statusCode: StatusCodes.Status400BadRequest);
+
+        var value = ToolsRandomGenerator.NextInt(RandomSource, minInclusive, maxExclusive);
+        return OkJson(new
+        {
+            kind = "int",
+            minInclusive,
+            maxExclusive,
+            value
+        });
+    }
+
+    private IActionResult GetLong(string? minRaw, string? maxRaw)
+    {
+        if (!ToolsRandomGenerator.TryParseLongBounds(minRaw, maxRaw, out var minInclusive, out var maxExclusive, out var error))
+            return Problem(detail: error, statusCode: StatusCodes.Status400BadRequest);
+
+        var value = ToolsRandomGenerator.NextLong(RandomSource, minInclusive, maxExclusive);
+        return OkJson(new
+        {
+            kind = "long",
+            minInclusive,
+            maxExclusive,
+            value
+        });
+    }
+
+    private IActionResult GetString(string? lengthRaw, string? charsetRaw)
+    {
+        if (!ToolsRandomGenerator.TryParseBoundedInt(
+                lengthRaw,
+                0,
+                ToolsRandomGenerator.MaxStringOrByteLength,
+                "length",
+                out var strLength,
+                out var lenError))
+            return Problem(detail: lenError, statusCode: StatusCodes.Status400BadRequest);
+
+        if (!ToolsRandomGenerator.TryValidateCharset(charsetRaw, out var charset, out var charsetError))
+            return Problem(detail: charsetError, statusCode: StatusCodes.Status400BadRequest);
+
+        var value = ToolsRandomGenerator.NextString(RandomSource, strLength, charset);
+        return OkJson(new
+        {
+            kind = "string",
+            length = strLength,
+            value
+        });
+    }
+
+    private IActionResult GetBytes(string? lengthRaw, string? encodingRaw)
+    {
+        if (!ToolsRandomGenerator.TryParseBoundedInt(
+                lengthRaw,
+                0,
+                ToolsRandomGenerator.MaxStringOrByteLength,
+                "length",
+                out var byteLength,
+                out var lenError))
+            return Problem(detail: lenError, statusCode: StatusCodes.Status400BadRequest);
+
+        if (!ToolsRandomGenerator.TryParseBytesEncoding(encodingRaw, out var enc))
+            return Problem(detail: $"Unknown encoding '{encodingRaw}'. Supported: base64, hex.", statusCode: StatusCodes.Status400BadRequest);
+
+        var value = ToolsRandomGenerator.NextBytesEncoded(RandomSource, byteLength, enc);
+        return OkJson(new
+        {
+            kind = "bytes",
+            length = byteLength,
+            encoding = enc.ToString().ToLowerInvariant(),
+            value
+        });
+    }
+
+    private static ContentResult OkJson(object payload) => ConditionalGetEtag.JsonContent(payload);
+}

--- a/src/UI/Api/ToolsRandomGenerator.cs
+++ b/src/UI/Api/ToolsRandomGenerator.cs
@@ -1,0 +1,214 @@
+using System.Globalization;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Builds pseudo-random payloads for <see cref="Controllers.ToolsRandomController"/>.
+/// </summary>
+internal static class ToolsRandomGenerator
+{
+    internal const int DefaultStringOrByteLength = 16;
+    internal const int MaxStringOrByteLength = 4096;
+    internal const int MaxCharsetLength = 512;
+    internal const int DefaultIntMinInclusive = 0;
+    internal const int DefaultIntMaxExclusive = 101;
+    internal const long DefaultLongMinInclusive = 0L;
+    internal const long DefaultLongMaxExclusive = 101L;
+
+    internal static readonly string DefaultCharset =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    internal static int NextInt(Random random, int minInclusive, int maxExclusive) =>
+        random.Next(minInclusive, maxExclusive);
+
+    internal static long NextLong(Random random, long minInclusive, long maxExclusive) =>
+        random.NextInt64(minInclusive, maxExclusive);
+
+    internal static Guid NextGuid(Random random)
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        random.NextBytes(bytes);
+        return new Guid(bytes);
+    }
+
+    internal static string NextString(Random random, int length, ReadOnlySpan<char> charset)
+    {
+        if (length == 0)
+            return string.Empty;
+
+        var buffer = length <= 1024 ? stackalloc char[length] : new char[length];
+        for (var i = 0; i < length; i++)
+            buffer[i] = charset[random.Next(charset.Length)];
+        return buffer.Length == 0 ? string.Empty : new string(buffer);
+    }
+
+    internal static string NextBytesEncoded(Random random, int length, BytesEncoding encoding)
+    {
+        if (length == 0)
+            return encoding == BytesEncoding.Hex ? string.Empty : Convert.ToBase64String(ReadOnlySpan<byte>.Empty);
+
+        var bytes = length <= 4096 ? stackalloc byte[length] : new byte[length];
+        random.NextBytes(bytes);
+        return encoding == BytesEncoding.Hex ? Convert.ToHexString(bytes) : Convert.ToBase64String(bytes);
+    }
+
+    internal static bool TryParseKind(string? raw, out RandomKind kind)
+    {
+        kind = RandomKind.Int;
+        if (string.IsNullOrWhiteSpace(raw))
+            return true;
+
+        return Enum.TryParse(raw, ignoreCase: true, out kind);
+    }
+
+    internal static bool TryParseBytesEncoding(string? raw, out BytesEncoding encoding)
+    {
+        encoding = BytesEncoding.Base64;
+        if (string.IsNullOrWhiteSpace(raw))
+            return true;
+
+        return Enum.TryParse(raw, ignoreCase: true, out encoding);
+    }
+
+    internal static bool TryParseBoundedInt(
+        string? raw,
+        int min,
+        int max,
+        string parameterName,
+        out int value,
+        out string? error)
+    {
+        value = 0;
+        error = null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            value = DefaultStringOrByteLength;
+            return true;
+        }
+
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+        {
+            error = $"{parameterName} must be a 32-bit integer.";
+            return false;
+        }
+
+        if (value < min || value > max)
+        {
+            error = $"{parameterName} must be between {min} and {max}.";
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool TryParseLongBounds(
+        string? minRaw,
+        string? maxRaw,
+        out long minInclusive,
+        out long maxExclusive,
+        out string? error)
+    {
+        error = null;
+        minInclusive = DefaultLongMinInclusive;
+        maxExclusive = DefaultLongMaxExclusive;
+
+        if (!string.IsNullOrWhiteSpace(minRaw))
+        {
+            if (!long.TryParse(minRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out minInclusive))
+            {
+                error = "min must be a 64-bit integer.";
+                return false;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(maxRaw))
+        {
+            if (!long.TryParse(maxRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out maxExclusive))
+            {
+                error = "max must be a 64-bit integer.";
+                return false;
+            }
+        }
+
+        if (minInclusive >= maxExclusive)
+        {
+            error = "min must be less than max (max is exclusive).";
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool TryParseIntBounds(
+        string? minRaw,
+        string? maxRaw,
+        out int minInclusive,
+        out int maxExclusive,
+        out string? error)
+    {
+        error = null;
+        minInclusive = DefaultIntMinInclusive;
+        maxExclusive = DefaultIntMaxExclusive;
+
+        if (!string.IsNullOrWhiteSpace(minRaw))
+        {
+            if (!int.TryParse(minRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out minInclusive))
+            {
+                error = "min must be a 32-bit integer.";
+                return false;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(maxRaw))
+        {
+            if (!int.TryParse(maxRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out maxExclusive))
+            {
+                error = "max must be a 32-bit integer.";
+                return false;
+            }
+        }
+
+        if (minInclusive >= maxExclusive)
+        {
+            error = "min must be less than max (max is exclusive).";
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool TryValidateCharset(string? charset, out string resolved, out string? error)
+    {
+        error = null;
+        if (string.IsNullOrEmpty(charset))
+        {
+            resolved = DefaultCharset;
+            return true;
+        }
+
+        if (charset.Length > MaxCharsetLength)
+        {
+            resolved = string.Empty;
+            error = $"charset must be at most {MaxCharsetLength} characters.";
+            return false;
+        }
+
+        resolved = charset;
+        return true;
+    }
+}
+
+internal enum RandomKind
+{
+    Int,
+    Long,
+    Guid,
+    String,
+    Bytes
+}
+
+internal enum BytesEncoding
+{
+    Base64,
+    Hex
+}

--- a/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
+++ b/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsRandomControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnIntInRange()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(kind: "int", min: "10", max: "20");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("kind").GetString().ShouldBe("int");
+        doc.RootElement.GetProperty("minInclusive").GetInt32().ShouldBe(10);
+        doc.RootElement.GetProperty("maxExclusive").GetInt32().ShouldBe(20);
+        var v = doc.RootElement.GetProperty("value").GetInt32();
+        v.ShouldBeGreaterThanOrEqualTo(10);
+        v.ShouldBeLessThan(20);
+    }
+
+    [Test]
+    public void Get_Should_Return400_WhenKindUnknown()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(kind: "widget");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_Return400_WhenBytesEncodingUnknown()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(kind: "bytes", length: "4", encoding: "rot13");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_ReturnGuidShape_WhenKindGuid()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(kind: "guid");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("kind").GetString().ShouldBe("guid");
+        Guid.TryParse(doc.RootElement.GetProperty("value").GetString(), out var g).ShouldBeTrue();
+        g.ShouldNotBe(Guid.Empty);
+    }
+
+    [Test]
+    public void Get_Should_ReturnStringOfRequestedLength()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(kind: "string", length: "12", charset: "AB");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("length").GetInt32().ShouldBe(12);
+        doc.RootElement.GetProperty("value").GetString()!.Length.ShouldBe(12);
+    }
+}

--- a/src/UnitTests/UI.Api/ToolsRandomGeneratorTests.cs
+++ b/src/UnitTests/UI.Api/ToolsRandomGeneratorTests.cs
@@ -1,0 +1,89 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsRandomGeneratorTests
+{
+    [TestCase(null, "Int")]
+    [TestCase("", "Int")]
+    [TestCase("INT", "Int")]
+    [TestCase("Long", "Long")]
+    [TestCase("GUID", "Guid")]
+    [TestCase("String", "String")]
+    [TestCase("BYTES", "Bytes")]
+    public void TryParseKind_Should_ParseOrDefault(string? raw, string expectedName)
+    {
+        var ok = ToolsRandomGenerator.TryParseKind(raw, out var kind);
+        ok.ShouldBeTrue();
+        kind.ToString().ShouldBe(expectedName);
+    }
+
+    [Test]
+    public void TryParseKind_Should_ReturnFalse_ForUnknown()
+    {
+        var ok = ToolsRandomGenerator.TryParseKind("nope", out _);
+        ok.ShouldBeFalse();
+    }
+
+    [Test]
+    public void TryParseIntBounds_Should_Default_WhenOmitted()
+    {
+        var ok = ToolsRandomGenerator.TryParseIntBounds(null, null, out var min, out var max, out var err);
+        ok.ShouldBeTrue();
+        err.ShouldBeNull();
+        min.ShouldBe(ToolsRandomGenerator.DefaultIntMinInclusive);
+        max.ShouldBe(ToolsRandomGenerator.DefaultIntMaxExclusive);
+    }
+
+    [Test]
+    public void TryParseIntBounds_Should_ReturnError_WhenMinNotLessThanMax()
+    {
+        var ok = ToolsRandomGenerator.TryParseIntBounds("5", "5", out _, out _, out var err);
+        ok.ShouldBeFalse();
+        err.ShouldNotBeNull();
+        err!.ShouldContain("min");
+    }
+
+    [Test]
+    public void TryParseLongBounds_Should_ReturnError_WhenMinNotLessThanMax()
+    {
+        var ok = ToolsRandomGenerator.TryParseLongBounds("10", "9", out _, out _, out var err);
+        ok.ShouldBeFalse();
+        err.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void TryParseBoundedInt_Should_UseDefaultLength_WhenLengthOmitted()
+    {
+        var ok = ToolsRandomGenerator.TryParseBoundedInt(
+            null,
+            0,
+            ToolsRandomGenerator.MaxStringOrByteLength,
+            "length",
+            out var value,
+            out var err);
+        ok.ShouldBeTrue();
+        err.ShouldBeNull();
+        value.ShouldBe(ToolsRandomGenerator.DefaultStringOrByteLength);
+    }
+
+    [Test]
+    public void TryValidateCharset_Should_ReturnError_WhenTooLong()
+    {
+        var huge = new string('a', ToolsRandomGenerator.MaxCharsetLength + 1);
+        var ok = ToolsRandomGenerator.TryValidateCharset(huge, out _, out var err);
+        ok.ShouldBeFalse();
+        err.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void NextString_Should_ReturnEmpty_ForZeroLength()
+    {
+        var r = new Random(42);
+        var s = ToolsRandomGenerator.NextString(r, 0, "abc");
+        s.ShouldBe(string.Empty);
+    }
+
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds anonymous `GET /api/tools/random` (and versioned `GET /api/v1.0/tools/random`) for non-cryptographic, configurable pseudo-random values: `int`, `long`, `guid`, `string`, and `bytes`. Responses are JSON and the route uses the same rate limiting as other `/api/*` endpoints.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/ToolsRandomController.cs` | MVC controller: query parsing, JSON responses, 400 on invalid input |
| `src/UI/Api/ToolsRandomGenerator.cs` | Shared parsing and generation helpers |
| `src/UnitTests/UI.Api/ToolsRandomControllerTests.cs` | Controller unit tests |
| `src/UnitTests/UI.Api/ToolsRandomGeneratorTests.cs` | Parser/helper unit tests |
| `src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs` | HTTP tests against UI.Server host |
| `src/IntegrationTests/Api/ToolsRandomWebApplicationFactory.cs` | Test host factory |

## Query parameters

- **kind** (default `int`): `int` \| `long` \| `guid` \| `string` \| `bytes`
- **min** / **max**: inclusive/exclusive bounds for `int` and `long` (defaults: 0 / 101 when omitted)
- **length**: for `string` and `bytes` (default 16, max 4096)
- **charset**: for `string` only (default alphanumeric ASCII, max 512 chars)
- **encoding**: for `bytes` — `base64` (default) or `hex`

## Testing

- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: unit tests (280) and integration tests (111) passed.
- New unit tests for controller and generator; new integration tests for unversioned, versioned, and invalid `kind`.

Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

Closes #5574
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d602d13d-e75c-47a2-936e-a5b52da600f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d602d13d-e75c-47a2-936e-a5b52da600f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

