### PR TITLE
New API endpoint GET /api/status/environment for runtime environment diagnostics (#6191)

### DIFF
--- a/src/IntegrationTests/Api/EnvironmentStatusEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/EnvironmentStatusEndpointIntegrationTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class EnvironmentStatusEndpointIntegrationTests
+{
+    private const string DistinctiveSecretEnvName = "BOOTCAMP_ENV_STATUS_INTEG_SECRET_6191";
+    private const string DistinctiveSecretValue = "integration-distinctive-6191";
+
+    private EnvironmentStatusWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new EnvironmentStatusWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+        Environment.SetEnvironmentVariable(DistinctiveSecretEnvName, null);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetEnvironmentStatusUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/status/environment");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("osDescription", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("processorCount", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("clrVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("frameworkDescription", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("environmentVariables", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetEnvironmentStatusVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/status/environment");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+    }
+
+    [Test]
+    public async Task Should_ParsePayload_WithProcessorCountNonNegative_When_ResponseDeserialized()
+    {
+        var response = await _client!.GetAsync("/api/status/environment");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<RuntimeEnvironmentResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.ProcessorCount.ShouldBeGreaterThanOrEqualTo(0);
+        payload.OsDescription.ShouldNotBeNullOrWhiteSpace();
+        payload.ClrVersion.ShouldNotBeNullOrWhiteSpace();
+        payload.FrameworkDescription.ShouldNotBeNullOrWhiteSpace();
+        payload.EnvironmentVariables.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Should_ReflectConfiguredAllowlist_When_RuntimeEnvironmentOptionsOverridden()
+    {
+        await using var factory = new EnvironmentStatusWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["RuntimeEnvironmentStatus:VariableNames:0"] = "ASPNETCORE_ENVIRONMENT",
+                    ["RuntimeEnvironmentStatus:VariableNames:1"] = "TEST_VAR_6191_INTEG_A",
+                    ["RuntimeEnvironmentStatus:VariableNames:2"] = "TEST_VAR_6191_INTEG_B"
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/status/environment");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<RuntimeEnvironmentResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.EnvironmentVariables.Select(e => e.Name).ToList().ShouldBe(
+            new List<string> { "ASPNETCORE_ENVIRONMENT", "TEST_VAR_6191_INTEG_A", "TEST_VAR_6191_INTEG_B" });
+    }
+
+    [Test]
+    public async Task Should_Redact_When_ProcessEnvContainsDistinctiveValue()
+    {
+        Environment.SetEnvironmentVariable(DistinctiveSecretEnvName, DistinctiveSecretValue);
+        await using var factory = new EnvironmentStatusWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["RuntimeEnvironmentStatus:VariableNames:0"] = DistinctiveSecretEnvName
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/status/environment");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.ShouldNotContain(DistinctiveSecretValue);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/status/environment");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/status/environment");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.GetAsync("/api/status/environment");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/status/environment");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_NotConflictWithAdjacentRoutes_When_Registered()
+    {
+        var env = await _client!.GetAsync("/api/status/environment");
+        env.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var ping = await _client.GetAsync("/api/ping");
+        ping.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/IntegrationTests/Api/EnvironmentStatusWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/EnvironmentStatusWebApplicationFactory.cs
@@ -1,0 +1,33 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server for <c>/api/status/environment</c> integration tests.
+/// </summary>
+public sealed class EnvironmentStatusWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = "",
+                ["FeatureFlags:SampleFeatureA"] = "true",
+                ["FeatureFlags:SampleFeatureB"] = "false"
+            });
+        });
+    }
+}

--- a/src/UI/Api/Controllers/EnvironmentStatusController.cs
+++ b/src/UI/Api/Controllers/EnvironmentStatusController.cs
@@ -1,0 +1,87 @@
+using System.Runtime.InteropServices;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes OS, CPU, runtime, and allowlisted environment variable names (values redacted) for operations and support.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/status/environment")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/status/environment")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class EnvironmentStatusController(IOptions<RuntimeEnvironmentStatusOptions> options) : ControllerBase
+{
+    /// <summary>
+    /// Returns runtime environment diagnostics. Variable values are never included; only configured allowlist names with <see cref="RuntimeEnvironmentVariableEntry.ValueRedacted"/> set.
+    /// Supports weak ETag and <c>If-None-Match</c> → 304 when the representation is unchanged (same inputs produce the same JSON).
+    /// </summary>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var names = ResolveAllowlistedNames(options.Value);
+        var entries = names
+            .Select(n => new RuntimeEnvironmentVariableEntry(Name: n, ValueRedacted: true))
+            .ToList();
+
+        var payload = new RuntimeEnvironmentResponse(
+            OsDescription: RuntimeInformation.OSDescription,
+            ProcessorCount: Environment.ProcessorCount,
+            ClrVersion: Environment.Version.ToString(),
+            FrameworkDescription: RuntimeInformation.FrameworkDescription,
+            EnvironmentVariables: entries);
+
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+        {
+            return StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+
+    internal static List<string> ResolveAllowlistedNames(RuntimeEnvironmentStatusOptions opts)
+    {
+        var source = opts.VariableNames is { Length: > 0 }
+            ? opts.VariableNames
+            : RuntimeEnvironmentStatusOptions.DefaultVariableNames;
+
+        var result = new List<string>(Math.Min(source.Length, RuntimeEnvironmentStatusOptions.MaxVariableNames));
+        foreach (var raw in source)
+        {
+            if (result.Count >= RuntimeEnvironmentStatusOptions.MaxVariableNames)
+            {
+                break;
+            }
+
+            var name = raw?.Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                continue;
+            }
+
+            var duplicate = false;
+            foreach (var existing in result)
+            {
+                if (string.Equals(existing, name, StringComparison.Ordinal))
+                {
+                    duplicate = true;
+                    break;
+                }
+            }
+
+            if (!duplicate)
+            {
+                result.Add(name);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/UI/Api/RuntimeEnvironmentModels.cs
+++ b/src/UI/Api/RuntimeEnvironmentModels.cs
@@ -1,0 +1,16 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/status/environment</c> and <c>GET /api/v1.0/status/environment</c>.
+/// </summary>
+public sealed record RuntimeEnvironmentResponse(
+    string OsDescription,
+    int ProcessorCount,
+    string ClrVersion,
+    string FrameworkDescription,
+    IReadOnlyList<RuntimeEnvironmentVariableEntry> EnvironmentVariables);
+
+/// <summary>
+/// One allowlisted process environment variable: name and redaction flag only (no raw value).
+/// </summary>
+public sealed record RuntimeEnvironmentVariableEntry(string Name, bool ValueRedacted);

--- a/src/UI/Api/RuntimeEnvironmentStatusOptions.cs
+++ b/src/UI/Api/RuntimeEnvironmentStatusOptions.cs
@@ -1,0 +1,28 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Configuration for <c>GET /api/status/environment</c>: bounded allowlist of environment variable names (values never returned).
+/// </summary>
+public sealed class RuntimeEnvironmentStatusOptions
+{
+    /// <summary>Configuration section name (root <c>RuntimeEnvironmentStatus</c> in appsettings).</summary>
+    public const string SectionName = "RuntimeEnvironmentStatus";
+
+    /// <summary>Maximum number of variable names honored from configuration (including defaults).</summary>
+    public const int MaxVariableNames = 32;
+
+    /// <summary>
+    /// Names to report with redacted values only. When empty or omitted, <see cref="DefaultVariableNames"/> is used.
+    /// </summary>
+    public string[] VariableNames { get; set; } = [];
+
+    /// <summary>Safe default allowlist when <see cref="VariableNames"/> is empty.</summary>
+    public static readonly string[] DefaultVariableNames =
+    [
+        "ASPNETCORE_ENVIRONMENT",
+        "DOTNET_RUNNING_IN_CONTAINER",
+        "WEBSITE_SITE_NAME",
+        "COMPUTERNAME",
+        "HOSTNAME"
+    ];
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -56,6 +56,8 @@ builder.Services.Configure<ApiKeyAuthenticationOptions>(
     builder.Configuration.GetSection(ApiKeyAuthenticationOptions.SectionName));
 builder.Services.Configure<DiagnosticsFeatureFlagsOptions>(
     builder.Configuration.GetSection(DiagnosticsFeatureFlagsOptions.SectionName));
+builder.Services.Configure<RuntimeEnvironmentStatusOptions>(
+    builder.Configuration.GetSection(RuntimeEnvironmentStatusOptions.SectionName));
 builder.Services.PostConfigure<ApiKeyAuthenticationOptions>(o =>
     o.ValidationKey = string.IsNullOrWhiteSpace(o.ValidationKey) ? null : o.ValidationKey.Trim());
 builder.Services.AddRequestDecompression();

--- a/src/UI/Server/appsettings.json
+++ b/src/UI/Server/appsettings.json
@@ -41,6 +41,9 @@
     "SampleFeatureA": false,
     "SampleFeatureB": false
   },
+  "RuntimeEnvironmentStatus": {
+    "VariableNames": []
+  },
   "Cors": {
     "Enabled": false,
     "AllowedOrigins": []

--- a/src/UnitTests/UI.Api/EnvironmentStatusControllerTests.cs
+++ b/src/UnitTests/UI.Api/EnvironmentStatusControllerTests.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EnvironmentStatusControllerTests
+{
+    private const string DistinctiveSecretEnvName = "BOOTCAMP_ENV_STATUS_TEST_SECRET_6191";
+    private const string DistinctiveSecretValue = "distinctive-secret-value-6191-never-in-json";
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable(DistinctiveSecretEnvName, null);
+    }
+
+    [Test]
+    public void Get_Should_ReturnJson_WithOsProcessorClrFrameworkAndRedactedEnvVars_When_Called()
+    {
+        var opts = Options.Create(new RuntimeEnvironmentStatusOptions
+        {
+            VariableNames = ["ASPNETCORE_ENVIRONMENT", "HOSTNAME"]
+        });
+        var controller = new EnvironmentStatusController(opts)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<RuntimeEnvironmentResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.OsDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.OSDescription);
+        payload.ProcessorCount.ShouldBeGreaterThanOrEqualTo(0);
+        payload.ClrVersion.ShouldBe(Environment.Version.ToString());
+        payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+        payload.EnvironmentVariables.Count.ShouldBe(2);
+        payload.EnvironmentVariables[0].Name.ShouldBe("ASPNETCORE_ENVIRONMENT");
+        payload.EnvironmentVariables[0].ValueRedacted.ShouldBeTrue();
+        payload.EnvironmentVariables[1].Name.ShouldBe("HOSTNAME");
+        payload.EnvironmentVariables[1].ValueRedacted.ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_Should_NeverIncludeRawEnvValue_When_AllowlistedVarHasDistinctiveValue()
+    {
+        Environment.SetEnvironmentVariable(DistinctiveSecretEnvName, DistinctiveSecretValue);
+        var opts = Options.Create(new RuntimeEnvironmentStatusOptions
+        {
+            VariableNames = [DistinctiveSecretEnvName]
+        });
+        var controller = new EnvironmentStatusController(opts)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+        var content = result.ShouldBeOfType<ContentResult>();
+
+        content.Content!.ShouldNotContain(DistinctiveSecretValue);
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesWeakEtag()
+    {
+        var opts = Options.Create(new RuntimeEnvironmentStatusOptions { VariableNames = [] });
+        var controller = new EnvironmentStatusController(opts)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        _ = controller.Get();
+        var etag = controller.Response.Headers.ETag.ToString();
+        etag.ShouldNotBeNullOrWhiteSpace();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.IfNoneMatch = etag;
+        var controller2 = new EnvironmentStatusController(opts)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+
+        var second = controller2.Get();
+        second.ShouldBeOfType<StatusCodeResult>();
+        ((StatusCodeResult)second).StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+
+    [Test]
+    public void ResolveAllowlistedNames_Should_CapAndDedupe_When_ConfigHasDuplicatesAndOverflow()
+    {
+        var many = Enumerable
+            .Range(0, RuntimeEnvironmentStatusOptions.MaxVariableNames + 10)
+            .Select(i => $"VAR_{i}")
+            .Append("VAR_0")
+            .ToArray();
+        var list = EnvironmentStatusController.ResolveAllowlistedNames(new RuntimeEnvironmentStatusOptions
+        {
+            VariableNames = many
+        });
+        list.Count.ShouldBe(RuntimeEnvironmentStatusOptions.MaxVariableNames);
+        list.Distinct(StringComparer.Ordinal).Count().ShouldBe(list.Count);
+    }
+
+    [Test]
+    public void ResolveAllowlistedNames_Should_UseDefaults_When_VariableNamesEmpty()
+    {
+        var list = EnvironmentStatusController.ResolveAllowlistedNames(new RuntimeEnvironmentStatusOptions
+        {
+            VariableNames = []
+        });
+        list.ShouldBe(RuntimeEnvironmentStatusOptions.DefaultVariableNames.ToList());
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/status/environment", false)]
+    [TestCase("/api/v1.0/status/environment", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -60,6 +60,35 @@ public class ApiKeyAuthenticationWebTests
     }
 
     [Test]
+    public async Task Should_Return401_When_ApiEnvironmentStatusCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/status/environment");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var versioned = await client.GetAsync("/api/v1.0/status/environment");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiEnvironmentStatusCalledWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var unversioned = await client.GetAsync("/api/status/environment");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/status/environment");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
     public async Task Should_Return401_When_WrongKey()
     {
         await using var factory = new ApiKeyProtectedWebApplicationFactory();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Submitter checklist
- [x] Issue is clearly tagged (#6191)
- [x] Feature complete: `GET /api/status/environment` and `GET /api/v1.0/status/environment` with bounded env var allowlist and API key parity with diagnostics
- [x] Approval checklist expected to be satisfied after CI

## Summary

Adds a JSON diagnostics endpoint for operators: OS description, processor count, CLR/runtime version, framework description, and a capped allowlist of environment variable **names** with `valueRedacted: true` only (no values). Weak ETag + `If-None-Match` returns 304 when unchanged, matching `VersionController` semantics. `RuntimeEnvironmentStatus` section in appsettings configures `VariableNames`; empty array falls back to a small safe default set. Same rate limiting and API key middleware behavior as `/api/diagnostics` (not in the public skip list).

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/RuntimeEnvironmentStatusOptions.cs` | Options + defaults + max 32 names |
| `src/UI/Api/RuntimeEnvironmentModels.cs` | `RuntimeEnvironmentResponse` + env var entry |
| `src/UI/Api/Controllers/EnvironmentStatusController.cs` | Controller, allowlist resolution, ETag/304 |
| `src/UI/Server/Program.cs` | Bind `RuntimeEnvironmentStatusOptions` |
| `src/UI/Server/appsettings.json` | Empty `RuntimeEnvironmentStatus:VariableNames` |
| `src/UnitTests/UI.Api/EnvironmentStatusControllerTests.cs` | Controller + allowlist unit tests |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Path coverage for new routes |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | 401/200 with API key |
| `src/IntegrationTests/Api/EnvironmentStatusWebApplicationFactory.cs` | Test host factory |
| `src/IntegrationTests/Api/EnvironmentStatusEndpointIntegrationTests.cs` | HTTP + API key integration tests |

## Testing

- `dotnet build src/ChurchBulletin.sln --configuration Release`
- `dotnet test src/UnitTests --configuration Release`
- `dotnet test src/IntegrationTests --configuration Release`
- No Playwright / acceptance tests (HTTP-only, no Blazor UX change per issue)

Closes #6191

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7598bf93-362c-4f03-9fe5-418da323bc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7598bf93-362c-4f03-9fe5-418da323bc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

