### PR TITLE
New API endpoint GET /api/metrics/summary for application runtime metrics (#6183)

### DIFF
--- a/src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class MetricsSummaryEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_WithExpectedProperties_When_GetMetricsSummaryUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("totalRequests", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("managedMemoryBytes", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("gcGen0Collections", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("gcGen1Collections", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("gcGen2Collections", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_WithExpectedProperties_When_GetMetricsSummaryVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("totalRequests", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("managedMemoryBytes", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_IncreaseTotalRequestsAcrossSequentialCalls_When_MetricsEndpointHitMultipleTimes()
+    {
+        var first = await _client!.GetAsync("/api/metrics/summary");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var firstPayload = await first.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        firstPayload.ShouldNotBeNull();
+
+        var second = await _client.GetAsync("/api/metrics/summary");
+        second.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var secondPayload = await second.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        secondPayload.ShouldNotBeNull();
+
+        secondPayload!.TotalRequests.ShouldBeGreaterThan(firstPayload!.TotalRequests);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabledAndRouteNotPublic()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/metrics/summary");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/metrics/summary");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.GetAsync("/api/metrics/summary");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/metrics/summary");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_StayConsistentWithDiagnostics_When_ComparingUptimeBounds()
+    {
+        var diagnostics = await _client!.GetAsync("/api/diagnostics");
+        diagnostics.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var metrics = await _client.GetAsync("/api/metrics/summary");
+        metrics.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var diagnosticsUptime =
+            JsonSerializer.Deserialize<DiagnosticsResponse>(
+                await diagnostics.Content.ReadAsStringAsync(),
+                ConditionalGetEtag.JsonSerializerOptions)!.Uptime;
+        var metricsUptime =
+            JsonSerializer.Deserialize<MetricsSummaryResponse>(
+                await metrics.Content.ReadAsStringAsync(),
+                ConditionalGetEtag.JsonSerializerOptions)!.Uptime;
+
+        var skew = diagnosticsUptime - metricsUptime;
+        Math.Abs(skew.TotalMilliseconds).ShouldBeLessThan(2000);
+    }
+}

--- a/src/UI/Api/Controllers/MetricsSummaryController.cs
+++ b/src/UI/Api/Controllers/MetricsSummaryController.cs
@@ -1,0 +1,36 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Operational runtime snapshot (uptime, request totals, GC, managed memory).
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/metrics")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/metrics")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class MetricsSummaryController(
+    TimeProvider timeProvider,
+    IRequestCounters requestCounters,
+    IProcessRuntimeMetrics runtimeMetrics) : ControllerBase
+{
+    /// <summary>
+    /// Returns process uptime (<see cref="SimpleHealthResponseBuilder"/>), middleware request total, managed memory, and GC collection counts at response time.
+    /// </summary>
+    [HttpGet("summary")]
+    public IActionResult Get()
+    {
+        var uptime = SimpleHealthResponseBuilder.Build(timeProvider).Uptime;
+        var payload = new MetricsSummaryResponse(
+            uptime,
+            requestCounters.TotalRequests,
+            runtimeMetrics.ManagedMemoryBytes,
+            runtimeMetrics.GcGen0Collections,
+            runtimeMetrics.GcGen1Collections,
+            runtimeMetrics.GcGen2Collections);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/IProcessRuntimeMetrics.cs
+++ b/src/UI/Api/IProcessRuntimeMetrics.cs
@@ -1,0 +1,25 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Point-in-time managed memory and GC collection counts from the current process BCL APIs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations intentionally read GC state at invocation time (<see cref="GC.GetTotalMemory"/>
+/// without a full blocking collection).
+/// </para>
+/// </remarks>
+public interface IProcessRuntimeMetrics
+{
+    /// <summary>Managed heap size in bytes (same semantics as <see cref="GC.GetTotalMemory(bool)"/> with <c>false</c>).</summary>
+    long ManagedMemoryBytes { get; }
+
+    /// <summary><see cref="GC.CollectionCount(int)"/> for generation 0.</summary>
+    int GcGen0Collections { get; }
+
+    /// <summary><see cref="GC.CollectionCount(int)"/> for generation 1.</summary>
+    int GcGen1Collections { get; }
+
+    /// <summary><see cref="GC.CollectionCount(int)"/> for generation 2.</summary>
+    int GcGen2Collections { get; }
+}

--- a/src/UI/Api/IRequestCounters.cs
+++ b/src/UI/Api/IRequestCounters.cs
@@ -1,0 +1,13 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Monotonic HTTP request totals for operational metrics (counts requests passing through UI.Server middleware).
+/// </summary>
+public interface IRequestCounters
+{
+    /// <summary>Total HTTP requests counted since process start.</summary>
+    long TotalRequests { get; }
+
+    /// <summary>Increases the counted request total by one (thread-safe).</summary>
+    void IncrementRequest();
+}

--- a/src/UI/Api/MetricsSummaryResponse.cs
+++ b/src/UI/Api/MetricsSummaryResponse.cs
@@ -1,0 +1,23 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Stable operational JSON payload for <c>GET /api/metrics/summary</c>. Property names are a public monitoring contract only for this host process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Counts reflect the web host only (typically UI.Server); request totals include every HTTP hit recorded by middleware (static assets, APIs, SignalR negotiation, etc.), not aggregates across Worker or MCP processes.
+/// </para>
+/// </remarks>
+/// <param name="Uptime">Elapsed time since the host process started (same source as diagnostics/health).</param>
+/// <param name="TotalRequests">Monotonic count of HTTP requests through the server's counting middleware.</param>
+/// <param name="ManagedMemoryBytes">Managed heap approximation in bytes (<see cref="GC.GetTotalMemory(bool)"/> with <c>false</c>).</param>
+/// <param name="GcGen0Collections"><see cref="GC.CollectionCount(int)"/> generation 0 at response time.</param>
+/// <param name="GcGen1Collections"><see cref="GC.CollectionCount(int)"/> generation 1 at response time.</param>
+/// <param name="GcGen2Collections"><see cref="GC.CollectionCount(int)"/> generation 2 at response time.</param>
+public sealed record MetricsSummaryResponse(
+    TimeSpan Uptime,
+    long TotalRequests,
+    long ManagedMemoryBytes,
+    int GcGen0Collections,
+    int GcGen1Collections,
+    int GcGen2Collections);

--- a/src/UI/Api/ProcessRuntimeMetrics.cs
+++ b/src/UI/Api/ProcessRuntimeMetrics.cs
@@ -1,0 +1,19 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Reads live values from <see cref="GC"/> for <see cref="IProcessRuntimeMetrics"/>.
+/// </summary>
+public sealed class ProcessRuntimeMetrics : IProcessRuntimeMetrics
+{
+    /// <inheritdoc />
+    public long ManagedMemoryBytes => GC.GetTotalMemory(false);
+
+    /// <inheritdoc />
+    public int GcGen0Collections => GC.CollectionCount(0);
+
+    /// <inheritdoc />
+    public int GcGen1Collections => GC.CollectionCount(1);
+
+    /// <inheritdoc />
+    public int GcGen2Collections => GC.CollectionCount(2);
+}

--- a/src/UI/Api/RequestCounters.cs
+++ b/src/UI/Api/RequestCounters.cs
@@ -1,0 +1,15 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Singleton <see cref="IRequestCounters"/> using <see cref="Interlocked"/> increments.
+/// </summary>
+public sealed class RequestCounters : IRequestCounters
+{
+    private long _totalRequests;
+
+    /// <inheritdoc />
+    public long TotalRequests => Volatile.Read(ref _totalRequests);
+
+    /// <inheritdoc />
+    public void IncrementRequest() => Interlocked.Increment(ref _totalRequests);
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -162,6 +162,8 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseMiddleware<RequestCountingMiddleware>();
+
 app.UseWhen(
     context => ApiRateLimitingExtensions.ShouldApplyToPath(context.Request.Path),
     branch => branch.UseRequestTimeouts());

--- a/src/UI/Server/RequestCountingMiddleware.cs
+++ b/src/UI/Server/RequestCountingMiddleware.cs
@@ -1,0 +1,17 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Counts incoming HTTP requests for <see cref="MetricsSummaryController"/> (whole pipeline: static assets, APIs, etc.).
+/// </summary>
+internal sealed class RequestCountingMiddleware(RequestDelegate next)
+{
+    public Task InvokeAsync(HttpContext httpContext)
+    {
+        var counters = httpContext.RequestServices.GetRequiredService<IRequestCounters>();
+        counters.IncrementRequest();
+        return next(httpContext);
+    }
+}

--- a/src/UI/Server/UIServiceRegistry.cs
+++ b/src/UI/Server/UIServiceRegistry.cs
@@ -73,5 +73,8 @@ public class UiServiceRegistry : ServiceRegistry
             .AddCheck<NeedsRebootHealthCheck>("NeedsReboot");
 
         this.AddSingleton<IDetailedHealthReportProvider, DetailedHealthReportProvider>();
+
+        this.AddSingleton<IRequestCounters, RequestCounters>();
+        this.AddSingleton<IProcessRuntimeMetrics, ProcessRuntimeMetrics>();
     }
 }

--- a/src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs
+++ b/src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class MetricsSummaryControllerTests
+{
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class StubRequestCounters(long total) : IRequestCounters
+    {
+        public long TotalRequests { get; } = total;
+        public void IncrementRequest() { }
+    }
+
+    private sealed class StubRuntimeMetrics : IProcessRuntimeMetrics
+    {
+        public long ManagedMemoryBytes { get; init; } = 42;
+        public int GcGen0Collections { get; init; } = 1;
+        public int GcGen1Collections { get; init; } = 2;
+        public int GcGen2Collections { get; init; } = 3;
+    }
+
+    [Test]
+    public void Get_Should_ReturnJson_WithUptimeTotalAndRuntimeFields_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+        var stubCounters = new StubRequestCounters(100);
+        var stubRuntime = new StubRuntimeMetrics();
+        var controller = new MetricsSummaryController(clock, stubCounters, stubRuntime)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<MetricsSummaryResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Uptime.ShouldBe(SimpleHealthResponseBuilder.Build(clock).Uptime);
+        payload.TotalRequests.ShouldBe(100);
+        payload.ManagedMemoryBytes.ShouldBe(42);
+        payload.GcGen0Collections.ShouldBe(1);
+        payload.GcGen1Collections.ShouldBe(2);
+        payload.GcGen2Collections.ShouldBe(3);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/metrics/summary", false)]
+    [TestCase("/api/v1.0/metrics/summary", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]

--- a/src/UnitTests/UI.Server/RequestCountingMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/RequestCountingMiddlewareTests.cs
@@ -1,0 +1,35 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class RequestCountingMiddlewareTests
+{
+    private sealed class StubCounters : IRequestCounters
+    {
+        public int InvocationCount { get; private set; }
+        public long TotalRequests => InvocationCount;
+        public void IncrementRequest() => InvocationCount++;
+    }
+
+    [Test]
+    public async Task InvokeAsync_Should_IncrementCountersOncePerRequest_When_RequestCompletesPipeline()
+    {
+        var stubs = new StubCounters();
+        var services = new ServiceCollection();
+        services.AddSingleton<IRequestCounters>(stubs);
+        var provider = services.BuildServiceProvider();
+        RequestDelegate downstream = ctx => Task.CompletedTask;
+        var sut = new RequestCountingMiddleware(downstream);
+        var ctx = new DefaultHttpContext();
+        ctx.RequestServices = provider;
+
+        await sut.InvokeAsync(ctx);
+
+        stubs.InvocationCount.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **`GET /api/metrics/summary`** and **`GET /api/v1.0/metrics/summary`** on UI.Server via `MetricsSummaryController`, returning JSON aligned with diagnostics (uptime via `SimpleHealthResponseBuilder`), a monotonic **`totalRequests`** counter (middleware on the ASP.NET pipeline), **`managedMemoryBytes`** (`GC.GetTotalMemory(false)`), and **GC generation collection counts**.

## Files changed

| Area | Files |
|------|--------|
| DTO / services | `src/UI/Api/MetricsSummaryResponse.cs`, `IRequestCounters.cs`, `RequestCounters.cs`, `IProcessRuntimeMetrics.cs`, `ProcessRuntimeMetrics.cs` |
| API | `src/UI/Api/Controllers/MetricsSummaryController.cs` |
| Server | `src/UI/Server/RequestCountingMiddleware.cs`, `Program.cs` (middleware after `UseRouting`), `UIServiceRegistry.cs` (singleton registration) |
| Tests | `src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs`, `src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs`, `src/UnitTests/UI.Server/RequestCountingMiddlewareTests.cs`, `ApiKeyAuthenticationMiddlewareTests.cs` (new path cases) |

## Behaviour notes

- **Request counting**: Every HTTP request that reaches `RequestCountingMiddleware` increments the counter (static files, `/api/*`, Blazor negotiation, etc.) — **not** API-only counts; metrics reflect **UI.Server process only**.
- **Rate limiting**: `[EnableRateLimiting(ApiRateLimiting.PolicyName)]` matches diagnostics.
- **API key**: Same protection as `/api/diagnostics` when `ApiKeyAuthentication` is enabled (not in the version/time/ping bypass list).

## Testing

- `DATABASE_ENGINE=SQLite` **PrivateBuild.ps1**: passed (265 unit tests, 113 integration tests).
- Filtered integration: `MetricsSummary*` — 5 tests passed.

Closes #6183
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1140bdbf-1557-4e99-83fd-52de23db0656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1140bdbf-1557-4e99-83fd-52de23db0656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

