### PR TITLE
Force capitalize all names in the login drop-down (#5630)

### DIFF
--- a/src/UI.Shared/LoginDisplayNameFormatter.cs
+++ b/src/UI.Shared/LoginDisplayNameFormatter.cs
@@ -6,8 +6,11 @@ namespace ClearMeasure.Bootcamp.UI.Shared;
 public static class LoginDisplayNameFormatter
 {
     /// <summary>
-    /// Returns the full name in uppercase so locally stored mixed-case names match mainframe all-caps names in the login drop-down.
+    /// Returns the full name in uppercase so locally stored mixed-case names match mainframe all-caps names in the login drop-down only.
     /// </summary>
+    /// <param name="fullName">Composed full name from the domain; this helper does not persist or mutate stored data.</param>
+    /// <returns>Uppercase invariant text for the login <c>&lt;select&gt;</c> labels, or empty when <paramref name="fullName"/> is null or empty.</returns>
+    /// <remarks>Uses <see cref="string.ToUpperInvariant"/> for culture-stable casing (e.g. Turkish I trade-off is accepted for this display-only control).</remarks>
     public static string FormatForLoginDropdown(string? fullName)
     {
         if (string.IsNullOrEmpty(fullName))


### PR DESCRIPTION
## Summary

Login **Select Church Member** options show each employee full name in **invariant uppercase** via `LoginDisplayNameFormatter.FormatForLoginDropdown`, so mainframe all-caps and locally mixed-case names look consistent **only** in this drop-down. Option **values** remain usernames; sign-in and tests that select by username are unchanged.

This PR adds XML documentation on `FormatForLoginDropdown` to state login-drop-down-only scope, null/empty behavior, and culture/invariant casing notes. Core implementation and tests (`LoginDisplayNameFormatterTests`, `LoginPageTests`, `StubBus` varied casing) were already on `master` from prior work; verified with a full PrivateBuild.

## Files changed

| File | Description |
|------|-------------|
| `src/UI.Shared/LoginDisplayNameFormatter.cs` | Expanded XML docs for public API (scope, params, returns, remarks). |

## Testing

- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — compile, 261 unit tests, SQL container, migrations, 111 integration tests — all passed.

Closes #5630
