### PR TITLE
New API endpoint GET /api/features/flags for runtime feature flag status (#6189)

### DIFF
--- a/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class FeatureFlagsEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [TestCase("/api/features/flags")]
+    [TestCase("/api/v1.0/features/flags")]
+    public async Task Should_Return200AndJson_When_GetFeatureFlags(string path)
+    {
+        var response = await _client!.GetAsync(path);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("flags", out var flagsElem).ShouldBeTrue();
+        flagsElem.GetProperty(FeatureFlagsCatalog.SampleFeatureAKey).GetBoolean().ShouldBeTrue();
+        flagsElem.GetProperty(FeatureFlagsCatalog.SampleFeatureBKey).GetBoolean().ShouldBeFalse();
+    }
+
+    [TestCase("/api/features/flags")]
+    [TestCase("/api/v1.0/features/flags")]
+    public async Task Should_ExposeFlags_FromOverriddenConfiguration_When_ConfigurationChanged(string path)
+    {
+        await using var factory = new DiagnosticsWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["FeatureFlags:SampleFeatureA"] = "false",
+                    ["FeatureFlags:SampleFeatureB"] = "true"
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(path);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var flagsElem = doc.RootElement.GetProperty("flags");
+        flagsElem.GetProperty(FeatureFlagsCatalog.SampleFeatureAKey).GetBoolean().ShouldBeFalse();
+        flagsElem.GetProperty(FeatureFlagsCatalog.SampleFeatureBKey).GetBoolean().ShouldBeTrue();
+    }
+
+    [TestCase("/api/features/flags")]
+    [TestCase("/api/v1.0/features/flags")]
+    public async Task Should_MatchDiagnosticsFeatureFlagValues_When_SameConfiguration(string path)
+    {
+        var diagnostics = await _client!.GetAsync("/api/diagnostics");
+        diagnostics.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var flags = await _client.GetAsync(path);
+        flags.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var diagnosticsPayload = await diagnostics.Content.ReadFromJsonAsync<DiagnosticsResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        await using var stream = await flags.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var flagsRoot = doc.RootElement.GetProperty("flags");
+
+        diagnosticsPayload.ShouldNotBeNull();
+        flagsRoot.GetProperty(FeatureFlagsCatalog.SampleFeatureAKey).GetBoolean()
+            .ShouldBe(diagnosticsPayload!.FeatureFlags.SampleFeatureA);
+        flagsRoot.GetProperty(FeatureFlagsCatalog.SampleFeatureBKey).GetBoolean()
+            .ShouldBe(diagnosticsPayload.FeatureFlags.SampleFeatureB);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabledAndFlagsProtected()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauthUnversioned = await client.GetAsync("/api/features/flags");
+        unauthUnversioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/features/flags");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var okUnversioned = await withKey.GetAsync("/api/features/flags");
+        okUnversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/features/flags");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_NotConflictWithDiagnosticsAndLegacyDiagnostics_When_RoutesRegistered()
+    {
+        var flags = await _client!.GetAsync("/api/features/flags");
+        flags.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var diagnostics = await _client.GetAsync("/api/diagnostics");
+        diagnostics.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var legacyResponse = await _client.PostAsync("/_diagnostics/reset-db-connections", null);
+        legacyResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/UI/Api/Controllers/FeatureFlagsController.cs
+++ b/src/UI/Api/Controllers/FeatureFlagsController.cs
@@ -1,0 +1,29 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Returns a snapshot of application feature flags and their configured enabled/disabled state.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/features/flags")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/features/flags")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class FeatureFlagsController(IOptions<DiagnosticsFeatureFlagsOptions> featureFlagsOptions)
+    : ControllerBase
+{
+    /// <summary>
+    /// Lists all cataloged feature flags and their current boolean values from configuration.
+    /// </summary>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var snapshot = FeatureFlagsCatalog.BuildSnapshot(featureFlagsOptions.Value);
+        var payload = new FeatureFlagsResponse(snapshot);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/FeatureFlagsCatalog.cs
+++ b/src/UI/Api/FeatureFlagsCatalog.cs
@@ -1,0 +1,31 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Static catalog of feature flag identifiers exposed via <c>GET /api/features/flags</c>;
+/// values are read from bound <see cref="DiagnosticsFeatureFlagsOptions"/>.
+/// </summary>
+internal static class FeatureFlagsCatalog
+{
+    /// <summary>JSON key aligned with camelCase serialization of <see cref="DiagnosticsFeatureFlagsOptions.SampleFeatureA"/>.</summary>
+    internal const string SampleFeatureAKey = "sampleFeatureA";
+
+    /// <summary>JSON key aligned with camelCase serialization of <see cref="DiagnosticsFeatureFlagsOptions.SampleFeatureB"/>.</summary>
+    internal const string SampleFeatureBKey = "sampleFeatureB";
+
+    /// <summary>All exposed flag keys in stable sort order (matches snapshot iteration order).</summary>
+    internal static readonly IReadOnlyList<string> AllKeys = new[]
+    {
+        SampleFeatureAKey,
+        SampleFeatureBKey
+    };
+
+    /// <summary>
+    /// Builds a sorted map of catalog keys to current configuration values for JSON responses.
+    /// </summary>
+    internal static SortedDictionary<string, bool> BuildSnapshot(DiagnosticsFeatureFlagsOptions options) =>
+        new(StringComparer.Ordinal)
+        {
+            [SampleFeatureAKey] = options.SampleFeatureA,
+            [SampleFeatureBKey] = options.SampleFeatureB
+        };
+}

--- a/src/UI/Api/FeatureFlagsResponse.cs
+++ b/src/UI/Api/FeatureFlagsResponse.cs
@@ -1,0 +1,7 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/features/flags</c>. Flag keys match the static catalog (<c>camelCase</c> names).
+/// </summary>
+/// <param name="Flags">Map of flag identifiers to enabled state.</param>
+public sealed record FeatureFlagsResponse(IReadOnlyDictionary<string, bool> Flags);

--- a/src/UnitTests/UI.Api/FeatureFlagsCatalogTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagsCatalogTests.cs
@@ -1,0 +1,30 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagsCatalogTests
+{
+    [Test]
+    public void BuildSnapshot_Should_ContainExactlyCatalogKeysWithCorrectValues_When_OptionsGiven()
+    {
+        var options = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = false, SampleFeatureB = true };
+
+        var snapshot = FeatureFlagsCatalog.BuildSnapshot(options);
+
+        snapshot.Count.ShouldBe(FeatureFlagsCatalog.AllKeys.Count);
+        snapshot.Keys.ShouldBe(FeatureFlagsCatalog.AllKeys);
+        snapshot[FeatureFlagsCatalog.SampleFeatureAKey].ShouldBeFalse();
+        snapshot[FeatureFlagsCatalog.SampleFeatureBKey].ShouldBeTrue();
+    }
+
+    [Test]
+    public void BuildSnapshot_Should_EnumerateKeysInStableCatalogOrder_When_Iterating()
+    {
+        var snapshot = FeatureFlagsCatalog.BuildSnapshot(
+            new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false });
+
+        snapshot.Keys.SequenceEqual(FeatureFlagsCatalog.AllKeys).ShouldBeTrue();
+    }
+}

--- a/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagsControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJson_WithFlagMap_When_Called()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+        var controller = new FeatureFlagsController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.TryGetProperty("flags", out var flagsElem).ShouldBeTrue();
+        flagsElem.GetProperty(FeatureFlagsCatalog.SampleFeatureAKey).GetBoolean().ShouldBeTrue();
+        flagsElem.GetProperty(FeatureFlagsCatalog.SampleFeatureBKey).GetBoolean().ShouldBeFalse();
+        var dto = JsonSerializer.Deserialize<FeatureFlagsResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        dto.ShouldNotBeNull();
+        dto!.Flags[FeatureFlagsCatalog.SampleFeatureAKey].ShouldBeTrue();
+        dto.Flags[FeatureFlagsCatalog.SampleFeatureBKey].ShouldBeFalse();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/features/flags", false)]
+    [TestCase("/api/v1.0/features/flags", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`GET /api/features/flags`** (and **`GET /api/v1.0/features/flags`**), returning JSON describing each cataloged feature flag name and its current boolean value from **`FeatureFlags`** configuration (`DiagnosticsFeatureFlagsOptions`). Responses use **`ConditionalGetEtag.JsonContent`** like diagnostics. Optional API-key middleware treats this path the **same as** `/api/diagnostics` (validated when middleware is enabled with a validation key).

## Files changed

| File | Purpose |
|------|---------|
| `src/UI/Api/FeatureFlagsCatalog.cs` | Static catalog keys + **`BuildSnapshot`** mapping to **`DiagnosticsFeatureFlagsOptions`** |
| `src/UI/Api/FeatureFlagsResponse.cs` | **`FeatureFlagsResponse`** DTO (**`flags`** object) |
| `src/UI/Api/Controllers/FeatureFlagsController.cs` | MVC controller + dual routes + rate limiting |
| `src/UnitTests/UI.Api/FeatureFlagsCatalogTests.cs` | Unit tests for snapshot keys/order |
| `src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs` | Controller JSON assertion |
| `src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs` | In-process GET tests, parity with diagnostics, API key wiring |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | **`ShouldValidate`** cases for flags paths |

## Testing

- `dotnet test src/UnitTests --configuration Release` (SQLite / default harness)
- `dotnet test src/IntegrationTests --configuration Release` with `DATABASE_ENGINE=SQLite`

Closes #6189
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9da20276-2b88-4fe4-9550-3e3f190c119b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9da20276-2b88-4fe4-9550-3e3f190c119b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

