### PR TITLE
New API endpoint GET /api/tools/random for configurable random data generation (#6190)

### DIFF
--- a/src/UI/Api/Controllers/ToolsRandomController.cs
+++ b/src/UI/Api/Controllers/ToolsRandomController.cs
@@ -1,0 +1,84 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates random scalar values for tests and tooling. Requires query <c>type</c>:
+/// <c>number</c>, <c>string</c>, <c>uuid</c>, or <c>color</c>.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/random")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/random")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsRandomController : ControllerBase
+{
+    /// <summary>
+    /// Default length for generated <c>string</c> payloads (URL-safe alphanumeric).
+    /// </summary>
+    public const int DefaultStringLength = 24;
+
+    private const string UrlSafeAlphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    /// <summary>
+    /// Returns a JSON object <c>{{ "type": "...", "value": ... }}</c>.
+    /// <list type="bullet">
+    /// <item><description><c>number</c> — random signed 32-bit integer.</description></item>
+    /// <item><description><c>string</c> — random URL-safe alphanumeric string of length <see cref="DefaultStringLength"/>.</description></item>
+    /// <item><description><c>uuid</c> — <see cref="Guid"/> standard string representation.</description></item>
+    /// <item><description><c>color</c> — six-digit hexadecimal color <c>#RRGGBB</c>.</description></item>
+    /// </list>
+    /// The <paramref name="type"/> parameter is matched case-insensitively.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] string type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return Problem(
+                detail: "Query parameter 'type' is required. Allowed values: number, string, uuid, color.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        switch (type.Trim().ToLowerInvariant())
+        {
+            case "number":
+            {
+                var value = unchecked((int)Random.Shared.NextInt64(int.MinValue, (long)int.MaxValue + 1));
+                return ConditionalGetEtag.JsonContent(new { type = "number", value });
+            }
+            case "string":
+                return ConditionalGetEtag.JsonContent(new { type = "string", value = GenerateUrlSafeAlphanumeric(DefaultStringLength) });
+            case "uuid":
+                return ConditionalGetEtag.JsonContent(new { type = "uuid", value = Guid.NewGuid().ToString() });
+            case "color":
+            {
+                var rgb = Random.Shared.Next(0, 0x1000000);
+                return ConditionalGetEtag.JsonContent(new { type = "color", value = $"#{rgb:X6}" });
+            }
+            default:
+                return Problem(
+                    detail: $"Unsupported type '{type}'. Allowed values: number, string, uuid, color.",
+                    statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    private static string GenerateUrlSafeAlphanumeric(int length)
+    {
+        Span<char> buffer = stackalloc char[length];
+        for (var i = 0; i < length; i++)
+            buffer[i] = UrlSafeAlphabet[Random.Shared.Next(UrlSafeAlphabet.Length)];
+
+        return new string(buffer);
+    }
+}

--- a/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
+++ b/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsRandomControllerTests
+{
+    private const string UrlSafeAlphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    private static ToolsRandomController CreateController(HttpContext? httpContext = null)
+    {
+        httpContext ??= new DefaultHttpContext();
+        return new ToolsRandomController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    [Test]
+    public void Get_Should_ReturnJsonNumber_WhenTypeIsNumber()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("number");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("number");
+        doc.RootElement.GetProperty("value").TryGetInt32(out var n).ShouldBeTrue();
+        n.ShouldBeGreaterThanOrEqualTo(int.MinValue);
+        n.ShouldBeLessThanOrEqualTo(int.MaxValue);
+    }
+
+    [Test]
+    public void Get_Should_ReturnJsonString_WhenTypeIsString()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("string");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("string");
+        var text = doc.RootElement.GetProperty("value").GetString();
+        text.ShouldNotBeNull();
+        text!.Length.ShouldBe(ToolsRandomController.DefaultStringLength);
+        text.All(UrlSafeAlphabet.Contains).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_Should_ReturnJsonUuid_WhenTypeIsUuid()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("uuid");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("uuid");
+        var guidText = doc.RootElement.GetProperty("value").GetString();
+        Guid.TryParse(guidText, out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_Should_ReturnHexColor_WhenTypeIsColor()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("color");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("color");
+        var hex = doc.RootElement.GetProperty("value").GetString();
+        Regex.IsMatch(hex!, "^#[0-9A-F]{6}$", RegexOptions.None).ShouldBeTrue();
+    }
+
+    [TestCase("NUMBER")]
+    [TestCase("Number")]
+    [TestCase("  number  ")]
+    public void Get_Should_AcceptTypeCaseInsensitive_AndTrim(string typeArgument)
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(typeArgument);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        using var doc = JsonDocument.Parse(content.Content!);
+        doc.RootElement.GetProperty("type").GetString().ShouldBe("number");
+    }
+
+    [Test]
+    public void Get_Should_ReturnBadRequest_WhenTypeMissing()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("");
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+        var problem = objectResult.Value.ShouldBeOfType<ProblemDetails>();
+        problem.Detail.ShouldNotBeNullOrEmpty();
+        problem.Detail.ShouldContain("'type'");
+    }
+
+    [Test]
+    public void Get_Should_ReturnBadRequest_WhenTypeUnsupported()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("boolean");
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+        var problem = objectResult.Value.ShouldBeOfType<ProblemDetails>();
+        problem.Detail.ShouldNotBeNull();
+        problem.Detail!.ShouldContain("boolean");
+        problem.Detail.ShouldContain("number");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/tools/random` (and versioned `GET /api/v1.0/tools/random`) with required query parameter `type` (`number`, `string`, `uuid`, `color`, case-insensitive). Successful responses use JSON `{ "type": "<kind>", "value": ... }` via existing `ConditionalGetEtag.JsonContent` serialization (no ETag/304 handling—responses are random). Missing or unsupported `type` returns `400` with RFC 7807 problem details and a clear `detail` message.

The endpoint follows the same patterns as other API controllers (`[ApiController]`, `ApiVersion("1.0")`, `[EnableRateLimiting]`, `[AllowAnonymous]`). It is **not** added to the API-key public bypass list: when API key enforcement is enabled, callers must supply `X-Api-Key` like other protected `/api/*` routes per issue specification.

CI: Branch build workflow completed successfully prior to marking this PR ready for review.

Closes #6190

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/ToolsRandomController.cs` | New controller: random int (full `int32` range), uuid string, `#RRGGBB` color, fixed-length URL-safe alphanumeric string (24 chars) |
| `src/UnitTests/UI.Api/ToolsRandomControllerTests.cs` | Unit tests for 200 payloads, invalid/missing `type`, case-insensitivity |

## Testing

- `dotnet test src/UnitTests --configuration Release --filter "FullyQualifiedName~ToolsRandomControllerTests"`
- `DATABASE_ENGINE=SQLite pwsh ./PrivateBuild.ps1` — unit + integration suites green on Linux CI environment

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59b249fa-7190-4263-940f-a1762b730100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59b249fa-7190-4263-940f-a1762b730100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

