### PR TITLE
New API endpoint GET /api/tools/random for configurable random data generation (#5641)

### DIFF
--- a/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
@@ -1,0 +1,135 @@
+using System.Globalization;
+using System.Net;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ToolsRandomEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndWellFormedNumber_When_TypeIsNumber()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=number");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        int.TryParse(body, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n).ShouldBeTrue();
+        n.ShouldBeGreaterThanOrEqualTo(int.MinValue);
+        n.ShouldBeLessThanOrEqualTo(int.MaxValue);
+
+        var v = await _client.GetAsync("/api/v1.0/tools/random?type=number");
+        v.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return200AndWellFormedString_When_TypeIsString()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=string");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Length.ShouldBe(ToolsRandomController.RandomStringLength);
+        body.ToCharArray().All(c => char.IsAsciiLetterOrDigit(c)).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndValidGuid_When_TypeIsUuid()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=uuid");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        Guid.TryParse(body, out var g).ShouldBeTrue();
+        g.ShouldNotBe(Guid.Empty);
+    }
+
+    [Test]
+    public async Task Should_Return200AndRecognizedColor_When_TypeIsColor()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=color");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Length.ShouldBe(7);
+        body[0].ShouldBe('#');
+        body[1..].All(c => char.IsAsciiHexDigitUpper(c)).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return400_When_TypeIsMissingOrEmpty()
+    {
+        var missing = await _client!.GetAsync("/api/tools/random");
+        missing.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        var empty = await _client.GetAsync("/api/tools/random?type=");
+        empty.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_TypeIsUnknown()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=not-a-real-type");
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_TreatTypeParameterCaseInsensitively_When_Number()
+    {
+        var a = await _client!.GetAsync("/api/tools/random?type=NUMBER");
+        var b = await _client.GetAsync("/api/tools/random?type=number");
+        a.StatusCode.ShouldBe(HttpStatusCode.OK);
+        b.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_NotRequireApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var withoutKey = await client.GetAsync("/api/tools/random?type=uuid");
+        withoutKey.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var withoutKeyV = await client.GetAsync("/api/v1.0/tools/random?type=uuid");
+        withoutKeyV.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var diagnostics = await client.GetAsync("/api/diagnostics");
+        diagnostics.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+        var okDiag = await withKey.GetAsync("/api/diagnostics");
+        okDiag.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_ReturnDifferentValues_When_TwoSequentialGets()
+    {
+        var first = await _client!.GetAsync("/api/tools/random?type=uuid");
+        var second = await _client.GetAsync("/api/tools/random?type=uuid");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        second.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var a = await first.Content.ReadAsStringAsync();
+        var b = await second.Content.ReadAsStringAsync();
+        a.ShouldNotBe(b);
+    }
+}

--- a/src/UI/Api/Controllers/ToolsRandomController.cs
+++ b/src/UI/Api/Controllers/ToolsRandomController.cs
@@ -1,0 +1,101 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates random values for scripts and integrations. Query parameter <c>type</c> is required.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/random")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/random")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsRandomController : ControllerBase
+{
+    /// <summary>
+    /// Length of the alphanumeric string returned when <paramref name="type"/> is <c>string</c>.
+    /// </summary>
+    public const int RandomStringLength = 16;
+
+    private const string AlphanumericChars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    /// <summary>
+    /// Returns random data as UTF-8 plain text. Supported <paramref name="type"/> values (case-insensitive):
+    /// <c>number</c> — uniform random 32-bit signed integer; <c>string</c> — <see cref="RandomStringLength"/> alphanumeric characters;
+    /// <c>uuid</c> — RFC 4122 version 4 GUID string; <c>color</c> — CSS hex <c>#RRGGBB</c> with uppercase hex digits.
+    /// </summary>
+    /// <param name="type">One of: number, string, uuid, color.</param>
+    /// <returns>200 with <c>text/plain; charset=utf-8</c>, or 400 with problem details when <paramref name="type"/> is missing, empty, or unknown.</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Produces("text/plain")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return Problem(
+                detail: "Query parameter 'type' is required. Allowed values: number, string, uuid, color.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var normalized = type.Trim();
+        if (normalized.Equals("number", StringComparison.OrdinalIgnoreCase))
+        {
+            Span<byte> buf = stackalloc byte[4];
+            RandomNumberGenerator.Fill(buf);
+            var n = BitConverter.ToInt32(buf);
+            return PlainText(n.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (normalized.Equals("string", StringComparison.OrdinalIgnoreCase))
+        {
+            var chars = new char[RandomStringLength];
+            for (var i = 0; i < chars.Length; i++)
+            {
+                chars[i] = AlphanumericChars[RandomNumberGenerator.GetInt32(0, AlphanumericChars.Length)];
+            }
+
+            return PlainText(new string(chars));
+        }
+
+        if (normalized.Equals("uuid", StringComparison.OrdinalIgnoreCase))
+        {
+            Span<byte> uuidBytes = stackalloc byte[16];
+            RandomNumberGenerator.Fill(uuidBytes);
+            uuidBytes[6] = (byte)((uuidBytes[6] & 0x0F) | 0x40);
+            uuidBytes[8] = (byte)((uuidBytes[8] & 0x3F) | 0x80);
+            var g = new Guid(uuidBytes);
+            return PlainText(g.ToString("D"));
+        }
+
+        if (normalized.Equals("color", StringComparison.OrdinalIgnoreCase))
+        {
+            Span<byte> rgb = stackalloc byte[3];
+            RandomNumberGenerator.Fill(rgb);
+            var hex = Convert.ToHexString(rgb);
+            return PlainText("#" + hex);
+        }
+
+        return Problem(
+            detail: "Unknown 'type'. Allowed values: number, string, uuid, color.",
+            statusCode: StatusCodes.Status400BadRequest);
+    }
+
+    private static ContentResult PlainText(string content) =>
+        new()
+        {
+            Content = content,
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = StatusCodes.Status200OK
+        };
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and tools/random endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -79,6 +79,21 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (segments.Length >= 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("random", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("random", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         if (segments.Length >= 3

--- a/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
+++ b/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
@@ -1,0 +1,155 @@
+using System.Globalization;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsRandomControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnPlainTextNumber_When_TypeIsNumber()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("number");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        content.Content.ShouldNotBeNull();
+        int.TryParse(content.Content, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n).ShouldBeTrue();
+        n.ShouldBeGreaterThanOrEqualTo(int.MinValue);
+        n.ShouldBeLessThanOrEqualTo(int.MaxValue);
+    }
+
+    [Test]
+    public void Get_Should_ReturnPlainTextString_When_TypeIsString()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("string");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.Content.ShouldNotBeNull();
+        content.Content!.Length.ShouldBe(ToolsRandomController.RandomStringLength);
+        content.Content.ToCharArray().All(c => char.IsAsciiLetterOrDigit(c)).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_Should_ReturnPlainTextUuid_When_TypeIsUuid()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("uuid");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.Content.ShouldNotBeNull();
+        Guid.TryParse(content.Content, out var g).ShouldBeTrue();
+        g.ShouldNotBe(Guid.Empty);
+    }
+
+    [Test]
+    public void Get_Should_ReturnUppercaseHexColor_When_TypeIsColor()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("color");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.Content.ShouldNotBeNull();
+        content.Content!.Length.ShouldBe(7);
+        content.Content[0].ShouldBe('#');
+        content.Content[1..].All(c => char.IsAsciiHexDigitUpper(c)).ShouldBeTrue();
+    }
+
+    [TestCase("NUMBER")]
+    [TestCase("Number")]
+    public void Get_Should_AcceptTypeCaseInsensitively_When_Number(string type)
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(type);
+
+        result.ShouldBeOfType<ContentResult>();
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_TypeIsNull()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get(null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_TypeIsEmpty()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("   ");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_TypeIsUnknown()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get("not-a-real-type");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldNotBeNull();
+        details.Detail!.ShouldContain("Unknown");
+    }
+
+    [Test]
+    public void Get_Should_ReturnDifferentNumbers_When_CalledTwice()
+    {
+        var controller = new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var a = (controller.Get("number") as ContentResult)!.Content!;
+        var b = (controller.Get("number") as ContentResult)!.Content!;
+        a.ShouldNotBe(b);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/random", true)]
+    [TestCase("/api/v1.0/tools/random", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/tools/random` (and `GET /api/v1.0/tools/random`) so programmatic clients can request random values via the `type` query parameter. Supported types: **number** (random 32-bit signed integer as invariant-culture plain text), **string** (16 alphanumeric characters), **uuid** (RFC 4122 version 4 GUID), **color** (`#RRGGBB` uppercase hex). All entropy uses `RandomNumberGenerator`. Invalid or missing `type` returns HTTP 400 with `ProblemDetails`. When optional API key middleware is enabled, **tools/random** is treated as a public path (same idea as version/time/ping), so scripts can call it without `X-Api-Key`.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/ToolsRandomController.cs` | New API controller with dual routes, rate limiting, and `Get(type)` action |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Public-path handling for `/api/tools/random` and `/api/v1.0/tools/random` |
| `src/UnitTests/UI.Api/ToolsRandomControllerTests.cs` | Unit tests for success and validation paths |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Test cases for public random paths under API key |
| `src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs` | In-process host tests per test design |

## Testing

- `DATABASE_ENGINE=SQLite` **PrivateBuild.ps1**: clean build, 273 unit tests, 117 integration tests — all passed.
- Filtered runs during development: `ToolsRandomControllerTests`, `ApiKeyAuthenticationMiddlewareTests`, `ToolsRandomEndpointIntegrationTests`.

Closes #5641
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b477f708-8bce-4452-b84c-d338953ccd3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b477f708-8bce-4452-b84c-d338953ccd3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

