### PR TITLE
New API endpoint GET /api/health/detailed for component-level health (#6182)

### DIFF
--- a/src/UI/Api/Controllers/DetailedHealthController.cs
+++ b/src/UI/Api/Controllers/DetailedHealthController.cs
@@ -25,7 +25,11 @@ public class DetailedHealthController(
     public async Task<IActionResult> GetDetailed(CancellationToken cancellationToken)
     {
         var payload = await detailedHealthReportProvider.GetReportAsync(cancellationToken);
-        return ConditionalJson(payload);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(DetailedHealthEtagFingerprint.FromReport(payload));
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
     }
 
     private IActionResult ConditionalJson<T>(T payload)

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -74,3 +74,55 @@ public static class ComponentHealthStatus
     public const string Degraded = nameof(Degraded);
     public const string Unhealthy = nameof(Unhealthy);
 }
+
+/// <summary>
+/// Per-component fingerprint for conditional GET (<see cref="ComponentHealthEntry.ExceptionDetail"/> excluded).
+/// </summary>
+internal sealed record DetailedHealthComponentEtagFingerprint(
+    string Name,
+    string Status,
+    string? Description,
+    string? ExceptionMessage,
+    IReadOnlyList<KeyValuePair<string, string>>? Data);
+
+/// <summary>
+/// Fingerprint payload for conditional GET over <see cref="DetailedHealthReport"/>.
+/// </summary>
+/// <remarks>
+/// Omits <see cref="DetailedHealthReport.CheckedAtUtc"/> and per-component durations. Exception stack traces
+/// (<see cref="ComponentHealthEntry.ExceptionDetail"/>) are omitted so probes can reuse ETags across polls.
+/// </remarks>
+internal sealed record DetailedHealthEtagFingerprint(
+    string OverallStatus,
+    IReadOnlyList<DetailedHealthComponentEtagFingerprint> Components)
+{
+    /// <summary>
+    /// Builds a fingerprint from <paramref name="report"/> omitting volatile fields so repeated polls can yield 304.
+    /// </summary>
+    internal static DetailedHealthEtagFingerprint FromReport(DetailedHealthReport report)
+    {
+        var components = report.Components
+            .OrderBy(c => c.Name, StringComparer.Ordinal)
+            .Select(c => new DetailedHealthComponentEtagFingerprint(
+                c.Name,
+                c.Status,
+                c.Description,
+                c.ExceptionMessage,
+                StableDataEntries(c.Data)))
+            .ToList();
+
+        return new DetailedHealthEtagFingerprint(report.OverallStatus, components);
+    }
+
+    private static IReadOnlyList<KeyValuePair<string, string>>? StableDataEntries(
+        IReadOnlyDictionary<string, object>? data)
+    {
+        if (data is null || data.Count == 0)
+            return null;
+
+        return data
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => KeyValuePair.Create(kv.Key, kv.Value?.ToString() ?? ""))
+            .ToList();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -8,6 +8,8 @@ public class ApiKeyAuthenticationMiddlewareTests
 {
     [TestCase("/api/health", false)]
     [TestCase("/api/v1.0/health", false)]
+    [TestCase("/api/health/detailed", false)]
+    [TestCase("/api/v1.0/health/detailed", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
     [TestCase("/api/version", true)]

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -40,6 +40,33 @@ public class ApiVersioningEndpointTests
     }
 
     [Test]
+    public async Task Should_Return200AndSamePayload_When_GetDetailedHealth_LegacyAndV1Paths()
+    {
+        var legacy = await _client!.GetAsync("/api/health/detailed");
+        var v1 = await _client.GetAsync("/api/v1.0/health/detailed");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var legacyPayload = JsonSerializer.Deserialize<JsonElement>(await legacy.Content.ReadAsStringAsync());
+        var v1Payload = JsonSerializer.Deserialize<JsonElement>(await v1.Content.ReadAsStringAsync());
+
+        legacyPayload.GetProperty("overallStatus").GetString().ShouldBe(
+            v1Payload.GetProperty("overallStatus").GetString());
+
+        var legacyComponents = legacyPayload.GetProperty("components").EnumerateArray()
+            .Select(e => (e.GetProperty("name").GetString(), e.GetProperty("status").GetString()))
+            .OrderBy(x => x.Item1)
+            .ToList();
+        var v1Components = v1Payload.GetProperty("components").EnumerateArray()
+            .Select(e => (e.GetProperty("name").GetString(), e.GetProperty("status").GetString()))
+            .OrderBy(x => x.Item1)
+            .ToList();
+
+        legacyComponents.ShouldBeEquivalentTo(v1Components);
+    }
+
+    [Test]
     public async Task Should_ReturnNotSuccess_When_GetSimpleHealth_UnsupportedVersion()
     {
         var response = await _client!.GetAsync("/api/v2.0/health");

--- a/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
+++ b/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
@@ -33,11 +33,37 @@ public class EtagConditionalGetWebTests
         (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
     }
 
+    [TestCase("/api/health/detailed")]
+    [TestCase("/api/v1.0/health/detailed")]
+    public async Task Should_Return304NotModified_When_IfNoneMatchMatchesEtag_DetailedHealth(string path)
+    {
+        using var client = _factory!.CreateClient();
+        var first = await client.GetAsync(path);
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        first.Headers.ETag.ShouldNotBeNull();
+
+        using var second = new HttpRequestMessage(HttpMethod.Get, path);
+        second.Headers.IfNoneMatch.Add(first.Headers.ETag!);
+        var notModified = await client.SendAsync(second);
+        notModified.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
+    }
+
     [Test]
     public async Task Should_IncludeEtagHeader_When_GetSimpleHealth()
     {
         using var client = _factory!.CreateClient();
         var response = await client.GetAsync("/api/health");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+    }
+
+    [TestCase("/api/health/detailed")]
+    [TestCase("/api/v1.0/health/detailed")]
+    public async Task Should_IncludeEtagHeader_When_GetDetailedHealth(string path)
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.GetAsync(path);
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Headers.ETag.ShouldNotBeNull();
     }

--- a/src/UnitTests/UI/Api/DetailedHealthEtagFingerprintTests.cs
+++ b/src/UnitTests/UI/Api/DetailedHealthEtagFingerprintTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class DetailedHealthEtagFingerprintTests
+{
+    private static DetailedHealthReport BuildReport(DateTime checkedAtUtc, double durationA, double durationB)
+    {
+        return new DetailedHealthReport
+        {
+            OverallStatus = ComponentHealthStatus.Degraded,
+            CheckedAtUtc = checkedAtUtc,
+            Components =
+            [
+                new ComponentHealthEntry
+                {
+                    Name = "Alpha",
+                    Status = ComponentHealthStatus.Healthy,
+                    DurationMs = durationA,
+                    ExceptionDetail = "stacktrace-alpha"
+                },
+                new ComponentHealthEntry
+                {
+                    Name = "Beta",
+                    Status = ComponentHealthStatus.Degraded,
+                    DurationMs = durationB,
+                    ExceptionDetail = "stacktrace-beta"
+                }
+            ]
+        };
+    }
+
+    [Test]
+    public void FromReport_Should_ProduceEquivalentJson_When_OnlyVolatileFieldsDiffer()
+    {
+        var a = DetailedHealthEtagFingerprint.FromReport(
+            BuildReport(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), 1.5, 2.0));
+        var b = DetailedHealthEtagFingerprint.FromReport(
+            BuildReport(new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Utc), 99.0, 0.1));
+
+        JsonSerializer.Serialize(a, ConditionalGetEtag.JsonSerializerOptions)
+            .ShouldBe(JsonSerializer.Serialize(b, ConditionalGetEtag.JsonSerializerOptions));
+    }
+
+    [Test]
+    public void FromReport_Should_ProduceDifferentJson_When_ComponentStatusChanges()
+    {
+        static DetailedHealthReport oneStatus(string componentStatus)
+        {
+            return new DetailedHealthReport
+            {
+                OverallStatus = componentStatus,
+                CheckedAtUtc = DateTime.UtcNow,
+                Components =
+                [
+                    new ComponentHealthEntry { Name = "X", Status = componentStatus }
+                ]
+            };
+        }
+
+        var degraded = DetailedHealthEtagFingerprint.FromReport(oneStatus(ComponentHealthStatus.Degraded));
+        var healthy = DetailedHealthEtagFingerprint.FromReport(oneStatus(ComponentHealthStatus.Healthy));
+
+        JsonSerializer.Serialize(degraded, ConditionalGetEtag.JsonSerializerOptions)
+            .ShouldNotBe(JsonSerializer.Serialize(healthy, ConditionalGetEtag.JsonSerializerOptions));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The detailed health endpoint and supporting types were largely present on master; this branch completes the behavioral contract implied by issue #6182 for **conditional GET**: weak ETags for `GET /api/health/detailed` (and the versioned route) now hash a **stable fingerprint** of aggregate and per-component outcomes so monitors can poll with `If-None-Match` and receive **`304 Not Modified`** when timestamps, durations, or exception stack traces change without a meaningful health transition.

Adds regression tests for:

- **`304`** and **`ETag`** on `/api/health/detailed` and `/api/v1.0/health/detailed`
- **Payload parity** (component names/statuses vs overall status) between legacy and v1 routes
- **Api key middleware** expectation that `/detailed` is treated like other `/api/*` health paths under key enforcement
- **Fingerprint serialization** equivalence when only volatile detailed fields change

Closes #6182

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/DetailedHealthModels.cs` | `DetailedHealthEtagFingerprint` (+ component fingerprint types) excluding `checkedAtUtc`, `durationMs`, and `exceptionDetail` from ETag input |
| `src/UI/Api/Controllers/DetailedHealthController.cs` | `GetDetailed`: compute weak ETag from fingerprint; unchanged JSON response body shape |
| `src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs` | 304 / ETag tests for legacy + versioned detailed paths |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | Assert same aggregated component statuses on legacy vs v1 detailed |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Case rows for `/api/health/detailed` routes |
| `src/UnitTests/UI/Api/DetailedHealthEtagFingerprintTests.cs` | Unit tests for stable vs changing fingerprint semantics |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — unit + integration suites green.

## Branch

`cursor/detailed-health-api-endpoint-6193`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5062fbe8-416c-40fd-8b38-f4001fe1df2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5062fbe8-416c-40fd-8b38-f4001fe1df2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

