### PR TITLE
New API endpoint POST /api/tools/guid-generator for on-demand GUID creation (#6186)

### DIFF
--- a/src/IntegrationTests/Api/GuidGeneratorIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GuidGeneratorIntegrationTests.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public sealed class GuidGeneratorIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndOneGuid_When_PostUnversionedWithEmptyBody()
+    {
+        var response = await _client!.PostAsync(
+            "/api/tools/guid-generator",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType.ShouldContain("application/json");
+
+        var guids = await ReadGuidsAsync(response);
+        guids.Count.ShouldBe(1);
+        _ = Guid.Parse(guids[0]);
+    }
+
+    [Test]
+    public async Task Should_Return200AndDistinctGuids_When_PostWithCount()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 5 });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var guids = await ReadGuidsAsync(response);
+        guids.Count.ShouldBe(5);
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var g in guids)
+        {
+            set.Add(g).ShouldBeTrue();
+            _ = Guid.Parse(g);
+        }
+    }
+
+    [Test]
+    public async Task Should_Return200_When_CountAtMaximumBoundary()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 100 });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var guids = await ReadGuidsAsync(response);
+        guids.Count.ShouldBe(100);
+        foreach (var g in guids)
+        {
+            _ = Guid.Parse(g);
+        }
+    }
+
+    [TestCase(0)]
+    [TestCase(-3)]
+    [TestCase(101)]
+    public async Task Should_Return400_When_CountOutOfRange(int count)
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("detail", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return415_When_InvalidContentTypeForJsonBinding()
+    {
+        using var content = new StringContent("{}", Encoding.UTF8, "text/plain");
+        var response = await _client!.PostAsync("/api/tools/guid-generator", content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_InvalidJsonBody()
+    {
+        var response = await _client!.PostAsync(
+            "/api/tools/guid-generator",
+            new StringContent("{ not json", Encoding.UTF8, "application/json"));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return200WithEmptyBody_When_PostWithoutBody()
+    {
+        var response = await _client!.PostAsync("/api/tools/guid-generator", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var guids = await ReadGuidsAsync(response);
+        guids.Count.ShouldBe(1);
+        _ = Guid.Parse(guids[0]);
+    }
+
+    [Test]
+    public async Task Should_ExposeSameContract_When_PostVersionedRoute()
+    {
+        var unversioned = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 2 });
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var uGuids = await ReadGuidsAsync(unversioned);
+        uGuids.Count.ShouldBe(2);
+
+        var versioned = await _client!.PostAsJsonAsync("/api/v1.0/tools/guid-generator", new { count = 2 });
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var vGuids = await ReadGuidsAsync(versioned);
+        vGuids.Count.ShouldBe(2);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.PostAsJsonAsync("/api/tools/guid-generator", new { });
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.PostAsJsonAsync("/api/v1.0/tools/guid-generator", new { });
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKeyClient = factory.CreateClient();
+        withKeyClient.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKeyClient.PostAsJsonAsync("/api/tools/guid-generator", new { count = 3 });
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var guids = await ReadGuidsAsync(ok);
+        guids.Count.ShouldBe(3);
+
+        var okVersioned = await withKeyClient.PostAsJsonAsync("/api/v1.0/tools/guid-generator", new { count = 1 });
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await ReadGuidsAsync(okVersioned)).Count.ShouldBe(1);
+    }
+
+    private static async Task<List<string>> ReadGuidsAsync(HttpResponseMessage response)
+    {
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var arr = doc.RootElement.GetProperty("guids");
+        var list = new List<string>();
+        foreach (var el in arr.EnumerateArray())
+        {
+            list.Add(el.GetString().ShouldNotBeNull());
+        }
+
+        return list;
+    }
+
+}

--- a/src/UI/Api/Controllers/GuidGeneratorController.cs
+++ b/src/UI/Api/Controllers/GuidGeneratorController.cs
@@ -1,0 +1,64 @@
+using System.Net.Mime;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates one or more random GUIDs for integrations and tooling.
+/// When <c>ApiKeyAuthentication:Enabled</c> is true, requests require the shared API key header like other protected <c>/api/*</c> routes (not in the version/time/ping public allowlist).
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/guid-generator")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/guid-generator")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class GuidGeneratorController : ControllerBase
+{
+    private const int DefaultCount = 1;
+    private const int MaxCount = 100;
+
+    /// <summary>
+    /// Creates new GUIDs. Optional JSON body with <c>count</c> (default 1, maximum 100).
+    /// </summary>
+    [HttpPost]
+    [AllowAnonymous]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(GuidGeneratorResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Post([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] GuidGeneratorRequest? request)
+    {
+        var count = request?.Count ?? DefaultCount;
+        if (count < 1 || count > MaxCount)
+        {
+            return Problem(
+                detail: $"Count must be between 1 and {MaxCount} inclusive.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var guids = new List<string>(count);
+        for (var i = 0; i < count; i++)
+        {
+            guids.Add(Guid.NewGuid().ToString("D"));
+        }
+
+        return Ok(new GuidGeneratorResponse(guids));
+    }
+}
+
+/// <summary>
+/// Request body for <see cref="GuidGeneratorController.Post"/>.
+/// </summary>
+/// <param name="Count">Optional number of GUIDs to generate; omitted or null defaults to 1.</param>
+public sealed record GuidGeneratorRequest(int? Count = null);
+
+/// <summary>
+/// Response payload listing generated GUID strings in order.
+/// </summary>
+/// <param name="Guids">GUID strings in standard "D" format.</param>
+public sealed record GuidGeneratorResponse(IReadOnlyList<string> Guids);

--- a/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
+++ b/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
@@ -1,0 +1,64 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class GuidGeneratorControllerTests
+{
+    private static GuidGeneratorController CreateController()
+    {
+        return new GuidGeneratorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+    }
+
+    [Test]
+    public void Post_Should_ReturnOneGuid_When_CountOmitted()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(null);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.StatusCode.ShouldBe(200);
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(1);
+        _ = Guid.Parse(payload.Guids[0]);
+    }
+
+    [Test]
+    public void Post_Should_ReturnNGuids_When_CountSpecified()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(5));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(5);
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var g in payload.Guids)
+        {
+            set.Add(g).ShouldBeTrue();
+            _ = Guid.Parse(g);
+        }
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(101)]
+    public void Post_Should_Return400_When_CountOutOfRange(int count)
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(count));
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        problem.Value.ShouldBeOfType<ProblemDetails>();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `POST /api/tools/guid-generator` and the versioned `POST /api/v1.0/tools/guid-generator` route. The handler accepts optional JSON `{ "count": <n> }` (default 1, max 100), returns `{ "guids": [ ... ] }` with standard `"D"` format strings, and uses `Problem` (400) for out-of-range counts. When API key middleware is enabled, this route stays **protected** (not added to the ping/time/version public allowlist), as documented on the controller.

Closes #6186

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/GuidGeneratorController.cs` | Controller, request/response records, validation, rate limiting |
| `src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs` | Unit tests for default count, N GUIDs, validation |
| `src/IntegrationTests/Api/GuidGeneratorIntegrationTests.cs` | HTTP tests: empty body, boundaries, bad JSON, versioning, API key |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — unit + integration suites green (266 + 119 tests).

---

Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7c16957-696d-437e-8731-55ce52a62299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7c16957-696d-437e-8731-55ce52a62299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

