### PR TITLE
New API endpoint GET /api/metrics/summary for application runtime metrics (#5634)

### DIFF
--- a/src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class MetricsSummaryEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetMetricsSummaryUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        AssertRequiredProperties(doc.RootElement);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetMetricsSummaryVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        AssertRequiredProperties(doc.RootElement);
+    }
+
+    [Test]
+    public async Task Should_IncreaseTotalRequests_When_AdditionalGetsAfterSummary()
+    {
+        var first = await _client!.GetAsync("/api/metrics/summary");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var firstPayload = await first.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        firstPayload.ShouldNotBeNull();
+        var baseline = firstPayload!.TotalRequestsServed;
+
+        for (var i = 0; i < 4; i++)
+        {
+            (await _client.GetAsync("/api/version")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        var second = await _client.GetAsync("/api/metrics/summary");
+        second.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var secondPayload = await second.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        secondPayload.ShouldNotBeNull();
+        secondPayload!.TotalRequestsServed.ShouldBeGreaterThanOrEqualTo(baseline + 5);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabledAndMetricsProtected()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/metrics/summary");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/metrics/summary");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.GetAsync("/api/metrics/summary");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/metrics/summary");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private static void AssertRequiredProperties(JsonElement root)
+    {
+        root.TryGetProperty("uptime", out _).ShouldBeTrue();
+        root.TryGetProperty("totalRequestsServed", out _).ShouldBeTrue();
+        root.TryGetProperty("workingSetBytes", out _).ShouldBeTrue();
+        root.TryGetProperty("totalAllocatedBytes", out _).ShouldBeTrue();
+        root.TryGetProperty("gcGen0Collections", out _).ShouldBeTrue();
+        root.TryGetProperty("gcGen1Collections", out _).ShouldBeTrue();
+        root.TryGetProperty("gcGen2Collections", out _).ShouldBeTrue();
+    }
+}

--- a/src/UI/Api/Controllers/MetricsSummaryController.cs
+++ b/src/UI/Api/Controllers/MetricsSummaryController.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes basic runtime metrics (uptime, request totals, memory, GC) for operators and monitoring.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/metrics")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/metrics")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class MetricsSummaryController(TimeProvider timeProvider, IHttpRequestMetrics httpRequestMetrics) : ControllerBase
+{
+    /// <summary>
+    /// Returns uptime, total HTTP requests counted by the host, working set, allocated bytes, and GC collection counts.
+    /// </summary>
+    [HttpGet("summary")]
+    public IActionResult GetSummary()
+    {
+        var healthSlice = SimpleHealthResponseBuilder.Build(timeProvider);
+        using var process = Process.GetCurrentProcess();
+        process.Refresh();
+        var payload = new MetricsSummaryResponse(
+            Uptime: healthSlice.Uptime,
+            TotalRequestsServed: httpRequestMetrics.TotalRequestsServed,
+            WorkingSetBytes: process.WorkingSet64,
+            TotalAllocatedBytes: GC.GetTotalAllocatedBytes(false),
+            GcGen0Collections: GC.CollectionCount(0),
+            GcGen1Collections: GC.CollectionCount(1),
+            GcGen2Collections: GC.CollectionCount(2));
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/IHttpRequestMetrics.cs
+++ b/src/UI/Api/IHttpRequestMetrics.cs
@@ -1,0 +1,14 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Process-wide count of HTTP requests observed by host middleware after routing.
+/// Increments once per request that reaches the counter (Kestrel HTTP pipeline); excludes requests that never reach the middleware (for example some gRPC paths if not routed through the same branch).
+/// </summary>
+public interface IHttpRequestMetrics
+{
+    /// <summary>Total requests recorded since process start.</summary>
+    long TotalRequestsServed { get; }
+
+    /// <summary>Records one request (thread-safe).</summary>
+    void RecordRequest();
+}

--- a/src/UI/Api/MetricsSummaryModels.cs
+++ b/src/UI/Api/MetricsSummaryModels.cs
@@ -1,0 +1,20 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/metrics/summary</c> and <c>GET /api/v1.0/metrics/summary</c>.
+/// </summary>
+/// <param name="Uptime">Elapsed time since the host process started (same semantics as <see cref="SimpleHealthResponseBuilder"/>).</param>
+/// <param name="TotalRequestsServed">Requests counted by host middleware since process start; not sampled Application Insights telemetry.</param>
+/// <param name="WorkingSetBytes">Current process working set from <see cref="System.Diagnostics.Process.WorkingSet64"/>.</param>
+/// <param name="TotalAllocatedBytes">Bytes allocated on the managed heap since the process started (<see cref="GC.GetTotalAllocatedBytes"/>).</param>
+/// <param name="GcGen0Collections">Gen 0 GC collection count.</param>
+/// <param name="GcGen1Collections">Gen 1 GC collection count.</param>
+/// <param name="GcGen2Collections">Gen 2 GC collection count.</param>
+public sealed record MetricsSummaryResponse(
+    TimeSpan Uptime,
+    long TotalRequestsServed,
+    long WorkingSetBytes,
+    long TotalAllocatedBytes,
+    int GcGen0Collections,
+    int GcGen1Collections,
+    int GcGen2Collections);

--- a/src/UI/Server/HttpRequestMetrics.cs
+++ b/src/UI/Server/HttpRequestMetrics.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using ClearMeasure.Bootcamp.UI.Api;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Thread-safe implementation of <see cref="IHttpRequestMetrics"/>.
+/// </summary>
+public sealed class HttpRequestMetrics : IHttpRequestMetrics
+{
+    private long _totalRequestsServed;
+
+    /// <inheritdoc />
+    public long TotalRequestsServed => Interlocked.Read(ref _totalRequestsServed);
+
+    /// <inheritdoc />
+    public void RecordRequest() => Interlocked.Increment(ref _totalRequestsServed);
+}

--- a/src/UI/Server/Middleware/HttpRequestCountingMiddleware.cs
+++ b/src/UI/Server/Middleware/HttpRequestCountingMiddleware.cs
@@ -1,0 +1,19 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Http;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Middleware;
+
+/// <summary>
+/// Increments <see cref="IHttpRequestMetrics"/> for every HTTP request that passes through the pipeline after this middleware runs.
+/// </summary>
+public sealed class HttpRequestCountingMiddleware(RequestDelegate next)
+{
+    /// <summary>
+    /// Invokes the next delegate in the pipeline after recording the request.
+    /// </summary>
+    public Task InvokeAsync(HttpContext context, IHttpRequestMetrics metrics)
+    {
+        metrics.RecordRequest();
+        return next(context);
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddApiVersioning(options =>
 builder.Services.AddRazorPages();
 builder.Host.UseLamar(registry => { registry.IncludeRegistry<UiServiceRegistry>(); });
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<IHttpRequestMetrics, HttpRequestMetrics>();
 builder.Services.AddScoped<IDistributedBus, DistributedBus>();
 builder.Services.AddMemoryCache();
 builder.Services.Configure<IdempotencyOptions>(
@@ -161,6 +162,8 @@ app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+app.UseMiddleware<HttpRequestCountingMiddleware>();
 
 app.UseWhen(
     context => ApiRateLimitingExtensions.ShouldApplyToPath(context.Request.Path),

--- a/src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs
+++ b/src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class MetricsSummaryControllerTests
+{
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class StubHttpRequestMetrics(long total) : IHttpRequestMetrics
+    {
+        public long TotalRequestsServed => total;
+
+        public void RecordRequest() => throw new InvalidOperationException("not used in unit test");
+    }
+
+    [Test]
+    public void GetSummary_Should_ReturnJson_WithExpectedFields_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+        var metrics = new StubHttpRequestMetrics(42);
+        var controller = new MetricsSummaryController(clock, metrics)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.GetSummary();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<MetricsSummaryResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Uptime.ShouldBe(SimpleHealthResponseBuilder.Build(clock).Uptime);
+        payload.TotalRequestsServed.ShouldBe(42);
+        payload.WorkingSetBytes.ShouldBeGreaterThan(0);
+        payload.TotalAllocatedBytes.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcGen0Collections.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcGen1Collections.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcGen2Collections.ShouldBeGreaterThanOrEqualTo(0);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/metrics/summary", false)]
+    [TestCase("/api/v1.0/metrics/summary", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -60,6 +60,33 @@ public class ApiKeyAuthenticationWebTests
     }
 
     [Test]
+    public async Task Should_Return401_When_ApiMetricsSummaryCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiMetricsSummaryCalledWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var unversioned = await client.GetAsync("/api/metrics/summary");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/metrics/summary");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
     public async Task Should_Return401_When_WrongKey()
     {
         await using var factory = new ApiKeyProtectedWebApplicationFactory();


### PR DESCRIPTION
## Summary

Adds `GET /api/metrics/summary` (and versioned `GET /api/v1.0/metrics/summary`) returning JSON with process uptime (same semantics as health/diagnostics), total HTTP requests counted by host middleware after routing, working set, total allocated bytes, and GC collection counts per generation. Uses the same versioning, dual-route, rate-limiting, and conditional JSON patterns as diagnostics. Registers a singleton `IHttpRequestMetrics` and `HttpRequestCountingMiddleware` immediately after `UseRouting()`.

Closes #5634

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/IHttpRequestMetrics.cs` | Abstraction for thread-safe request total |
| `src/UI/Api/MetricsSummaryModels.cs` | `MetricsSummaryResponse` record |
| `src/UI/Api/Controllers/MetricsSummaryController.cs` | API controller |
| `src/UI/Server/HttpRequestMetrics.cs` | Singleton implementation |
| `src/UI/Server/Middleware/HttpRequestCountingMiddleware.cs` | Increments counter per request |
| `src/UI/Server/Program.cs` | DI + middleware registration |
| `src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs` | Unit tests |
| `src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs` | Integration tests (routes, counter drift, API key) |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | API key coverage for metrics |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Path validation cases for metrics |

## Testing

- `dotnet build src/ChurchBulletin.sln --configuration Release`
- Focused `dotnet test` filters for metrics and API key tests
- `DATABASE_ENGINE=SQLite pwsh ./PrivateBuild.ps1` (full unit + integration suite)
