### PR TITLE
New API endpoint POST /api/tools/guid-generator for on-demand GUID creation (#5637)

### DIFF
--- a/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class GuidGeneratorEndpointIntegrationTests
+{
+    private DetailedHealthWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DetailedHealthWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndOneGuid_When_PostWithoutBody()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/tools/guid-generator")
+        {
+            Content = new StringContent("", Encoding.UTF8, "application/json")
+        };
+
+        var response = await _client!.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Guids.Count.ShouldBe(1);
+        Guid.TryParseExact(payload.Guids[0], "D", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndRequestedCount_When_PostWithJsonBody()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 5 });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Guids.Count.ShouldBe(5);
+        payload.Guids.Select(Guid.Parse).Distinct().Count().ShouldBe(5);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_CountTooLarge()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 101 });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_PostVersionedRoute()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/v1.0/tools/guid-generator", new { count = 2 });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload!.Guids.Count.ShouldBe(2);
+    }
+}

--- a/src/UI/Api/Controllers/GuidGeneratorController.cs
+++ b/src/UI/Api/Controllers/GuidGeneratorController.cs
@@ -1,0 +1,64 @@
+using System.Net.Mime;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates one or more new GUID strings for scripts and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/guid-generator")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/guid-generator")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class GuidGeneratorController : ControllerBase
+{
+    private const int DefaultCount = 1;
+    private const int MaxCount = 100;
+
+    /// <summary>
+    /// Creates new GUID values. Request body is optional; when omitted or when <see cref="GuidGeneratorRequest.Count"/> is null, one GUID is returned.
+    /// </summary>
+    [HttpPost]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [AllowAnonymous]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(GuidGeneratorResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Post([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] GuidGeneratorRequest? request)
+    {
+        var count = request?.Count ?? DefaultCount;
+        if (count < 1 || count > MaxCount)
+        {
+            return Problem(
+                detail: $"Count must be between 1 and {MaxCount}, inclusive.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var guids = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            guids[i] = Guid.NewGuid().ToString("D");
+        }
+
+        return Ok(new GuidGeneratorResponse(guids));
+    }
+}
+
+/// <summary>
+/// Optional JSON body for <c>POST /api/tools/guid-generator</c>.
+/// </summary>
+/// <param name="Count">Number of GUIDs to generate; defaults to 1 when omitted or null.</param>
+public sealed record GuidGeneratorRequest(int? Count = null);
+
+/// <summary>
+/// Response payload containing newly generated GUID strings (lowercase hex with hyphens, "D" format).
+/// </summary>
+/// <param name="Guids">The generated identifiers.</param>
+public sealed record GuidGeneratorResponse(IReadOnlyList<string> Guids);

--- a/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
+++ b/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
@@ -1,0 +1,114 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class GuidGeneratorControllerTests
+{
+    private static GuidGeneratorController CreateController()
+    {
+        return new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+    }
+
+    [Test]
+    public void Post_Should_ReturnOneGuid_When_RequestIsNull()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(null);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(1);
+        ShouldParseAsGuidD(payload.Guids[0]);
+    }
+
+    [Test]
+    public void Post_Should_ReturnOneGuid_When_CountIsOmitted()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest());
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(1);
+        ShouldParseAsGuidD(payload.Guids[0]);
+    }
+
+    [Test]
+    public void Post_Should_ReturnDistinctGuids_When_CountIsThree()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(3));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(3);
+        payload.Guids.Select(Guid.Parse).Distinct().Count().ShouldBe(3);
+        foreach (var g in payload.Guids)
+        {
+            ShouldParseAsGuidD(g);
+        }
+    }
+
+    [Test]
+    public void Post_Should_ReturnProblem_When_CountIsZero()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(0));
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Post_Should_ReturnProblem_When_CountIsNegative()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(-1));
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Post_Should_ReturnProblem_When_CountExceedsMaximum()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(101));
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Post_Should_ReturnHundredGuids_When_CountIsMaximum()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(100));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(100);
+        payload.Guids.Select(Guid.Parse).Distinct().Count().ShouldBe(100);
+    }
+
+    private static void ShouldParseAsGuidD(string text)
+    {
+        Guid.TryParseExact(text, "D", out var parsed).ShouldBeTrue();
+        parsed.ShouldNotBe(Guid.Empty);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `POST /api/tools/guid-generator` (and `POST /api/v1.0/tools/guid-generator`) for generating one or more new GUID strings. Optional JSON body `{ "count": N }` defaults to 1; `count` must be between 1 and 100 inclusive. GUIDs are returned as lowercase hyphenated strings (`Guid.ToString("D")`). The endpoint uses the same rate limiting and anonymous access pattern as other utility APIs (`TimeController`). API key middleware is **not** whitelisted for this path (unchanged from design default).

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/GuidGeneratorController.cs` | New controller + request/response records |
| `src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs` | Unit tests for validation and output shape |
| `src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs` | HTTP integration tests (unversioned + versioned routes) |

## Testing

- `dotnet test` filtered to `GuidGeneratorControllerTests` and `GuidGeneratorEndpointIntegrationTests` during development
- Full `./PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite`: all unit tests (268) and integration tests (112) passed

Closes #5637
