### PR TITLE
New API endpoint GET /api/version for build and deployment metadata (#6185)

### DIFF
--- a/src/UI/Api/Controllers/VersionController.cs
+++ b/src/UI/Api/Controllers/VersionController.cs
@@ -34,6 +34,7 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
         var payload = new VersionMetadataResponse(
             AssemblyVersion: assemblyVersion,
             InformationalVersion: informationalVersion,
+            BuildConfiguration: BuildConfiguration.Current,
             Environment: hostEnvironment.EnvironmentName,
             MachineName: Environment.MachineName,
             FrameworkDescription: RuntimeInformation.FrameworkDescription);
@@ -51,6 +52,16 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
 public record VersionMetadataResponse(
     string? AssemblyVersion,
     string? InformationalVersion,
+    string BuildConfiguration,
     string? Environment,
     string MachineName,
     string FrameworkDescription);
+
+internal static class BuildConfiguration
+{
+#if DEBUG
+    internal const string Current = "Debug";
+#else
+    internal const string Current = "Release";
+#endif
+}

--- a/src/UnitTests/UI.Api/VersionControllerTests.cs
+++ b/src/UnitTests/UI.Api/VersionControllerTests.cs
@@ -32,6 +32,7 @@ public class VersionControllerTests
         payload.ShouldNotBeNull();
         payload!.AssemblyVersion.ShouldNotBeNullOrEmpty();
         payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+        payload.BuildConfiguration.ShouldBeOneOf("Debug", "Release");
         payload.Environment.ShouldBe("TestEnvironment");
         payload.MachineName.ShouldBe(Environment.MachineName);
         payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`/api/version` and `/api/v1.0/version` already existed; issue #6185 called out missing **build configuration** (Debug vs Release) alongside assembly/informational version and ASP.NET Core environment name. This change adds an **additive** JSON property `buildConfiguration` populated at compile time via `#if DEBUG` / `#else`.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/VersionController.cs` | `VersionMetadataResponse` + `buildConfiguration`; internal `BuildConfiguration.Current` constant |
| `src/UnitTests/UI.Api/VersionControllerTests.cs` | Assert `buildConfiguration` is `Debug` or `Release` |

## Testing

- `dotnet test ... --filter FullyQualifiedName~VersionControllerTests` (Release config)
- `dotnet test ...` filtered web tests touching `/api/version` (etag, output cache, API versioning): all passed
- `DATABASE_ENGINE=SQLite pwsh PrivateBuild.ps1`: build + **261** unit + **108** integration tests passed

Submitter checklist
- [x] Issue is clearly tagged
- [x] Feature complete for #6185 (additive JSON field); branch ready for CI
- [x] Expect approval checklist satisfied after CI green on this branch

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

Closes #6185

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-887cb077-d1e6-4300-9bd6-65c5626ea314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-887cb077-d1e6-4300-9bd6-65c5626ea314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

