### PR TITLE
New API endpoint GET /api/features/flags for runtime feature flag status (#5640)

### DIFF
--- a/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
@@ -166,4 +166,17 @@ public class DiagnosticsEndpointIntegrationTests
         var okVersioned = await withKey.GetAsync("/api/v1.0/diagnostics");
         okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_AllowFeatureFlagsWithoutApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/features/flags");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/features/flags");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }

--- a/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class FeatureFlagsEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetFeatureFlagsUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/features/flags");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("flags", out var flags).ShouldBeTrue();
+        flags.ValueKind.ShouldBe(JsonValueKind.Array);
+        flags.GetArrayLength().ShouldBe(2);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetFeatureFlagsVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/features/flags");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("flags", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_ExposeFlagValues_FromConfiguration_When_GetFeatureFlags()
+    {
+        var response = await _client!.GetAsync("/api/features/flags");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<FeatureFlagsResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Flags.ShouldContain(f => f.Name == "SampleFeatureA" && f.Enabled);
+        payload.Flags.ShouldContain(f => f.Name == "SampleFeatureB" && !f.Enabled);
+    }
+
+    [Test]
+    public async Task Should_ExposeFlagValues_FromOverriddenConfiguration_When_GetFeatureFlags()
+    {
+        await using var factory = new DiagnosticsWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["FeatureFlags:SampleFeatureA"] = "false",
+                    ["FeatureFlags:SampleFeatureB"] = "true"
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/features/flags");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<FeatureFlagsResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Flags.ShouldContain(f => f.Name == "SampleFeatureA" && !f.Enabled);
+        payload.Flags.ShouldContain(f => f.Name == "SampleFeatureB" && f.Enabled);
+    }
+
+    [Test]
+    public async Task Should_Return304_When_IfNoneMatchMatchesEtag()
+    {
+        var first = await _client!.GetAsync("/api/features/flags");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var etag = first.Headers.ETag;
+        etag.ShouldNotBeNull();
+
+        using var second = new HttpRequestMessage(HttpMethod.Get, "/api/features/flags");
+        second.Headers.IfNoneMatch.Add(etag);
+
+        var cached = await _client!.SendAsync(second);
+        cached.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+    }
+}

--- a/src/UI/Api/ApplicationFeatureFlags.cs
+++ b/src/UI/Api/ApplicationFeatureFlags.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Static registry of application feature flag names. Runtime enabled/disabled values are taken from
+/// <see cref="DiagnosticsFeatureFlagsOptions"/> (bound from the <c>FeatureFlags</c> configuration section) on each build.
+/// </summary>
+public static class ApplicationFeatureFlags
+{
+    private static readonly IReadOnlyDictionary<string, Func<DiagnosticsFeatureFlagsOptions, bool>> Registry =
+        new Dictionary<string, Func<DiagnosticsFeatureFlagsOptions, bool>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [nameof(DiagnosticsFeatureFlagsOptions.SampleFeatureA)] = o => o.SampleFeatureA,
+            [nameof(DiagnosticsFeatureFlagsOptions.SampleFeatureB)] = o => o.SampleFeatureB
+        };
+
+    /// <summary>
+    /// Known flag names in stable order for API responses.
+    /// </summary>
+    public static IReadOnlyList<string> KnownNames { get; } = Registry.Keys.OrderBy(k => k, StringComparer.Ordinal).ToList();
+
+    /// <summary>
+    /// Builds a response listing each registered flag with its current value from configuration.
+    /// </summary>
+    public static FeatureFlagsResponse BuildSnapshot(IOptions<DiagnosticsFeatureFlagsOptions> options)
+    {
+        var value = options.Value;
+        var items = KnownNames.Select(name => new FeatureFlagItem(name, Registry[name](value))).ToList();
+        return new FeatureFlagsResponse(items);
+    }
+}

--- a/src/UI/Api/Controllers/FeatureFlagsController.cs
+++ b/src/UI/Api/Controllers/FeatureFlagsController.cs
@@ -1,0 +1,34 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes runtime feature flag status for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/features/flags")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/features/flags")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class FeatureFlagsController(IOptions<DiagnosticsFeatureFlagsOptions> featureFlagsOptions) : ControllerBase
+{
+    /// <summary>
+    /// Returns all registered feature flags and their enabled state, synchronized from <c>FeatureFlags</c> configuration.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var payload = ApplicationFeatureFlags.BuildSnapshot(featureFlagsOptions);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/FeatureFlagsModels.cs
+++ b/src/UI/Api/FeatureFlagsModels.cs
@@ -1,0 +1,11 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON contract for one entry in <c>GET /api/features/flags</c>.
+/// </summary>
+public sealed record FeatureFlagItem(string Name, bool Enabled);
+
+/// <summary>
+/// JSON payload for <c>GET /api/features/flags</c> and <c>GET /api/v1.0/features/flags</c>.
+/// </summary>
+public sealed record FeatureFlagsResponse(IReadOnlyList<FeatureFlagItem> Flags);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and feature-flags endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,12 +57,36 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionOrTimePath(value) || IsPublicFeaturesFlagsPath(value))
         {
             return false;
         }
 
         return true;
+    }
+
+    internal static bool IsPublicFeaturesFlagsPath(string pathValue)
+    {
+        var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 3 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (segments.Length == 3)
+        {
+            return segments[1].Equals("features", StringComparison.OrdinalIgnoreCase)
+                   && segments[2].Equals("flags", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
+        {
+            return segments[2].Equals("features", StringComparison.OrdinalIgnoreCase)
+                   && segments[3].Equals("flags", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
     }
 
     internal static bool IsPublicVersionOrTimePath(string pathValue)

--- a/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagsControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJson_WithFlagsFromOptions_When_Called()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+        var controller = new FeatureFlagsController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<FeatureFlagsResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Flags.Count.ShouldBe(2);
+        payload.Flags.ShouldContain(f => f.Name == "SampleFeatureA" && f.Enabled);
+        payload.Flags.ShouldContain(f => f.Name == "SampleFeatureB" && !f.Enabled);
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesEtag()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = false, SampleFeatureB = true };
+        var httpContext = new DefaultHttpContext();
+        var controller = new FeatureFlagsController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+
+        var first = controller.Get();
+        var firstContent = first.ShouldBeOfType<ContentResult>();
+        var snapshot = JsonSerializer.Deserialize<FeatureFlagsResponse>(
+            firstContent.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        snapshot.ShouldNotBeNull();
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(snapshot);
+
+        httpContext.Request.Headers.IfNoneMatch = etag.ToString();
+        var second = controller.Get();
+        var notModified = second.ShouldBeOfType<StatusCodeResult>();
+        notModified.StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+
+    [Test]
+    public void Get_Should_SetWeakEtagHeader_When_200()
+    {
+        var controller = new FeatureFlagsController(
+                Options.Create(new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = true }))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        _ = controller.Get();
+
+        var etagValues = controller.Response.Headers.ETag;
+        etagValues.Count.ShouldBe(1);
+        EntityTagHeaderValue.TryParse(etagValues.ToString(), out var parsed).ShouldBeTrue();
+        parsed!.IsWeak.ShouldBeTrue();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/features/flags", true)]
+    [TestCase("/api/v1.0/features/flags", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -92,4 +92,17 @@ public class ApiKeyAuthenticationWebTests
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return200_When_FeatureFlagsWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/features/flags");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/features/flags");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/features/flags` and `GET /api/v1.0/features/flags` returning JSON `{ "flags": [ { "name", "enabled" }, ... ] }`. Flag names come from a static registry (`ApplicationFeatureFlags`); enabled values are read from `IOptions<DiagnosticsFeatureFlagsOptions>` on each request so `appsettings` / environment overrides stay accurate. Uses the same rate limiting as other `/api/*` JSON routes, weak ETag + `304 Not Modified` when `If-None-Match` matches, and `[AllowAnonymous]` for interactive auth parity with lightweight probes.

When API key middleware is enabled, `features/flags` is treated as a public path (same category as `ping`, `version`, `time`) so operators can read flag state without `X-Api-Key`.

Closes #5640

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/ApplicationFeatureFlags.cs` | Static registry + `BuildSnapshot` from options |
| `src/UI/Api/FeatureFlagsModels.cs` | `FeatureFlagItem`, `FeatureFlagsResponse` records |
| `src/UI/Api/Controllers/FeatureFlagsController.cs` | Dual-route GET with ETag / 304 |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Skip key validation for `api/features/flags` and versioned variant |
| `src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs` | Controller JSON, ETag header, 304 |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Public path cases |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | 200 without key when middleware on |
| `src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs` | Host tests: routes, config, 304 |
| `src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs` | Feature flags public under API key factory |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — passed (267 unit + 114 integration tests).

---

Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df92ad16-159e-43e7-a1c5-5fb675ac7d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df92ad16-159e-43e7-a1c5-5fb675ac7d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

