### PR TITLE
New API endpoint GET /api/tools/timestamp-converter for epoch and ISO conversions (#5639)

### DIFF
--- a/src/IntegrationTests/Api/TimestampConverterIntegrationTests.cs
+++ b/src/IntegrationTests/Api/TimestampConverterIntegrationTests.cs
@@ -1,0 +1,24 @@
+using System.Net;
+using System.Text.Json;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class TimestampConverterIntegrationTests
+{
+    [Test]
+    public async Task Get_Should_Return200Json_ForVersionedRoute()
+    {
+        await using var factory = new GrpcWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1.0/tools/timestamp-converter?value=0");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe("application/json");
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("unixTimeSeconds").GetInt64().ShouldBe(0L);
+    }
+}

--- a/src/UI/Api/Controllers/TimestampConverterController.cs
+++ b/src/UI/Api/Controllers/TimestampConverterController.cs
@@ -1,0 +1,119 @@
+using System.Globalization;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Converts between Unix epoch timestamps and ISO-8601 instants for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/timestamp-converter")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/timestamp-converter")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class TimestampConverterController : ControllerBase
+{
+    private const long MillisecondsEpochThreshold = 100_000_000_000L;
+
+    /// <summary>
+    /// Parses <paramref name="value"/> as a Unix epoch (seconds or milliseconds) or ISO-8601 instant and returns both representations.
+    /// </summary>
+    /// <param name="value">Required query value: integer string for Unix time (ms if absolute value ≥ 1e11, else seconds) or an ISO-8601 instant.</param>
+    [HttpGet]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(TimestampConverterResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] string? value)
+    {
+        var trimmed = value?.Trim() ?? string.Empty;
+        if (trimmed.Length == 0)
+        {
+            return Problem(
+                detail: "Query parameter 'value' is required and cannot be empty or whitespace.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (!TryParseInstant(trimmed, out var instant, out var errorDetail))
+        {
+            return Problem(detail: errorDetail, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var utc = instant.ToOffset(TimeSpan.Zero);
+        var payload = TimestampConverterResponse.FromUtc(utc);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+
+    internal static bool TryParseInstant(string trimmed, out DateTimeOffset instant, out string errorDetail)
+    {
+        instant = default;
+        errorDetail = string.Empty;
+
+        if (IsIntegerOnlyString(trimmed))
+        {
+            if (!long.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var epoch))
+            {
+                errorDetail = "The value is not a valid Unix epoch integer.";
+                return false;
+            }
+
+            var magnitude = epoch >= 0 ? epoch : checked(-epoch);
+            try
+            {
+                instant = magnitude >= MillisecondsEpochThreshold
+                    ? DateTimeOffset.FromUnixTimeMilliseconds(epoch)
+                    : DateTimeOffset.FromUnixTimeSeconds(epoch);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                errorDetail = "The Unix epoch value is out of the supported range.";
+                return false;
+            }
+
+            return true;
+        }
+
+        if (DateTimeOffset.TryParse(
+                trimmed,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces,
+                out instant))
+        {
+            return true;
+        }
+
+        errorDetail = "The value is not a valid ISO-8601 instant.";
+        return false;
+    }
+
+    private static bool IsIntegerOnlyString(string s)
+    {
+        if (s.Length == 0)
+            return false;
+
+        var i = 0;
+        if (s[0] == '-')
+        {
+            i = 1;
+            if (i == s.Length)
+                return false;
+        }
+
+        for (; i < s.Length; i++)
+        {
+            var c = s[i];
+            if (c is < '0' or > '9')
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/UI/Api/TimestampConverterModels.cs
+++ b/src/UI/Api/TimestampConverterModels.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/tools/timestamp-converter</c> and the versioned route.
+/// </summary>
+/// <param name="UnixTimeSeconds">Unix epoch seconds (UTC).</param>
+/// <param name="UnixTimeMilliseconds">Unix epoch milliseconds (UTC).</param>
+/// <param name="Iso8601Utc">ISO-8601 round-trip string for the instant in UTC (<c>O</c> format).</param>
+/// <param name="UtcDate">Calendar date in UTC (<c>yyyy-MM-dd</c>).</param>
+/// <param name="UtcTimeOfDay">Time-of-day in UTC (<c>HH:mm:ss.fff</c>).</param>
+/// <param name="DisplayUtc">Single human-readable UTC label using invariant culture.</param>
+public record TimestampConverterResponse(
+    long UnixTimeSeconds,
+    long UnixTimeMilliseconds,
+    string Iso8601Utc,
+    string UtcDate,
+    string UtcTimeOfDay,
+    string DisplayUtc)
+{
+    /// <summary>
+    /// Builds a response from a UTC-normalized <see cref="DateTimeOffset"/>.
+    /// </summary>
+    public static TimestampConverterResponse FromUtc(DateTimeOffset utc)
+    {
+        var normalized = utc.ToOffset(TimeSpan.Zero);
+        var dt = normalized.UtcDateTime;
+        return new TimestampConverterResponse(
+            UnixTimeSeconds: normalized.ToUnixTimeSeconds(),
+            UnixTimeMilliseconds: normalized.ToUnixTimeMilliseconds(),
+            Iso8601Utc: normalized.ToString("O", CultureInfo.InvariantCulture),
+            UtcDate: dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            UtcTimeOfDay: dt.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture),
+            DisplayUtc: dt.ToString("yyyy-MM-dd HH:mm:ss.fff 'UTC'", CultureInfo.InvariantCulture));
+    }
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and timestamp-converter endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -71,6 +71,21 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
         {
             return false;
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         if (segments.Length == 2)

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterControllerTests
+{
+    [Test]
+    public void Get_Should_Return400_When_ValueMissing()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_ValueWhitespace()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("   ");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_ReturnJson_When_EpochSeconds()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("0");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("application/json");
+        var dto = JsonSerializer.Deserialize<TimestampConverterResponse>(content.Content!, ConditionalGetEtag.JsonSerializerOptions);
+        dto.ShouldNotBeNull();
+        dto.UnixTimeSeconds.ShouldBe(0L);
+        dto.UnixTimeMilliseconds.ShouldBe(0L);
+        dto.UtcDate.ShouldBe("1970-01-01");
+        dto.Iso8601Utc.ShouldStartWith("1970-01-01T00:00:00");
+    }
+
+    [Test]
+    public void Get_Should_UseMilliseconds_When_AbsoluteEpochAtLeast1e11()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("100000000000");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var dto = JsonSerializer.Deserialize<TimestampConverterResponse>(content.Content!, ConditionalGetEtag.JsonSerializerOptions);
+        dto.ShouldNotBeNull();
+        dto.UnixTimeSeconds.ShouldBe(100_000_000L);
+        dto.UnixTimeMilliseconds.ShouldBe(100_000_000_000L);
+    }
+
+    [Test]
+    public void Get_Should_ParseIso8601()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("2024-06-15T14:30:00Z");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var dto = JsonSerializer.Deserialize<TimestampConverterResponse>(content.Content!, ConditionalGetEtag.JsonSerializerOptions);
+        dto.ShouldNotBeNull();
+        dto.UnixTimeSeconds.ShouldBe(new DateTimeOffset(2024, 6, 15, 14, 30, 0, TimeSpan.Zero).ToUnixTimeSeconds());
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesWeakEtag()
+    {
+        var controller1 = CreateController();
+        var first = controller1.Get("0");
+        first.ShouldBeOfType<ContentResult>();
+        var etag = controller1.Response.Headers.ETag.ToString();
+
+        var httpContext2 = new DefaultHttpContext();
+        httpContext2.Request.Headers.IfNoneMatch = etag;
+        var controller2 = new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext2 }
+        };
+
+        var second = controller2.Get("0");
+
+        second.ShouldBeOfType<StatusCodeResult>().StatusCode.ShouldBe(304);
+    }
+
+    private static TimestampConverterController CreateController() =>
+        new()
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+}

--- a/src/UnitTests/UI.Api/TimestampConverterParseTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterParseTests.cs
@@ -1,0 +1,33 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterParseTests
+{
+    [Test]
+    public void TryParseInstant_Should_ParseNegativeEpochSeconds()
+    {
+        var ok = TimestampConverterController.TryParseInstant("-1", out var instant, out var error);
+        ok.ShouldBeTrue();
+        error.ShouldBeEmpty();
+        instant.ShouldBe(DateTimeOffset.FromUnixTimeSeconds(-1));
+    }
+
+    [Test]
+    public void TryParseInstant_Should_Fail_When_NotIntegerAndNotIso()
+    {
+        var ok = TimestampConverterController.TryParseInstant("not-a-date", out _, out var error);
+        ok.ShouldBeFalse();
+        error.ShouldContain("ISO-8601");
+    }
+
+    [Test]
+    public void TryParseInstant_Should_ParseFractionalAsIso_NotEpoch()
+    {
+        var ok = TimestampConverterController.TryParseInstant("2020-01-01T00:00:00.500Z", out var instant, out _);
+        ok.ShouldBeTrue();
+        instant.UtcTicks.ShouldBe(new DateTimeOffset(2020, 1, 1, 0, 0, 0, 500, TimeSpan.Zero).UtcTicks);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/timestamp-converter", true)]
+    [TestCase("/api/v1.0/tools/timestamp-converter", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -92,4 +92,15 @@ public class ApiKeyAuthenticationWebTests
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return200_When_TimestampConverterWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/tools/timestamp-converter?value=0");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/tools/timestamp-converter` (and `GET /api/v1.0/tools/timestamp-converter`) so operators and integrations can convert between Unix epoch values and ISO-8601 instants in one call. The endpoint follows the same patterns as `TimeController` and `VersionController`: anonymous access, rate limiting, optional weak ETag with `304 Not Modified` when `If-None-Match` matches.

When optional API-key enforcement is enabled, both unversioned and versioned paths are treated as public (no `X-Api-Key`), consistent with `/api/time` and `/api/ping`.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/TimestampConverterController.cs` | New controller: required query `value`, epoch vs ISO parsing rules from the issue, `Problem` for 400, JSON 200 + ETag |
| `src/UI/Api/TimestampConverterModels.cs` | `TimestampConverterResponse` record with Unix seconds/ms, ISO UTC, `UtcDate`, `UtcTimeOfDay`, `DisplayUtc` |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Public path handling for `api/tools/timestamp-converter` and `api/v*/tools/timestamp-converter` |
| `src/UnitTests/UI.Api/TimestampConverterControllerTests.cs` | Controller unit tests (400, epoch, ms threshold, ISO, 304) |
| `src/UnitTests/UI.Api/TimestampConverterParseTests.cs` | Parsing edge cases |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Middleware path matrix |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Web test: 200 without API key when protection enabled |
| `src/IntegrationTests/Api/TimestampConverterIntegrationTests.cs` | Smoke on versioned route |

## Testing

- `dotnet test` filtered to TimestampConverter unit tests
- `PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` (full unit + integration suite)

Closes #5639
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eec3269d-bc2b-4957-9911-d1b872ae795e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eec3269d-bc2b-4957-9911-d1b872ae795e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

