### PR TITLE
New API endpoint GET /api/tools/timestamp-converter for epoch and ISO conversions (#6188)

### DIFF
--- a/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class TimestampConverterEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [TestCase("/api/tools/timestamp-converter")]
+    [TestCase("/api/v1.0/tools/timestamp-converter")]
+    public async Task Should_Return200AndParsedTimestamp_When_UnixSeconds(string route)
+    {
+        var response = await _client!.GetAsync($"{route}?unix=1609459200");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+
+        doc.RootElement.GetProperty("unixSeconds").GetInt64().ShouldBe(1609459200L);
+        doc.RootElement.GetProperty("utcIso8601").GetString().ShouldBe("2021-01-01T00:00:00.0000000Z");
+    }
+
+    [TestCase("/api/tools/timestamp-converter")]
+    [TestCase("/api/v1.0/tools/timestamp-converter")]
+    public async Task Should_Return200_When_UnixMilliseconds(string route)
+    {
+        var response = await _client!.GetAsync($"{route}?unix=1609459200000");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            await response.Content.ReadAsStringAsync(),
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.UnixMilliseconds.ShouldBe(1609459200000L);
+    }
+
+    [Test]
+    public async Task Should_UseSecondsVersusMillisecondsHeuristic_When_InputScaleDiffersButInstantCanMatch()
+    {
+        var asSeconds = await _client!.GetAsync("/api/tools/timestamp-converter?unix=1700000000");
+        asSeconds.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var secondsPayload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            await asSeconds.Content.ReadAsStringAsync(),
+            ConditionalGetEtag.JsonSerializerOptions)!;
+
+        var asMilliseconds =
+            await _client.GetAsync("/api/tools/timestamp-converter?unix=1700000000000");
+        asMilliseconds.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        JsonSerializer.Deserialize<TimestampConverterResponse>(
+                await asMilliseconds.Content.ReadAsStringAsync(),
+                ConditionalGetEtag.JsonSerializerOptions)!
+            .UtcIso8601.ShouldBe(secondsPayload.UtcIso8601);
+
+        var outOfRangeSeconds = await _client.GetAsync("/api/tools/timestamp-converter?unix=253402400000");
+        outOfRangeSeconds.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        var fractionalMsDifference = await _client.GetAsync("/api/tools/timestamp-converter?unix=1000000000001");
+        fractionalMsDifference.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        JsonSerializer.Deserialize<TimestampConverterResponse>(
+                await fractionalMsDifference.Content.ReadAsStringAsync(),
+                ConditionalGetEtag.JsonSerializerOptions)!
+            .UtcIso8601.ShouldBe("2001-09-09T01:46:40.0010000Z");
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ValidIso()
+    {
+        var response = await _client!.GetAsync(
+            "/api/tools/timestamp-converter?iso=2026-03-30T12%3A00%3A00.0000000Z");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            await response.Content.ReadAsStringAsync(),
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.UtcIso8601.ShouldBe("2026-03-30T12:00:00.0000000Z");
+        payload.UnixSeconds.ShouldBe(new DateTimeOffset(2026, 3, 30, 12, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds());
+    }
+
+    [TestCase("/api/tools/timestamp-converter")]
+    [TestCase("/api/v1.0/tools/timestamp-converter")]
+    public async Task Should_Return400_When_BothParameters(string route)
+    {
+        var response = await _client!.GetAsync($"{route}?iso=1970-01-01Z&unix=0");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_MissingBothParameters()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_GarbageIso()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?iso=zzz");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return304_When_EtagMatchesIfNoneMatch()
+    {
+        var first = await _client!.GetAsync("/api/tools/timestamp-converter?unix=0");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        first.Headers.ETag.ShouldNotBeNull();
+        using var rq = new HttpRequestMessage(HttpMethod.Get, "/api/tools/timestamp-converter?unix=0");
+        rq.Headers.IfNoneMatch.Add(first.Headers.ETag!);
+
+        var second = await _client.SendAsync(rq);
+
+        second.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+    }
+}

--- a/src/UI/Api/Controllers/TimestampConverterController.cs
+++ b/src/UI/Api/Controllers/TimestampConverterController.cs
@@ -1,0 +1,116 @@
+using System.Globalization;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Stateless conversion between Unix epoch timestamps and ISO-8601 instants for operators and scripts.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/timestamp-converter")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/timestamp-converter")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class TimestampConverterController : ControllerBase
+{
+    private const long MillisecondsInterpretationThreshold = 1_000_000_000_000L;
+
+    /// <summary>
+    /// Converts either <paramref name="iso"/> (ISO-8601 / XML round-trip) or <paramref name="unix"/> (numeric string).
+    /// </summary>
+    /// <remarks>
+    /// Exactly one query parameter must be supplied. Numeric <c>unix</c> uses seconds when
+    /// <c>Abs(value) &lt; 1_000_000_000_000</c>, otherwise milliseconds. Parsing uses invariant culture after trim.
+    /// </remarks>
+    [HttpGet]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(TimestampConverterResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] string? iso, [FromQuery] string? unix)
+    {
+        var isoNormalized = NormalizeQuery(iso);
+        var unixNormalized = NormalizeQuery(unix);
+        var hasIso = isoNormalized.Length > 0;
+        var hasUnix = unixNormalized.Length > 0;
+
+        if (!hasIso && !hasUnix)
+        {
+            return Problem(
+                detail: "Specify exactly one query parameter: `iso` (ISO-8601) or `unix` (epoch seconds or milliseconds).",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (hasIso && hasUnix)
+        {
+            return Problem(
+                detail: "Specify only one of `iso` or `unix`, not both.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        DateTimeOffset instant;
+        if (hasUnix)
+        {
+            if (!long.TryParse(unixNormalized, NumberStyles.Integer, CultureInfo.InvariantCulture, out var epochValue))
+            {
+                return Problem(
+                    detail: "The `unix` value must be a whole integer.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            try
+            {
+                instant = Math.Abs(epochValue) >= MillisecondsInterpretationThreshold
+                    ? DateTimeOffset.FromUnixTimeMilliseconds(epochValue)
+                    : DateTimeOffset.FromUnixTimeSeconds(epochValue);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return Problem(
+                    detail: "The `unix` value represents an instant outside the supported range.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+        }
+        else if (!DateTimeOffset.TryParse(
+                     isoNormalized,
+                     CultureInfo.InvariantCulture,
+                     DateTimeStyles.RoundtripKind,
+                     out instant))
+        {
+            return Problem(
+                detail: "The `iso` value could not be parsed as ISO-8601.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var utc = instant.UtcDateTime;
+        var payload = new TimestampConverterResponse(
+            UtcIso8601: utc.ToString("O", CultureInfo.InvariantCulture),
+            UnixSeconds: instant.ToUnixTimeSeconds(),
+            UnixMilliseconds: instant.ToUnixTimeMilliseconds(),
+            UtcRfc1123: utc.ToString("R", CultureInfo.InvariantCulture),
+            UtcInvariantFormatted: utc.ToString("F", CultureInfo.InvariantCulture));
+
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+
+    private static string NormalizeQuery(string? value) => value?.Trim() ?? "";
+}
+
+/// <summary>
+/// JSON payload for timestamp conversion endpoints: canonical UTC ISO-8601, Unix seconds/ms, and invariant human-readable fields.
+/// </summary>
+public sealed record TimestampConverterResponse(
+    string UtcIso8601,
+    long UnixSeconds,
+    long UnixMilliseconds,
+    string UtcRfc1123,
+    string UtcInvariantFormatted);

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -1,0 +1,231 @@
+using System.Globalization;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterControllerTests
+{
+    private sealed class StubProblemDetailsFactory : ProblemDetailsFactory
+    {
+        public override ProblemDetails CreateProblemDetails(
+            HttpContext httpContext,
+            int? statusCode = default,
+            string? title = default,
+            string? type = default,
+            string? detail = default,
+            string? instance = default) =>
+            new() { Status = statusCode ?? 400, Detail = detail, Title = title ?? "Problem" };
+
+        public override ValidationProblemDetails CreateValidationProblemDetails(
+            HttpContext httpContext,
+            ModelStateDictionary modelStateDictionary,
+            int? statusCode = default,
+            string? title = default,
+            string? type = default,
+            string? detail = default,
+            string? instance = default) =>
+            new(modelStateDictionary) { Status = statusCode ?? 400 };
+    }
+
+    private static TimestampConverterController CreateController(HttpContext? httpContext = null)
+    {
+        httpContext ??= new DefaultHttpContext();
+        httpContext.RequestServices = new ServiceCollection()
+            .AddSingleton<ProblemDetailsFactory, StubProblemDetailsFactory>()
+            .BuildServiceProvider();
+
+        return new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    [Test]
+    public void Get_Should_ReturnJson_When_UnixEpochSeconds()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(iso: null, unix: "1609459200");
+
+        var content = AssertJsonOk(result);
+        content.UtcIso8601.ShouldBe("2021-01-01T00:00:00.0000000Z");
+        content.UnixSeconds.ShouldBe(1609459200L);
+        content.UnixMilliseconds.ShouldBe(1609459200000L);
+        content.UtcRfc1123.ShouldBe("Fri, 01 Jan 2021 00:00:00 GMT");
+        content.UtcInvariantFormatted.ShouldBe(
+            new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToString("F", CultureInfo.InvariantCulture));
+    }
+
+    [Test]
+    public void Get_Should_UseMilliseconds_When_AbsUnixPastThreshold()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(iso: null, unix: "1609459200000");
+
+        var content = AssertJsonOk(result);
+        content.UnixMilliseconds.ShouldBe(1609459200000L);
+    }
+
+    [Test]
+    public void Get_Should_UseSeconds_When_ValueBelowMillisecondsThresholdAndInRange()
+    {
+        var controller = CreateController();
+
+        var resultSeconds = controller.Get(iso: null, unix: "2000000000");
+
+        AssertJsonOk(resultSeconds).UnixSeconds.ShouldBe(2000000000L);
+
+        var resultMs = controller.Get(iso: null, unix: "2000000000000");
+
+        var msPayload = AssertJsonOk(resultMs);
+        msPayload.UtcIso8601.ShouldBe("2033-05-18T03:33:20.0000000Z");
+    }
+
+    [Test]
+    public void Get_Should_MapSameUtcInstant_ForEquivalentSecondsVersusMillisecondsRepresentations()
+    {
+        var controller = CreateController();
+
+        var fromSeconds = AssertJsonOk(controller.Get(iso: null, unix: "1609459200"));
+
+        var millisecondsController = CreateController();
+
+        var fromMilliseconds = AssertJsonOk(millisecondsController.Get(iso: null, unix: "1609459200000"));
+
+        fromSeconds.UtcIso8601.ShouldBe(fromMilliseconds.UtcIso8601);
+        fromSeconds.UnixSeconds.ShouldBe(fromMilliseconds.UnixSeconds);
+        fromMilliseconds.UnixMilliseconds.ShouldBe(1609459200000L);
+    }
+
+    [Test]
+    public void Get_Should_TreatHugeNumericAsMilliseconds_ButHugeSecondsFailWhenOutOfRange()
+    {
+        var controller = CreateController();
+
+        var outOfRangeSeconds = controller.Get(iso: null, unix: "253402400000");
+        ((ObjectResult)outOfRangeSeconds).StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_DistinguishInterpretationAcrossScaleWhenInstantsWouldDifferAtSameDigits()
+    {
+        var asSecondsController = CreateController();
+
+        var asSecondsPayload = AssertJsonOk(asSecondsController.Get(iso: null, unix: "1700000000"));
+
+        var millisecondsController = CreateController();
+
+        var millisecondsPayload =
+            AssertJsonOk(millisecondsController.Get(iso: null, unix: "1700000000000"));
+
+        asSecondsPayload.UtcIso8601.ShouldBe(millisecondsPayload.UtcIso8601);
+        asSecondsPayload.UtcIso8601.ShouldBe("2023-11-14T22:13:20.0000000Z");
+        millisecondsPayload.UnixMilliseconds.ShouldBe(1700000000000L);
+    }
+
+    [Test]
+    public void Get_Should_ReturnJson_When_IsoRoundTripUtc()
+    {
+        var controller = CreateController();
+
+        var content = AssertJsonOk(controller.Get(iso: "2026-03-30T12:00:00.0000000Z", unix: null));
+        content.UtcIso8601.ShouldBe("2026-03-30T12:00:00.0000000Z");
+        content.UnixSeconds.ShouldBe(1774872000L);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_BothQueriesSupplied()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(iso: "2026-03-30T12:00:00.0000000Z", unix: "0");
+
+        var problem = result.ShouldBeOfType<ObjectResult>().Value.ShouldBeOfType<ProblemDetails>();
+        problem.Status.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_NeitherQuerySupplied()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(iso: null, unix: null);
+
+        ((ObjectResult)result).StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_EmptyIsoWhitespaceOnly()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(iso: "   ", unix: null);
+
+        ((ObjectResult)result).StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_InvalidUnixNumeric()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(iso: null, unix: "not-a-number");
+
+        ((ObjectResult)result).StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_InvalidIsoGarbage()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(iso: "not-a-ts", unix: null);
+
+        ((ObjectResult)result).StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesWeakEtag()
+    {
+        var httpContext = new DefaultHttpContext();
+        var controller = CreateController(httpContext);
+
+        var first = controller.Get(iso: null, unix: "0");
+        var content = AssertJsonOk(first);
+
+        httpContext.Response.Headers.Remove(HeaderNames.ETag);
+        controller = CreateController(httpContext);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(content);
+        httpContext.Request.Headers.IfNoneMatch = etag.ToString();
+
+        var second = controller.Get(iso: null, unix: "0");
+
+        second.ShouldBeOfType<StatusCodeResult>()
+            .StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+
+    private static TimestampConverterResponse AssertJsonOk(IActionResult result)
+    {
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        return payload!;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds anonymous `GET /api/tools/timestamp-converter` (and dual-routed `GET /api/v1.0/tools/timestamp-converter`) for converting between Unix epoch numeric strings and ISO-8601 instants. The handler enforces exactly one of query parameters `iso` or `unix`, applies the seconds-vs-milliseconds rule when **Abs(value) ≥ 1_000_000_000_000**, returns canonical UTC `"O"` JSON plus Unix seconds/ms and invariant human-readable fields, uses `Problem` for validation errors (400), and supports weak `ETag` + `304` conditional GET aligned with existing API utilities.

Closes #6188

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/TimestampConverterController.cs` | Controller + `TimestampConverterResponse` record |
| `src/UnitTests/UI.Api/TimestampConverterControllerTests.cs` | Controller unit coverage (happy paths, 400 cases, If-None-Match) |
| `src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs` | `WebApplicationFactory` integration tests vs unversioned and versioned routes |

## Testing notes

- `pwsh PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` and `APPLICATIONINSIGHTS_CONNECTION_STRING=""` succeeded (274 unit tests, 119 integration tests).
- Filtered runs: `TimestampConverterControllerTests`, `TimestampConverterEndpointIntegrationTests` all passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7076b82-6487-4391-a61c-e2d8af034e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7076b82-6487-4391-a61c-e2d8af034e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

