### PR TITLE
New API endpoint POST /api/tools/hash for computing SHA-256 hashes of text input (#5638)

### DIFF
--- a/src/IntegrationTests/Api/ToolsHashEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ToolsHashEndpointIntegrationTests.cs
@@ -1,0 +1,183 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ToolsHashEndpointIntegrationTests
+{
+    private DetailedHealthWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DetailedHealthWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    private static ToolsHashResponse ExpectedForText(string text)
+    {
+        var utf8 = Encoding.UTF8.GetBytes(text);
+        return new ToolsHashResponse
+        {
+            Sha256 = Convert.ToHexString(SHA256.HashData(utf8)).ToLowerInvariant(),
+            Md5 = Convert.ToHexString(MD5.HashData(utf8)).ToLowerInvariant(),
+            Sha1 = Convert.ToHexString(SHA1.HashData(utf8)).ToLowerInvariant()
+        };
+    }
+
+    [Test]
+    public async Task Should_Return200AndCorrectDigests_When_PostValidText_UnversionedRoute()
+    {
+        const string text = "abc";
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new { text });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        var payload = await response.Content.ReadFromJsonAsync<ToolsHashResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        var expected = ExpectedForText(text);
+        payload!.Sha256.ShouldBe(expected.Sha256);
+        payload.Md5.ShouldBe(expected.Md5);
+        payload.Sha1.ShouldBe(expected.Sha1);
+    }
+
+    [Test]
+    public async Task Should_Return200AndSameDigests_When_PostValidText_VersionedRoute()
+    {
+        const string text = "abc";
+        var unversioned = await _client!.PostAsJsonAsync("/api/tools/hash", new { text });
+        var versioned = await _client!.PostAsJsonAsync("/api/v1.0/tools/hash", new { text });
+
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var a = await unversioned.Content.ReadFromJsonAsync<ToolsHashResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var b = await versioned.Content.ReadFromJsonAsync<ToolsHashResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        a.ShouldNotBeNull();
+        b.ShouldNotBeNull();
+        b!.Sha256.ShouldBe(a!.Sha256);
+        b.Md5.ShouldBe(a.Md5);
+        b.Sha1.ShouldBe(a.Sha1);
+    }
+
+    [Test]
+    public async Task Should_Return200AndKnownVectors_When_TextIsEmptyString()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new { text = "" });
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<ToolsHashResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var expected = ExpectedForText("");
+        payload.ShouldNotBeNull();
+        payload!.Sha256.ShouldBe(expected.Sha256);
+        payload.Md5.ShouldBe(expected.Md5);
+        payload.Sha1.ShouldBe(expected.Sha1);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_TextMissing()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new { });
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_TextNull()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new { text = (string?)null });
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400Or415_When_BodyIsNotValidJson()
+    {
+        using var content = new StringContent("{not json", Encoding.UTF8, "application/json");
+        var response = await _client!.PostAsync("/api/tools/hash", content);
+        (response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.UnsupportedMediaType)
+            .ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.PostAsJsonAsync("/api/tools/hash", new { text = "x" });
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.PostAsJsonAsync("/api/v1.0/tools/hash", new { text = "x" });
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(ApiKeyConstants.HeaderName, ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.PostAsJsonAsync("/api/tools/hash", new { text = "x" });
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.PostAsJsonAsync("/api/v1.0/tools/hash", new { text = "x" });
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_ReturnDeterministicCachedResponse_When_IdempotencyKeyReplayed()
+    {
+        const string bodyJson = """{"text":"idem"}""";
+        using var req1 = new HttpRequestMessage(HttpMethod.Post, "/api/tools/hash");
+        req1.Headers.Add(IdempotencyConstants.HeaderName, "tools-hash-idem");
+        req1.Content = new StringContent(bodyJson, Encoding.UTF8, "application/json");
+
+        var r1 = await _client!.SendAsync(req1);
+        r1.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body1 = await r1.Content.ReadAsStringAsync();
+
+        using var req2 = new HttpRequestMessage(HttpMethod.Post, "/api/tools/hash");
+        req2.Headers.Add(IdempotencyConstants.HeaderName, "tools-hash-idem");
+        req2.Content = new StringContent(bodyJson, Encoding.UTF8, "application/json");
+
+        var r2 = await _client.SendAsync(req2);
+        r2.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body2 = await r2.Content.ReadAsStringAsync();
+
+        body2.ShouldBe(body1);
+    }
+
+    [Test]
+    public async Task Should_HashUtf8Bytes_When_InputContainsNonAscii()
+    {
+        const string text = "café";
+        var response = await _client!.PostAsJsonAsync("/api/tools/hash", new { text });
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<ToolsHashResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var expected = ExpectedForText(text);
+        payload.ShouldNotBeNull();
+        payload!.Sha256.ShouldBe(expected.Sha256);
+        payload.Md5.ShouldBe(expected.Md5);
+        payload.Sha1.ShouldBe(expected.Sha1);
+    }
+}

--- a/src/UI/Api/Controllers/ToolsHashController.cs
+++ b/src/UI/Api/Controllers/ToolsHashController.cs
@@ -1,0 +1,63 @@
+using System.Net.Mime;
+using System.Security.Cryptography;
+using System.Text;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Computes SHA-256, MD5, and SHA-1 digests of request <c>text</c> using UTF-8 encoding.
+/// Success JSON uses stable field names: <c>sha256</c>, <c>md5</c>, <c>sha1</c> (lowercase hex strings).
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/hash")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/hash")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsHashController : ControllerBase
+{
+    private const int MaxTextLength = 1024 * 1024;
+
+    /// <summary>
+    /// Returns hexadecimal digests of the UTF-8 encoding of <paramref name="request"/>.<see cref="ToolsHashRequest.Text"/>.
+    /// </summary>
+    [HttpPost]
+    [RequestSizeLimit(MaxTextLength + 64)]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [AllowAnonymous]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(ToolsHashResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Post([FromBody] ToolsHashRequest? request)
+    {
+        if (request?.Text is null)
+        {
+            return Problem(
+                detail: "JSON body must include a non-null \"text\" property.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (request.Text.Length > MaxTextLength)
+        {
+            return Problem(
+                detail: $"The \"text\" value must be at most {MaxTextLength} characters.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var utf8 = Encoding.UTF8.GetBytes(request.Text);
+        var sha256Hex = Convert.ToHexString(SHA256.HashData(utf8)).ToLowerInvariant();
+        var md5Hex = Convert.ToHexString(MD5.HashData(utf8)).ToLowerInvariant();
+        var sha1Hex = Convert.ToHexString(SHA1.HashData(utf8)).ToLowerInvariant();
+
+        return Ok(new ToolsHashResponse
+        {
+            Sha256 = sha256Hex,
+            Md5 = md5Hex,
+            Sha1 = sha1Hex
+        });
+    }
+}

--- a/src/UI/Api/ToolsHashModels.cs
+++ b/src/UI/Api/ToolsHashModels.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Request body for <c>POST /api/tools/hash</c> and the versioned duplicate route.
+/// </summary>
+public sealed class ToolsHashRequest
+{
+    /// <summary>
+    /// UTF-8 text to digest; required (empty string is allowed).
+    /// </summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+}
+
+/// <summary>
+/// JSON response carrying lowercase hexadecimal digests of the input UTF-8 bytes.
+/// MD5 and SHA-1 are checksums only, not for security.
+/// </summary>
+public sealed class ToolsHashResponse
+{
+    /// <summary>
+    /// SHA-256 digest (64 hex characters, lowercase).
+    /// </summary>
+    [JsonPropertyName("sha256")]
+    public required string Sha256 { get; init; }
+
+    /// <summary>
+    /// MD5 digest (32 hex characters, lowercase).
+    /// </summary>
+    [JsonPropertyName("md5")]
+    public required string Md5 { get; init; }
+
+    /// <summary>
+    /// SHA-1 digest (40 hex characters, lowercase).
+    /// </summary>
+    [JsonPropertyName("sha1")]
+    public required string Sha1 { get; init; }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/tools/hash", false)]
+    [TestCase("/api/v1.0/tools/hash", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `POST /api/tools/hash` (and `POST /api/v1.0/tools/hash`) accepting JSON `{"text": "..."}` and returning lowercase hex digests for UTF-8 bytes: `sha256` (primary), plus `md5` and `sha1` as checksums. Returns `400` with ProblemDetails when `text` is null or omitted. Applies the same rate limiting and optional API-key rules as other `/api/*` routes.

## Files changed

- `src/UI/Api/ToolsHashModels.cs` — request/response DTOs with stable JSON names.
- `src/UI/Api/Controllers/ToolsHashController.cs` — POST handler, 1 MiB `text` cap, `RequestSizeLimit` aligned with abuse mitigation.
- `src/IntegrationTests/Api/ToolsHashEndpointIntegrationTests.cs` — integration coverage (unversioned/versioned routes, empty string, validation, malformed JSON, API key, idempotency replay, Unicode UTF-8).
- `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` — documents that `/api/tools/hash` is not a public API-key bypass path.

## Testing

- `DATABASE_ENGINE=SQLite ./PrivateBuild.ps1` — unit tests (263) and integration tests (117) passed.

Closes #5638
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d086ee7e-c135-4d95-8b6e-67b6b22442a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d086ee7e-c135-4d95-8b6e-67b6b22442a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

