### PR TITLE
New API endpoint GET /api/echo with request reflection for debugging (#6184)

### DIFF
--- a/src/UI/Api/Controllers/EchoController.cs
+++ b/src/UI/Api/Controllers/EchoController.cs
@@ -1,0 +1,76 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Returns a JSON snapshot of the inbound GET request for debugging and client diagnostics.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/echo")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/echo")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class EchoController : ControllerBase
+{
+    private static readonly HashSet<string> AllowedHeaderNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Accept",
+            "Accept-Encoding",
+            "Accept-Language",
+            "User-Agent",
+            "Host",
+            "Referer",
+            "X-Correlation-ID",
+            "X-Request-ID",
+            "traceparent"
+        };
+
+    /// <summary>
+    /// Returns JSON reflecting method, URL parts, remote IP, protocol, parsed query (last value wins per key),
+    /// and allowlisted headers only.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var query = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in Request.Query)
+        {
+            var values = pair.Value;
+            query[pair.Key] = values.Count > 0 ? values[^1]! : string.Empty;
+        }
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in Request.Headers)
+        {
+            if (!AllowedHeaderNames.Contains(pair.Key))
+            {
+                continue;
+            }
+
+            headers[pair.Key] = pair.Value.Count > 0 ? pair.Value.ToString() : string.Empty;
+        }
+
+        var remote = HttpContext.Connection.RemoteIpAddress;
+        var remoteText = remote?.ToString();
+
+        var payload = new EchoResponse(
+            Method: Request.Method,
+            Scheme: Request.Scheme,
+            Host: Request.Host.HasValue ? Request.Host.Value : string.Empty,
+            Path: Request.Path.Value ?? string.Empty,
+            PathBase: Request.PathBase.Value ?? string.Empty,
+            QueryString: Request.QueryString.HasValue ? Request.QueryString.Value! : string.Empty,
+            Query: query,
+            RemoteIpAddress: remoteText,
+            Protocol: Request.Protocol,
+            Headers: headers);
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/EchoModels.cs
+++ b/src/UI/Api/EchoModels.cs
@@ -1,0 +1,33 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/echo</c> and <c>GET /api/v1.0/echo</c>.
+/// Debug-only: reflects non-sensitive request metadata. Headers use an allowlist only;
+/// credential-bearing headers (<c>Authorization</c>, <c>Cookie</c>, <c>X-Api-Key</c>, etc.) are never included.
+/// Query strings may contain secrets—operators must avoid putting sensitive tokens in query parameters.
+/// </summary>
+/// <param name="Method">HTTP method (for GET echo, typically GET).</param>
+/// <param name="Scheme">Request scheme (http or https).</param>
+/// <param name="Host"><see cref="Microsoft.AspNetCore.Http.HostString"/> value (<c>Host</c> header / connection).</param>
+/// <param name="Path">Path portion from <see cref="Microsoft.AspNetCore.Http.HttpRequest.Path"/>.</param>
+/// <param name="PathBase">Application path base from <see cref="Microsoft.AspNetCore.Http.HttpRequest.PathBase"/>.</param>
+/// <param name="QueryString">Raw query string including leading <c>?</c> when present.</param>
+/// <param name="Query">Parsed query keys; duplicate keys keep the last value.</param>
+/// <param name="RemoteIpAddress">Client remote IP from <see cref="Microsoft.AspNetCore.Http.ConnectionInfo.RemoteIpAddress"/>, if present.</param>
+/// <param name="Protocol">HTTP protocol (for example HTTP/1.1).</param>
+/// <param name="Headers">
+/// Allowlisted header names only:
+/// <c>Accept</c>, <c>Accept-Encoding</c>, <c>Accept-Language</c>, <c>User-Agent</c>, <c>Host</c>, <c>Referer</c>,
+/// <c>X-Correlation-ID</c>, <c>X-Request-ID</c>, <c>traceparent</c>.
+/// </param>
+public sealed record EchoResponse(
+    string Method,
+    string Scheme,
+    string Host,
+    string Path,
+    string PathBase,
+    string QueryString,
+    IReadOnlyDictionary<string, string> Query,
+    string? RemoteIpAddress,
+    string Protocol,
+    IReadOnlyDictionary<string, string> Headers);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and echo endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/Api/EchoWebTests.cs
+++ b/src/UnitTests/Api/EchoWebTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Text.Json;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.Api;
+
+[TestFixture]
+public class EchoWebTests
+{
+    [Test]
+    public async Task Should_ReturnJsonEcho_When_UnversionedPathWithQuery()
+    {
+        await using var factory = new CorsEnabledApiWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/echo?a=1&b=two&a=last");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.ShouldBe("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var root = doc.RootElement;
+
+        root.GetProperty("path").GetString().ShouldBe("/api/echo");
+        root.GetProperty("queryString").GetString().ShouldBe("?a=1&b=two&a=last");
+        root.GetProperty("query").GetProperty("a").GetString().ShouldBe("last");
+        root.GetProperty("query").GetProperty("b").GetString().ShouldBe("two");
+        root.GetProperty("method").GetString().ShouldBe("GET");
+    }
+
+    [Test]
+    public async Task Should_ReturnJsonEcho_When_VersionedPath()
+    {
+        await using var factory = new CorsEnabledApiWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/v1.0/echo?q=test");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.ShouldBe("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var root = doc.RootElement;
+
+        root.GetProperty("path").GetString().ShouldBe("/api/v1.0/echo");
+        root.GetProperty("query").GetProperty("q").GetString().ShouldBe("test");
+    }
+
+    [Test]
+    public async Task Should_NotIncludeSensitiveHeaders_InEchoJson()
+    {
+        await using var factory = new CorsEnabledApiWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret");
+        request.Headers.TryAddWithoutValidation("X-Api-Key", "super-secret");
+
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var headers = doc.RootElement.GetProperty("headers");
+
+        headers.TryGetProperty("Authorization", out _).ShouldBeFalse();
+        headers.TryGetProperty("X-Api-Key", out _).ShouldBeFalse();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/echo", true)]
+    [TestCase("/api/v1.0/echo", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds anonymous `GET /api/echo` and `GET /api/v1.0/echo` that return JSON reflecting non-sensitive request metadata (method, scheme, host, path, pathBase, raw query string, parsed query with last-wins duplicates, remote IP, HTTP protocol, and **allowlisted** headers only). Matches `PingController` routing, versioning, rate limiting, and JSON serialization via `ConditionalGetEtag.JsonContent`.

Extends API key middleware so `echo` is public when enforcement is on (same as `ping`, `time`, `version`).

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/EchoModels.cs` | New `EchoResponse` record + XML docs (allowlist documented). |
| `src/UI/Api/Controllers/EchoController.cs` | New controller with `[EnableRateLimiting]`, `[AllowAnonymous]`, reflection logic. |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Public path for `echo` (unversioned + versioned); XML summary updated. |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Test cases for `/api/echo`, `/api/v1.0/echo`. |
| `src/UnitTests/Api/EchoWebTests.cs` | Factory HTTP tests: JSON shape, duplicate query keys, sensitive headers omitted. |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — unit tests 266 passed, integration tests 108 passed.
- Filtered earlier: `EchoWebTests` + `ApiKeyAuthenticationMiddlewareTests` against Release build.

Closes #6184

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59af83c1-1f25-4b7b-8c8b-e8cdfb8e4e39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59af83c1-1f25-4b7b-8c8b-e8cdfb8e4e39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

