### PR TITLE
Force capitalize all names in the login drop-down (#6179)

### DIFF
--- a/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
@@ -83,6 +83,9 @@ public class LoginPageTests
 
         var jdoeOption = component.FindAll("option").Single(o => o.GetAttribute("value") == "jdoe");
         jdoeOption.TextContent.ShouldBe("MARY JANE SIMPSON");
+
+        var mburnsOption = component.FindAll("option").Single(o => o.GetAttribute("value") == "mburns");
+        mburnsOption.TextContent.ShouldBe("MONTGOMERY BURNS");
     }
 
     [Test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #6179 requires **display-only** uppercase (`ToUpperInvariant()`) for member names in the **Select Church Member** drop-down on `/login`, matching mainframe all-caps while leaving `<option value>` as `UserName` and all other UI unchanged.

That behavior is already implemented on `master` (`LoginDisplayNameFormatter`, `Login.razor` / `Login.razor.cs`, and existing tests). This PR adds one **bUnit** assertion so a **mixed-case first name** (`Montgomery Burns` via `mburns`) is verified as **`MONTGOMERY BURNS`** in the dropdown label.

## Files changed

| File | Change |
|------|--------|
| `src/UnitTests/UI.Shared/Pages/LoginPageTests.cs` | Extend `ShouldDisplayUppercaseLabelsInLoginDropdown_ForMixedAndAllCapsNames` with `mburns` → `MONTGOMERY BURNS`. |

## Testing

- `dotnet test src/UnitTests/UnitTests.csproj --configuration Release --filter "FullyQualifiedName~LoginPageTests.ShouldDisplayUppercaseLabelsInLoginDropdown_ForMixedAndAllCapsNames"`
- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File ./PrivateBuild.ps1` — unit + integration green.

Closes #6179

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fe1e0a0-07b8-4a12-b93b-5191365bf403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fe1e0a0-07b8-4a12-b93b-5191365bf403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

