### PR TITLE
New API endpoint POST /api/tools/hash for computing SHA-256 hashes of text input (#6187)

### DIFF
--- a/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
 using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UnitTests.UI.Server;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -165,5 +166,32 @@ public class DiagnosticsEndpointIntegrationTests
 
         var okVersioned = await withKey.GetAsync("/api/v1.0/diagnostics");
         okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_HashEndpointProtectedSameAsDiagnostics()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauthLegacy = await client.PostAsJsonAsync("/api/tools/hash", new HashTextRequest { Text = "x" });
+        unauthLegacy.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthV1 = await client.PostAsJsonAsync("/api/v1.0/tools/hash", new HashTextRequest { Text = "x" });
+        unauthV1.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var okLegacy = await withKey.PostAsJsonAsync("/api/tools/hash", new HashTextRequest { Text = "hello" });
+        okLegacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await okLegacy.Content.ReadFromJsonAsync<HashTextResponse>();
+        payload.ShouldNotBeNull();
+        payload!.Sha256.ShouldBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+
+        var okV1 = await withKey.PostAsJsonAsync("/api/v1.0/tools/hash", new HashTextRequest { Text = "hello" });
+        okV1.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
 }

--- a/src/UI/Api/Controllers/ToolsHashController.cs
+++ b/src/UI/Api/Controllers/ToolsHashController.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using System.Text;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Computes SHA-256 (primary digest), MD5, and SHA-1 hex digests over UTF-8 bytes of supplied text.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/hash")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/hash")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class ToolsHashController : ControllerBase
+{
+    /// <summary>
+    /// Accepts JSON <c>{ "text": "..." }</c> and returns lowercase hexadecimal <c>sha256</c>, <c>md5</c>, and <c>sha1</c> digests computed from UTF-8 encoding (no BOM, no normalization).
+    /// </summary>
+    [HttpPost]
+    public ActionResult<HashTextResponse> Post(HashTextRequest request)
+    {
+        var bytes = Encoding.UTF8.GetBytes(request.Text);
+        var sha256Hex = HexLower(SHA256.HashData(bytes));
+        var md5Hex = HexLower(MD5.HashData(bytes));
+#pragma warning disable CA5350 // SHA-1 only for interoperability / checksum per API contract — not security
+        var sha1Hex = HexLower(SHA1.HashData(bytes));
+#pragma warning restore CA5350
+
+        var response = new HashTextResponse(sha256Hex, md5Hex, sha1Hex);
+        return Ok(response);
+    }
+
+    private static string HexLower(ReadOnlySpan<byte> bytes)
+    {
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}
+
+/// <summary>
+/// JSON body for POST <c>/api/tools/hash</c>.
+/// </summary>
+public sealed record HashTextRequest
+{
+    /// <summary>The input string hashed as UTF-8 (including empty).</summary>
+    public required string Text { get; init; }
+}
+
+/// <summary>
+/// Response digest payload (all hex strings lowercase).
+/// </summary>
+public sealed record HashTextResponse(string Sha256, string Md5, string Sha1);

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/hash", false)]
+    [TestCase("/api/v1.0/tools/hash", false)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Net.Http.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
 using ClearMeasure.Bootcamp.UI.Shared;
 using Shouldly;
 
@@ -91,5 +93,34 @@ public class ApiKeyAuthenticationWebTests
         var response = await client.GetAsync("/api/time");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return401_When_ToolsHashPostWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.PostAsJsonAsync("/api/tools/hash", new HashTextRequest { Text = "x" });
+        var versioned = await client.PostAsJsonAsync("/api/v1.0/tools/hash", new HashTextRequest { Text = "x" });
+
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        versioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ToolsHashPostWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var unversioned = await client.PostAsJsonAsync("/api/tools/hash", new HashTextRequest { Text = "hello" });
+        var versioned = await client.PostAsJsonAsync("/api/v1.0/tools/hash", new HashTextRequest { Text = "hello" });
+
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
 }

--- a/src/UnitTests/UI.Server/ToolsHashEndpointWebTests.cs
+++ b/src/UnitTests/UI.Server/ToolsHashEndpointWebTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class ToolsHashEndpointWebTests
+{
+    private ApiVersioningRoutingWebApplicationFactory? _factory;
+
+    [SetUp]
+    public void SetUp() => _factory = new ApiVersioningRoutingWebApplicationFactory();
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+
+        _factory = null;
+    }
+
+    [TestCase("/api/tools/hash")]
+    [TestCase("/api/v1.0/tools/hash")]
+    public async Task Should_Return200AndGoldenDigests_When_PostHello(string route)
+    {
+        using var client = _factory!.CreateClient();
+
+        var response = await client.PostAsJsonAsync(route, new HashTextRequest { Text = "hello" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        var body = await response.Content.ReadFromJsonAsync<HashTextResponse>();
+        body.ShouldNotBeNull();
+        body!.Sha256.ShouldBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+        body.Md5.ShouldBe("5d41402abc4b2a76b9719d911017c592");
+        body.Sha1.ShouldBe("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
+    }
+
+    [Test]
+    public async Task Should_ReturnSameDigests_OnUnversionedAndV1Routes()
+    {
+        using var client = _factory!.CreateClient();
+
+        var legacy = await client.PostAsJsonAsync("/api/tools/hash", new HashTextRequest { Text = "hello" });
+        var v1 = await client.PostAsJsonAsync("/api/v1.0/tools/hash", new HashTextRequest { Text = "hello" });
+
+        var a = await legacy.Content.ReadFromJsonAsync<HashTextResponse>();
+        var b = await v1.Content.ReadFromJsonAsync<HashTextResponse>();
+        a.ShouldNotBeNull();
+        b.ShouldNotBeNull();
+        a!.Sha256.ShouldBe(b!.Sha256);
+        a.Md5.ShouldBe(b.Md5);
+        a.Sha1.ShouldBe(b.Sha1);
+    }
+
+    [TestCase("/api/tools/hash")]
+    [TestCase("/api/v1.0/tools/hash")]
+    public async Task Should_Return200AndStableUnicodeDigests_When_PostUtf8Text(string route)
+    {
+        using var client = _factory!.CreateClient();
+        var text = "日本";
+
+        var response = await client.PostAsJsonAsync(route, new HashTextRequest { Text = text });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<HashTextResponse>();
+        body.ShouldNotBeNull();
+        body!.Sha256.ShouldBe("cf2abf0c5be326cb922a70f8163f91079c4d9aa8655c60ead89ad545c9de2e92");
+        body.Md5.ShouldBe("4dbed2e657457884e67137d3514119b3");
+        body.Sha1.ShouldBe("44da6bbcf285cdb317aa91174217990d1b94d64d");
+    }
+
+    [TestCase("/api/tools/hash")]
+    [TestCase("/api/v1.0/tools/hash")]
+    public async Task Should_Return200AndEmptyStringDigests_When_TextEmpty(string route)
+    {
+        using var client = _factory!.CreateClient();
+
+        var response = await client.PostAsJsonAsync(route, new HashTextRequest { Text = "" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<HashTextResponse>();
+        body.ShouldNotBeNull();
+        body!.Sha256.ShouldBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        body.Md5.ShouldBe("d41d8cd98f00b204e9800998ecf8427e");
+        body.Sha1.ShouldBe("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    }
+
+    [TestCase("/api/tools/hash")]
+    [TestCase("/api/v1.0/tools/hash")]
+    public async Task Should_ReturnNotSuccess_When_JsonMalformed(string route)
+    {
+        using var client = _factory!.CreateClient();
+        using var content = new StringContent("{", Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync(route, content);
+
+        response.IsSuccessStatusCode.ShouldBeFalse();
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [TestCase("/api/tools/hash")]
+    [TestCase("/api/v1.0/tools/hash")]
+    public async Task Should_ReturnNotSuccess_When_TextPropertyMissing(string route)
+    {
+        using var client = _factory!.CreateClient();
+        using var content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync(route, content);
+
+        response.IsSuccessStatusCode.ShouldBeFalse();
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_ReturnNotSuccess_When_UnsupportedVersion()
+    {
+        using var client = _factory!.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/v2.0/tools/hash", new HashTextRequest { Text = "x" });
+
+        response.IsSuccessStatusCode.ShouldBeFalse();
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.NotFound, HttpStatusCode.BadRequest);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item

## Summary

Adds `POST /api/tools/hash` and `POST /api/v1.0/tools/hash`: JSON body `{ "text": "<string>" }`, response `{ "sha256", "md5", "sha1" }` as **lowercase** hex digests over **UTF-8** bytes (`System.Security.Cryptography`). Uses the same versioning, dual-route pattern, and rate limiting as `PingController`. No new NuGet packages; no Core/DataAccess changes.

Empty `text` is allowed (digests match hashing an empty UTF-8 byte sequence). Missing `text` or invalid JSON yields **400** via standard API controller validation.

When API key middleware is enabled, this route behaves like other non-public `/api/*` endpoints (requires `X-Api-Key`).

## Files changed

| Path | Change |
|------|--------|
| `src/UI/Api/Controllers/ToolsHashController.cs` | New controller + `HashTextRequest` / `HashTextResponse`. |
| `src/UnitTests/UI.Server/ToolsHashEndpointWebTests.cs` | Golden vectors (`hello`), Unicode UTF-8, empty string, malformed/missing JSON, unsupported API version parity. |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Assert `/api/tools/hash` routes are **not** public-bypass paths. |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | 401 without key / 200 with key for POST hash. |
| `src/IntegrationTests/Api/DiagnosticsEndpointIntegrationTests.cs` | Hosted API key enforcement for hash POST aligned with diagnostics factory. |

## Testing

- `./PrivateBuild.ps1` — build, 277 unit tests, SQL container + migrations, 112 integration tests — **green**.
- Focused earlier: `dotnet test` filters for `ToolsHashEndpointWebTests`, new API key web tests, and hash integration case.

Closes #6187
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a562aa1-9b72-46d0-b1c2-fdd4615bcfa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a562aa1-9b72-46d0-b1c2-fdd4615bcfa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

