### PR TITLE
Add navigate hide button (#5632)

### DIFF
--- a/src/AcceptanceTests/App/NavRailToggleTests.cs
+++ b/src/AcceptanceTests/App/NavRailToggleTests.cs
@@ -1,0 +1,31 @@
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UI.Shared;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
+
+[TestFixture]
+public class NavRailToggleTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldCollapseAndExpandNavRail_OnWideViewport()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+        await Expect(toggle).ToBeVisibleAsync();
+        await Expect(toggle).ToHaveAttributeAsync("aria-expanded", "true");
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+
+        await Expect(toggle).ToHaveAttributeAsync("aria-expanded", "false");
+        await Expect(Page.Locator("#app-navigation-rail")).ToHaveClassAsync(new Regex("rail-hidden"));
+        await Expect(Page.Locator(".modern-app").First).ToHaveClassAsync(new Regex("rail-collapsed"));
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+
+        await Expect(toggle).ToHaveAttributeAsync("aria-expanded", "true");
+        await Expect(Page.Locator("#app-navigation-rail")).Not.ToHaveClassAsync(new Regex("rail-hidden"));
+        await Expect(Page.Locator(".modern-app").First).Not.ToHaveClassAsync(new Regex("rail-collapsed"));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The shared shell already exposes a header nav-rail toggle (`MainLayout`) with wide/narrow behavior, ARIA, and bUnit coverage per the issue technical design. This change adds a **Playwright acceptance test** so the product gate described in the issue is covered end-to-end: the toggle collapses the rail on a wide viewport (`rail-hidden`, `rail-collapsed`) and restores it on second click.

## Files changed

| File | Description |
|------|-------------|
| `src/AcceptanceTests/App/NavRailToggleTests.cs` | New test: visibility, `aria-expanded`, layout classes after toggle clicks |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — unit + integration tests green (261 + 108).
- `dotnet build src/AcceptanceTests/AcceptanceTests.csproj -c Release` — compiles (Playwright test not executed in that build).

Closes #5632
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e23edfe8-89a0-4eeb-af4d-27202b8ea21b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e23edfe8-89a0-4eeb-af4d-27202b8ea21b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

