### PR TITLE
Add work order instructions as a new field (#6178)

### DIFF
--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -299,7 +299,7 @@ public abstract class AcceptanceTestBase
         await Expect(locator).ToBeEditableAsync(new LocatorAssertionsToBeEditableOptions { Timeout = 30_000 });
 
         await locator.EvaluateAsync(
-            """(el, v) => { el.removeAttribute('maxlength'); el.value = v; el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); }""",
+            "(el, v) => { el.removeAttribute('maxlength'); el.value = v; el.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true, inputType: 'insertFromPaste' })); el.dispatchEvent(new Event('change', { bubbles: true })); }",
             value);
 
         await locator.BlurAsync();

--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -299,7 +299,7 @@ public abstract class AcceptanceTestBase
         await Expect(locator).ToBeEditableAsync(new LocatorAssertionsToBeEditableOptions { Timeout = 30_000 });
 
         await locator.EvaluateAsync(
-            "(el, v) => { el.removeAttribute('maxlength'); el.value = v; el.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: true, inputType: 'insertFromPaste' })); el.dispatchEvent(new Event('change', { bubbles: true })); }",
+            "(el, v) => { el.removeAttribute(\"maxlength\"); el.value = v; el.dispatchEvent(new Event(\"input\", { bubbles: true })); el.dispatchEvent(new Event(\"change\", { bubbles: true })); }",
             value);
 
         await locator.BlurAsync();

--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -398,7 +398,10 @@ public abstract class AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), username);
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
-        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        if (!string.IsNullOrEmpty(order.Instructions))
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        }
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -416,7 +419,10 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
-        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        if (!string.IsNullOrEmpty(order.Instructions))
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        }
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToInProgressCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
@@ -433,7 +439,10 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
-        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        if (!string.IsNullOrEmpty(order.Instructions))
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
+        }
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToCompleteCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         await Task.Delay(GetInputDelayMs()); // Give time for the save operation to complete on Azure

--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -279,6 +279,35 @@ public abstract class AcceptanceTestBase
         await Expect(locator).ToHaveValueAsync(value ?? "");
     }
 
+    /// <summary>
+    /// Sets input value while bypassing HTML attributes such as <c>maxlength</c>.
+    /// Blazor maps <see cref="System.ComponentModel.DataAnnotations.StringLengthAttribute"/> to <c>maxlength</c>,
+    /// which prevents typing past the limit and blocks DataAnnotations validation from running on submit.
+    /// </summary>
+    protected async Task InputBypassingHtmlConstraints(string elementTestId, string value)
+    {
+        var locator = Page.GetByTestId(elementTestId);
+        if (!await locator.IsVisibleAsync()) await locator.WaitForAsync();
+        await Expect(locator).ToBeVisibleAsync();
+
+        if (!await locator.IsEditableAsync())
+        {
+            await Page.ReloadAsync();
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        }
+
+        await Expect(locator).ToBeEditableAsync(new LocatorAssertionsToBeEditableOptions { Timeout = 30_000 });
+
+        await locator.EvaluateAsync(
+            """(el, v) => { el.removeAttribute('maxlength'); el.value = v; el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); }""",
+            value);
+
+        await locator.BlurAsync();
+
+        var delayMs = GetInputDelayMs();
+        await Task.Delay(delayMs);
+    }
+
     protected int GetInputDelayMs()
     {
         var envValue = Environment.GetEnvironmentVariable("TEST_INPUT_DELAY_MS");

--- a/src/AcceptanceTests/AcceptanceTestBase.cs
+++ b/src/AcceptanceTests/AcceptanceTestBase.cs
@@ -304,7 +304,7 @@ public abstract class AcceptanceTestBase
         await locator.SelectOptionAsync(value ?? "");
     }
 
-    protected async Task<WorkOrder> CreateAndSaveNewWorkOrder()
+    protected async Task<WorkOrder> CreateAndSaveNewWorkOrder(string? instructions = null)
     {
         var order = Faker<WorkOrder>();
         order.Title = $"[{TestTag}] from automation";
@@ -324,6 +324,11 @@ public abstract class AcceptanceTestBase
         order.Number = newWorkOrderNumber;
         await Input(nameof(WorkOrderManage.Elements.Title), testTitle);
         await Input(nameof(WorkOrderManage.Elements.Description), testDescription);
+        if (instructions != null)
+        {
+            await Input(nameof(WorkOrderManage.Elements.Instructions), instructions);
+        }
+
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), testRoomNumber);
         await TakeScreenshotAsync(2, "FormFilled");
 
@@ -364,6 +369,7 @@ public abstract class AcceptanceTestBase
         await Select(nameof(WorkOrderManage.Elements.Assignee), username);
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + DraftToAssignedCommand.Name);
 
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -381,6 +387,7 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + AssignedToInProgressCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
@@ -397,6 +404,7 @@ public abstract class AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), order.Title);
         await Input(nameof(WorkOrderManage.Elements.Description), order.Description);
+        await Input(nameof(WorkOrderManage.Elements.Instructions), order.Instructions);
         await Click(nameof(WorkOrderManage.Elements.CommandButton) + InProgressToCompleteCommand.Name);
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         await Task.Delay(GetInputDelayMs()); // Give time for the save operation to complete on Azure

--- a/src/AcceptanceTests/WorkOrders/WorkOrderCompleteTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderCompleteTests.cs
@@ -21,8 +21,10 @@ public class WorkOrderCompleteTests : AcceptanceTestBase
 
         var expectedTitle = "Title from automation";
         var expectedDescription = "Description";
+        var expectedInstructions = "Bring ladder from storage.";
         order.Title = expectedTitle;
         order.Description = expectedDescription;
+        order.Instructions = expectedInstructions;
         order = await CompleteExistingWorkOrder(order);
         order = await ClickWorkOrderNumberFromSearchPage(order);
 
@@ -36,6 +38,7 @@ public class WorkOrderCompleteTests : AcceptanceTestBase
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description)))
             .ToHaveValueAsync(expectedDescription);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Description))).ToBeDisabledAsync();
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions))).ToHaveTextAsync(expectedInstructions);
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Status)))
             .ToHaveTextAsync(WorkOrderStatus.Complete.FriendlyName);
 
@@ -61,6 +64,9 @@ public class WorkOrderCompleteTests : AcceptanceTestBase
         order = await BeginExistingWorkOrder(order);
         order = await ClickWorkOrderNumberFromSearchPage(order);
 
+        order.Title = "Title from automation";
+        order.Description = "Description";
+        order.Instructions = "Bring ladder.";
         order = await CompleteExistingWorkOrder(order);
         order = await ClickWorkOrderNumberFromSearchPage(order);
 
@@ -70,5 +76,7 @@ public class WorkOrderCompleteTests : AcceptanceTestBase
 
         await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.ReadOnlyMessage)))
             .ToHaveTextAsync("This work order is read-only for you at this time.");
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions))).ToHaveTextAsync("Bring ladder.");
     }
 }

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -122,8 +122,14 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
 
         await Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name).ClickAsync();
 
-        await Expect(Page.Locator(".validation-summary, .validation-message").First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
         await Expect(Page).Not.ToHaveURLAsync(new Regex(".*/workorder/search.*"));
+
+        var instructionsLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsLocator).ToHaveJSPropertyAsync("value.length", 4001);
+
+        var fieldMessage = Page.Locator(".instructions-validation-message");
+        var summaryErrors = Page.Locator(".validation-summary.validation-errors");
+        await Expect(fieldMessage.Or(summaryErrors).First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
     }
 
     [Test, Retry(2)]

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -117,7 +117,7 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
 
         await Input(nameof(WorkOrderManage.Elements.Title), $"[{TestTag}] validation test");
         await Input(nameof(WorkOrderManage.Elements.Description), "desc");
-        await Input(nameof(WorkOrderManage.Elements.Instructions), new string('z', 4001));
+        await InputBypassingHtmlConstraints(nameof(WorkOrderManage.Elements.Instructions), new string('z', 4001));
         await Input(nameof(WorkOrderManage.Elements.RoomNumber), "101");
 
         await Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name).ClickAsync();

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -66,7 +66,7 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
     {
         await LoginAsCurrentUser();
 
-        var instructionsText = "Step A\r\nStep B";
+        var instructionsText = "Step A\nStep B";
         WorkOrder order = await CreateAndSaveNewWorkOrder(instructionsText);
 
         await Page.WaitForURLAsync("**/workorder/search");
@@ -122,7 +122,7 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
 
         await Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name).ClickAsync();
 
-        await Expect(Page.Locator(".validation-summary")).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+        await Expect(Page.Locator(".validation-summary, .validation-message").First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
         await Expect(Page).Not.ToHaveURLAsync(new Regex(".*/workorder/search.*"));
     }
 

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -78,10 +78,11 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         await ClickWorkOrderNumberFromSearchPage(order);
 
         var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
-        await Expect(instructionsField).ToHaveValueAsync(instructionsText);
+        var displayed = await instructionsField.InputValueAsync();
+        displayed.Replace("\r\n", "\n").ShouldBe(instructionsText.Replace("\r\n", "\n"));
 
         WorkOrder rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ?? throw new InvalidOperationException();
-        rehydratedOrder.Instructions.ShouldBe(instructionsText);
+        rehydratedOrder.Instructions.ShouldBe(instructionsText.Replace("\r\n", "\n"));
     }
 
     [Test, Retry(2)]
@@ -125,11 +126,11 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         await Expect(Page).Not.ToHaveURLAsync(new Regex(".*/workorder/search.*"));
 
         var instructionsLocator = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
-        await Expect(instructionsLocator).ToHaveJSPropertyAsync("value.length", 4001);
+        await Expect(instructionsLocator).ToHaveValueAsync(new string('z', 4001));
 
         var fieldMessage = Page.Locator(".instructions-validation-message");
-        var summaryErrors = Page.Locator(".validation-summary.validation-errors");
-        await Expect(fieldMessage.Or(summaryErrors).First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+        var summaryItem = Page.Locator(".validation-summary li");
+        await Expect(fieldMessage.Or(summaryItem).First).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
     }
 
     [Test, Retry(2)]

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSaveDraftTests.cs
@@ -49,6 +49,9 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         var descriptionField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Description));
         await Expect(descriptionField).ToHaveValueAsync(order.Description!);
 
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(order.Instructions ?? "");
+
         var roomNumberField = Page.GetByTestId(nameof(WorkOrderManage.Elements.RoomNumber));
         await Expect(roomNumberField).ToHaveValueAsync(order.RoomNumber!);
 
@@ -56,6 +59,71 @@ public class WorkOrderSaveDraftTests : AcceptanceTestBase
         var displayedDate = await Page.GetDateTimeFromTestIdAsync(nameof(WorkOrderManage.Elements.CreatedDate));
 
         rehydratedOrder.CreatedDate.TruncateToMinute().ShouldBe(displayedDate);
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldRetainInstructionsAfterSaveDraftAndReopen()
+    {
+        await LoginAsCurrentUser();
+
+        var instructionsText = "Step A\r\nStep B";
+        WorkOrder order = await CreateAndSaveNewWorkOrder(instructionsText);
+
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var workOrderLink = Page.GetByTestId(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await workOrderLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+
+        await ClickWorkOrderNumberFromSearchPage(order);
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync(instructionsText);
+
+        WorkOrder rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ?? throw new InvalidOperationException();
+        rehydratedOrder.Instructions.ShouldBe(instructionsText);
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldAllowBlankInstructionsOnSaveDraft()
+    {
+        await LoginAsCurrentUser();
+
+        WorkOrder order = await CreateAndSaveNewWorkOrder();
+
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var workOrderLink = Page.GetByTestId(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await workOrderLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+
+        await ClickWorkOrderNumberFromSearchPage(order);
+
+        var instructionsField = Page.GetByTestId(nameof(WorkOrderManage.Elements.Instructions));
+        await Expect(instructionsField).ToHaveValueAsync("");
+
+        WorkOrder rehydratedOrder = await Bus.Send(new WorkOrderByNumberQuery(order.Number!)) ?? throw new InvalidOperationException();
+        rehydratedOrder.Instructions.ShouldBeNull();
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldSurfaceMaxLengthValidationWhenInstructionsExceed4000()
+    {
+        await LoginAsCurrentUser();
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Page.GetByTestId(nameof(NavMenu.Elements.NewWorkOrder)).ClickAsync();
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
+
+        await Input(nameof(WorkOrderManage.Elements.Title), $"[{TestTag}] validation test");
+        await Input(nameof(WorkOrderManage.Elements.Description), "desc");
+        await Input(nameof(WorkOrderManage.Elements.Instructions), new string('z', 4001));
+        await Input(nameof(WorkOrderManage.Elements.RoomNumber), "101");
+
+        await Page.GetByTestId(nameof(WorkOrderManage.Elements.CommandButton) + SaveDraftCommand.Name).ClickAsync();
+
+        await Expect(Page.Locator(".validation-summary")).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+        await Expect(Page).Not.ToHaveURLAsync(new Regex(".*/workorder/search.*"));
     }
 
     [Test, Retry(2)]

--- a/src/Core/Model/WorkOrder.cs
+++ b/src/Core/Model/WorkOrder.cs
@@ -3,6 +3,7 @@ namespace ClearMeasure.Bootcamp.Core.Model;
 public class WorkOrder : EntityBase<WorkOrder>
 {
     private string? _description = "";
+    private string? _instructions;
 
     public string? Title { get; set; } = "";
 
@@ -10,6 +11,12 @@ public class WorkOrder : EntityBase<WorkOrder>
     {
         get => _description;
         set => _description = getTruncatedString(value);
+    }
+
+    public string? Instructions
+    {
+        get => _instructions;
+        set => _instructions = string.IsNullOrWhiteSpace(value) ? null : getTruncatedString(value);
     }
 
     public string? RoomNumber { get; set; } = null;

--- a/src/DataAccess/Mappings/WorkOrderMap.cs
+++ b/src/DataAccess/Mappings/WorkOrderMap.cs
@@ -20,6 +20,7 @@ public class WorkOrderMap : IEntityFrameworkMapping
             entity.Property(e => e.Number).IsRequired().HasMaxLength(7);
             entity.Property(e => e.Title).IsRequired().HasMaxLength(300);
             entity.Property(e => e.Description).HasMaxLength(4000);
+            entity.Property(e => e.Instructions).HasMaxLength(4000);
             entity.Property(e => e.RoomNumber).HasMaxLength(50);
 
             // Configure relationships

--- a/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
+++ b/src/Database/scripts/Update/028_AddInstructionsToWorkOrder.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION
+GO
+PRINT N'Adding [Instructions] to [dbo].[WorkOrder]'
+GO
+ALTER TABLE [dbo].[WorkOrder] ADD [Instructions] NVARCHAR(4000) NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/IntegrationTests/Api/GrpcWorkOrderIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GrpcWorkOrderIntegrationTests.cs
@@ -71,6 +71,7 @@ public class GrpcWorkOrderIntegrationTests
                 Number = "GRPC-001",
                 Title = "Test title",
                 Description = "Test description",
+                Instructions = "Follow safety checklist.",
                 RoomNumber = "101",
                 Status = WorkOrderStatus.Draft,
                 Creator = creator,
@@ -87,6 +88,7 @@ public class GrpcWorkOrderIntegrationTests
         reply.WorkOrder.Number.ShouldBe("GRPC-001");
         reply.WorkOrder.Title.ShouldBe("Test title");
         reply.WorkOrder.Description.ShouldBe("Test description");
+        reply.WorkOrder.Instructions.ShouldBe("Follow safety checklist.");
         reply.WorkOrder.RoomNumber.ShouldBe("101");
         reply.WorkOrder.StatusKey.ShouldBe(WorkOrderStatus.Draft.Key);
         reply.WorkOrder.CreatorUsername.ShouldBe("grpc-creator");

--- a/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForSaveTests.cs
+++ b/src/IntegrationTests/DataAccess/Handlers/StateCommandHandlerForSaveTests.cs
@@ -74,6 +74,7 @@ public class StateCommandHandlerForSaveTests : IntegratedTestBase
         var order = context3.Find<WorkOrder>(workOrder.Id) ?? throw new InvalidOperationException();
         order.Title.ShouldBe(workOrder.Title);
         order.Description.ShouldBe(workOrder.Description);
+        order.Instructions.ShouldBe(workOrder.Instructions);
         order.Creator.ShouldBe(currentUser);
         order.Assignee.ShouldBe(assignee);
     }
@@ -103,6 +104,7 @@ public class StateCommandHandlerForSaveTests : IntegratedTestBase
         workOrder.Creator = currentUser;
         workOrder.Assignee = assignee;
         workOrder.Title = "newtitle";
+        workOrder.Instructions = "Updated execution notes";
 
         var command = RemotableRequestTests.SimulateRemoteObject(new SaveDraftCommand(workOrder, currentUser));
 
@@ -113,6 +115,7 @@ public class StateCommandHandlerForSaveTests : IntegratedTestBase
         var order = context3.Find<WorkOrder>(workOrder.Id) ?? throw new InvalidOperationException();
         order.Title.ShouldBe("newtitle");
         order.Description.ShouldBe(workOrder.Description);
+        order.Instructions.ShouldBe("Updated execution notes");
         order.Creator.ShouldBe(currentUser);
         order.Assignee.ShouldBe(assignee);
     }
@@ -142,6 +145,7 @@ public class StateCommandHandlerForSaveTests : IntegratedTestBase
         workOrder.Creator = currentUser;
         workOrder.Assignee = assignee;
         workOrder.Title = "newtitle";
+        workOrder.Instructions = "Updated execution notes";
 
         var command = RemotableRequestTests.SimulateRemoteObject(new SaveDraftCommand(workOrder, currentUser));
         var remotedCommand = RemotableRequestTests.SimulateRemoteObject(command);
@@ -153,6 +157,7 @@ public class StateCommandHandlerForSaveTests : IntegratedTestBase
         var order = context3.Find<WorkOrder>(workOrder.Id) ?? throw new InvalidOperationException();
         order.Title.ShouldBe("newtitle");
         order.Description.ShouldBe(workOrder.Description);
+        order.Instructions.ShouldBe("Updated execution notes");
         order.Creator.ShouldBe(currentUser);
         order.Assignee.ShouldBe(assignee);
     }

--- a/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
+++ b/src/IntegrationTests/DataAccess/Mappings/WorkOrderMappingTests.cs
@@ -19,6 +19,7 @@ public class WorkOrderMappingTests
             Number = "WO-01",
             Title = "Fix lighting",
             Description = "Replace broken light bulbs in conference room",
+            Instructions = "Use ladder from closet B.\r\nTurn power off first.",
             RoomNumber = "CR-101",
             Status = WorkOrderStatus.Draft,
             Creator = creator
@@ -43,6 +44,7 @@ public class WorkOrderMappingTests
         rehydratedWorkOrder.Number.ShouldBe("WO-01");
         rehydratedWorkOrder.Title.ShouldBe("Fix lighting");
         rehydratedWorkOrder.Description.ShouldBe("Replace broken light bulbs in conference room");
+        rehydratedWorkOrder.Instructions.ShouldBe("Use ladder from closet B.\r\nTurn power off first.");
         rehydratedWorkOrder.RoomNumber.ShouldBe("CR-101");
         rehydratedWorkOrder.Status.ShouldBe(WorkOrderStatus.Draft);
         rehydratedWorkOrder.Creator.ShouldNotBeNull();
@@ -62,6 +64,7 @@ public class WorkOrderMappingTests
             Assignee = assignee,
             Title = "foo",
             Description = "bar",
+            Instructions = "Do the thing",
             RoomNumber = "123 a"
         };
         order.ChangeStatus(WorkOrderStatus.InProgress);
@@ -89,6 +92,7 @@ public class WorkOrderMappingTests
             rehydratedWorkOrder.Assignee!.Id.ShouldBe(order.Assignee.Id);
             rehydratedWorkOrder.Title.ShouldBe(order.Title);
             rehydratedWorkOrder.Description.ShouldBe(order.Description);
+            rehydratedWorkOrder.Instructions.ShouldBe(order.Instructions);
             rehydratedWorkOrder.Status.ShouldBe(order.Status);
             rehydratedWorkOrder.RoomNumber.ShouldBe(order.RoomNumber);
             rehydratedWorkOrder.Number.ShouldBe(order.Number);
@@ -108,6 +112,7 @@ public class WorkOrderMappingTests
             Assignee = assignee,
             Title = "foo",
             Description = "bar",
+            Instructions = "Do the thing",
             RoomNumber = "123 a"
         };
         order.ChangeStatus(WorkOrderStatus.InProgress);

--- a/src/IntegrationTests/McpServer/McpWorkOrderToolTests.cs
+++ b/src/IntegrationTests/McpServer/McpWorkOrderToolTests.cs
@@ -86,6 +86,35 @@ public class McpWorkOrderToolTests
     }
 
     [Test]
+    public async Task ShouldGetWorkOrderIncludingInstructionsWhenPresent()
+    {
+        var employee = new Employee("user1", "John", "Doe", "john@test.com");
+        var order = new WorkOrder
+        {
+            Creator = employee,
+            Number = "WO-101",
+            Title = "With instructions",
+            Description = "Desc",
+            Instructions = "Line one\nLine two",
+            RoomNumber = "202"
+        };
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(employee);
+            context.Add(order);
+            await context.SaveChangesAsync();
+        }
+
+        var bus = TestHost.GetRequiredService<IBus>();
+        var result = await WorkOrderTools.GetWorkOrder(bus, "WO-101");
+
+        result.ShouldContain("Line one");
+        result.ShouldContain("Line two");
+        result.ShouldContain("202");
+    }
+
+    [Test]
     public async Task ShouldReturnNotFoundForMissingWorkOrder()
     {
         var bus = TestHost.GetRequiredService<IBus>();
@@ -111,6 +140,33 @@ public class McpWorkOrderToolTests
 
         result.ShouldContain("New Work Order");
         result.ShouldContain("Fix the broken window");
+        result.ShouldContain("Draft");
+    }
+
+    [Test]
+    public async Task ShouldCreateDraftWorkOrderWithRoomAndInstructions()
+    {
+        var employee = new Employee("creator1", "Jane", "Smith", "jane@test.com");
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(employee);
+            await context.SaveChangesAsync();
+        }
+
+        var bus = TestHost.GetRequiredService<IBus>();
+        var numberGenerator = new WorkOrderNumberGenerator();
+        var result = await WorkOrderTools.CreateWorkOrder(
+            bus,
+            numberGenerator,
+            "Room work",
+            "Fix leak",
+            "creator1",
+            roomNumber: "B12",
+            instructions: "Shut water main first.");
+
+        result.ShouldContain("\"RoomNumber\": \"B12\"");
+        result.ShouldContain("Shut water main first.");
         result.ShouldContain("Draft");
     }
 

--- a/src/LlmGateway/WorkOrderTool.cs
+++ b/src/LlmGateway/WorkOrderTool.cs
@@ -9,7 +9,7 @@ namespace ClearMeasure.Bootcamp.LlmGateway;
 public class WorkOrderTool(IBus bus)
 {
     [Description("Retrieves a specific work order by its unique number. " +
-                 "Returns the full work order including title, description, room number, status, " +
+                 "Returns the full work order including title, description, optional execution instructions, room number, status, " +
                  "the employee who created it (creator), and the employee it is assigned to (assignee). " +
                  "Use this when the user asks about a specific work order, its details, status, or who is involved.")]
     public async Task<WorkOrder?> GetWorkOrderByNumber(

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -51,8 +51,8 @@ public class WorkOrderTools
         [Description("Title of the work order")] string title,
         [Description("Description of the work order")] string description,
         [Description("Username of the employee creating the work order")] string creatorUsername,
-        [Description("Optional execution instructions (how to perform the work)")] string? instructions = null,
-        [Description("Optional room number or location for the work order")] string? roomNumber = null)
+        [Description("Optional room number or location for the work order")] string? roomNumber = null,
+        [Description("Optional execution instructions (how to perform the work)")] string? instructions = null)
     {
         try
         {

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -44,7 +44,7 @@ public class WorkOrderTools
             new JsonSerializerOptions { WriteIndented = true });
     }
 
-    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts execution instructions and a room number for the location.")]
+    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts a room number and execution instructions for the location and how to perform the work.")]
     public static async Task<string> CreateWorkOrder(
         IBus bus,
         IWorkOrderNumberGenerator numberGenerator,

--- a/src/McpServer/Tools/WorkOrderTools.cs
+++ b/src/McpServer/Tools/WorkOrderTools.cs
@@ -44,13 +44,14 @@ public class WorkOrderTools
             new JsonSerializerOptions { WriteIndented = true });
     }
 
-    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts a room number for the location.")]
+    [McpServerTool(Name = "create-work-order"), Description("Creates a new draft work order. Requires a title, description, and the username of the creator. Optionally accepts execution instructions and a room number for the location.")]
     public static async Task<string> CreateWorkOrder(
         IBus bus,
         IWorkOrderNumberGenerator numberGenerator,
         [Description("Title of the work order")] string title,
         [Description("Description of the work order")] string description,
         [Description("Username of the employee creating the work order")] string creatorUsername,
+        [Description("Optional execution instructions (how to perform the work)")] string? instructions = null,
         [Description("Optional room number or location for the work order")] string? roomNumber = null)
     {
         try
@@ -65,6 +66,7 @@ public class WorkOrderTools
             {
                 Title = title,
                 Description = description,
+                Instructions = instructions,
                 Creator = creator,
                 Status = WorkOrderStatus.Draft,
                 Number = numberGenerator.GenerateNumber(),
@@ -195,6 +197,7 @@ public class WorkOrderTools
         wo.Number,
         wo.Title,
         wo.Description,
+        wo.Instructions,
         Status = wo.Status.FriendlyName,
         wo.RoomNumber,
         Creator = wo.Creator?.GetFullName(),

--- a/src/UI.Shared/Models/WorkOrderManageModel.cs
+++ b/src/UI.Shared/Models/WorkOrderManageModel.cs
@@ -20,6 +20,8 @@ public class WorkOrderManageModel
 
     [Required] public string? Description { get; set; }
 
+    [StringLength(4000)] public string? Instructions { get; set; }
+
     public bool IsReadOnly { get; set; }
 
     public string? AssignedDate { get; set; }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -58,6 +58,20 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="Instructions" class="form-label">Instructions:</label>
+                    <div>
+                        @if (!Model.IsReadOnly)
+                        {
+                            <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea"/>
+                        }
+                        else
+                        {
+                            <span data-testid="@Elements.Instructions" class="value">@Model.Instructions</span>
+                        }
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="RoomNumber" class="form-label">Room:</label>
                     <div>
                         <InputText data-testid="@Elements.RoomNumber" id="RoomNumber" @bind-Value="Model.RoomNumber" class="form-control input-text" disabled="@Model.IsReadOnly"/>
@@ -146,6 +160,7 @@
         AssigneeFullName,
         RoomNumber,
         Description,
+        Instructions,
         AssignedDate,
         CompletedDate,
         CreatedDate,

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -8,7 +8,7 @@
 
     <EditForm Model="@Model" OnValidSubmit="HandleSubmit">
         <DataAnnotationsValidator/>
-        <ValidationSummary/>
+        <ValidationSummary CssClass="validation-summary"/>
 
         <div class="form-container">
             <div class="form-grid">
@@ -66,7 +66,7 @@
                         }
                         else
                         {
-                            <span data-testid="@Elements.Instructions" class="value">@Model.Instructions</span>
+                            <span data-testid="@Elements.Instructions" class="value instructions-readonly">@Model.Instructions</span>
                         }
                     </div>
                 </div>

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -62,7 +62,8 @@
                     <div>
                         @if (!Model.IsReadOnly)
                         {
-                            <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea"/>
+                            <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" @bind-Value:event="oninput" class="form-control input-textarea"/>
+                            <ValidationMessage For="@(() => Model.Instructions)" class="instructions-validation-message"/>
                         }
                         else
                         {

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -63,7 +63,7 @@
                         @if (!Model.IsReadOnly)
                         {
                             <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" @bind-Value:event="oninput" class="form-control input-textarea"/>
-                            <ValidationMessage For="@(() => Model.Instructions)" class="instructions-validation-message"/>
+                            <ValidationMessage For="@(() => Model.Instructions)" class="validation-message instructions-validation-message"/>
                         }
                         else
                         {

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -62,7 +62,7 @@
                     <div>
                         @if (!Model.IsReadOnly)
                         {
-                            <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" @bind-Value:event="oninput" class="form-control input-textarea"/>
+                            <InputTextArea data-testid="@Elements.Instructions" id="Instructions" @bind-Value="Model.Instructions" class="form-control input-textarea"/>
                             <ValidationMessage For="@(() => Model.Instructions)" class="validation-message instructions-validation-message"/>
                         }
                         else

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -92,6 +92,7 @@ public partial class WorkOrderManage : AppComponentBase
             AssignedToUserName = workOrder.Assignee?.UserName,
             Title = workOrder.Title,
             Description = workOrder.Description,
+            Instructions = workOrder.Instructions,
             RoomNumber = workOrder.RoomNumber,
             CreatedDate = workOrder.CreatedDate?.ToString("G", CultureInfo.CurrentCulture),
             AssignedDate = workOrder.AssignedDate?.ToString("G", CultureInfo.CurrentCulture),
@@ -131,6 +132,7 @@ public partial class WorkOrderManage : AppComponentBase
         workOrder.Assignee = assignee;
         workOrder.Title = Model.Title;
         workOrder.Description = Model.Description;
+        workOrder.Instructions = Model.Instructions;
         workOrder.RoomNumber = Model.RoomNumber;
 
         var matchingCommand = new StateCommandList()

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.css
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.css
@@ -107,6 +107,11 @@
     border: 2px solid #e2e8f0;
 }
 
+.instructions-readonly {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 .readonly-info {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/src/UI/Server/Generated/Protos/Workorders.cs
+++ b/src/UI/Server/Generated/Protos/Workorders.cs
@@ -29,21 +29,21 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             "aW5nUmVwbHkSDwoHbWVzc2FnZRgBIAEoCSItChtHZXRXb3JrT3JkZXJCeU51",
             "bWJlclJlcXVlc3QSDgoGbnVtYmVyGAEgASgJIkYKGUdldFdvcmtPcmRlckJ5",
             "TnVtYmVyUmVwbHkSKQoKd29ya19vcmRlchgBIAEoCzIVLndvcmtvcmRlcnMu",
-            "V29ya09yZGVyIpMDCglXb3JrT3JkZXISDgoGbnVtYmVyGAEgASgJEg0KBXRp",
+            "V29ya09yZGVyIqkDCglXb3JrT3JkZXISDgoGbnVtYmVyGAEgASgJEg0KBXRp",
             "dGxlGAIgASgJEhMKC2Rlc2NyaXB0aW9uGAMgASgJEhMKC3Jvb21fbnVtYmVy",
             "GAQgASgJEhIKCnN0YXR1c19rZXkYBSABKAkSGAoQY3JlYXRvcl91c2VybmFt",
             "ZRgGIAEoCRIZChFhc3NpZ25lZV91c2VybmFtZRgHIAEoCRI6ChFhc3NpZ25l",
             "ZF9kYXRlX3V0YxgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBI",
             "AIgBARI5ChBjcmVhdGVkX2RhdGVfdXRjGAkgASgLMhouZ29vZ2xlLnByb3Rv",
             "YnVmLlRpbWVzdGFtcEgBiAEBEjsKEmNvbXBsZXRlZF9kYXRlX3V0YxgKIAEo",
-            "CzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIAogBAUIUChJfYXNzaWdu",
-            "ZWRfZGF0ZV91dGNCEwoRX2NyZWF0ZWRfZGF0ZV91dGNCFQoTX2NvbXBsZXRl",
-            "ZF9kYXRlX3V0YzKsAQoKV29ya09yZGVycxI2CgRQaW5nEhcud29ya29yZGVy",
-            "cy5QaW5nUmVxdWVzdBoVLndvcmtvcmRlcnMuUGluZ1JlcGx5EmYKFEdldFdv",
-            "cmtPcmRlckJ5TnVtYmVyEicud29ya29yZGVycy5HZXRXb3JrT3JkZXJCeU51",
-            "bWJlclJlcXVlc3QaJS53b3Jrb3JkZXJzLkdldFdvcmtPcmRlckJ5TnVtYmVy",
-            "UmVwbHlCJ6oCJENsZWFyTWVhc3VyZS5Cb290Y2FtcC5VSS5TZXJ2ZXIuR3Jw",
-            "Y2IGcHJvdG8z"));
+            "CzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIAogBARIUCgxpbnN0cnVj",
+            "dGlvbnMYCyABKAlCFAoSX2Fzc2lnbmVkX2RhdGVfdXRjQhMKEV9jcmVhdGVk",
+            "X2RhdGVfdXRjQhUKE19jb21wbGV0ZWRfZGF0ZV91dGMyrAEKCldvcmtPcmRl",
+            "cnMSNgoEUGluZxIXLndvcmtvcmRlcnMuUGluZ1JlcXVlc3QaFS53b3Jrb3Jk",
+            "ZXJzLlBpbmdSZXBseRJmChRHZXRXb3JrT3JkZXJCeU51bWJlchInLndvcmtv",
+            "cmRlcnMuR2V0V29ya09yZGVyQnlOdW1iZXJSZXF1ZXN0GiUud29ya29yZGVy",
+            "cy5HZXRXb3JrT3JkZXJCeU51bWJlclJlcGx5QieqAiRDbGVhck1lYXN1cmUu",
+            "Qm9vdGNhbXAuVUkuU2VydmVyLkdycGNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -51,14 +51,13 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.PingReply), global::ClearMeasure.Bootcamp.UI.Server.Grpc.PingReply.Parser, new[]{ "Message" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberRequest), global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberRequest.Parser, new[]{ "Number" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberReply), global::ClearMeasure.Bootcamp.UI.Server.Grpc.GetWorkOrderByNumberReply.Parser, new[]{ "WorkOrder" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder), global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder.Parser, new[]{ "Number", "Title", "Description", "RoomNumber", "StatusKey", "CreatorUsername", "AssigneeUsername", "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, new[]{ "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder), global::ClearMeasure.Bootcamp.UI.Server.Grpc.WorkOrder.Parser, new[]{ "Number", "Title", "Description", "RoomNumber", "StatusKey", "CreatorUsername", "AssigneeUsername", "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc", "Instructions" }, new[]{ "AssignedDateUtc", "CreatedDateUtc", "CompletedDateUtc" }, null, null, null)
           }));
     }
     #endregion
 
   }
   #region Messages
-  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PingRequest : pb::IMessage<PingRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -185,11 +184,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -204,11 +199,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -219,7 +210,6 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
 
   }
 
-  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PingReply : pb::IMessage<PingReply>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -375,11 +365,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -398,11 +384,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -417,7 +399,6 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
 
   }
 
-  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetWorkOrderByNumberRequest : pb::IMessage<GetWorkOrderByNumberRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -573,11 +554,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -596,11 +573,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -615,7 +588,6 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
 
   }
 
-  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetWorkOrderByNumberReply : pb::IMessage<GetWorkOrderByNumberReply>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -774,11 +746,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -800,11 +768,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -822,7 +786,6 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
 
   }
 
-  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WorkOrder : pb::IMessage<WorkOrder>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -867,6 +830,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       assignedDateUtc_ = other.assignedDateUtc_ != null ? other.assignedDateUtc_.Clone() : null;
       createdDateUtc_ = other.createdDateUtc_ != null ? other.createdDateUtc_.Clone() : null;
       completedDateUtc_ = other.completedDateUtc_ != null ? other.completedDateUtc_.Clone() : null;
+      instructions_ = other.instructions_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -996,6 +960,18 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       }
     }
 
+    /// <summary>Field number for the "instructions" field.</summary>
+    public const int InstructionsFieldNumber = 11;
+    private string instructions_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Instructions {
+      get { return instructions_; }
+      set {
+        instructions_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -1021,6 +997,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       if (!object.Equals(AssignedDateUtc, other.AssignedDateUtc)) return false;
       if (!object.Equals(CreatedDateUtc, other.CreatedDateUtc)) return false;
       if (!object.Equals(CompletedDateUtc, other.CompletedDateUtc)) return false;
+      if (Instructions != other.Instructions) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -1038,6 +1015,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       if (assignedDateUtc_ != null) hash ^= AssignedDateUtc.GetHashCode();
       if (createdDateUtc_ != null) hash ^= CreatedDateUtc.GetHashCode();
       if (completedDateUtc_ != null) hash ^= CompletedDateUtc.GetHashCode();
+      if (Instructions.Length != 0) hash ^= Instructions.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -1096,6 +1074,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
         output.WriteRawTag(82);
         output.WriteMessage(CompletedDateUtc);
       }
+      if (Instructions.Length != 0) {
+        output.WriteRawTag(90);
+        output.WriteString(Instructions);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1146,6 +1128,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
         output.WriteRawTag(82);
         output.WriteMessage(CompletedDateUtc);
       }
+      if (Instructions.Length != 0) {
+        output.WriteRawTag(90);
+        output.WriteString(Instructions);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1185,6 +1171,9 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
       }
       if (completedDateUtc_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(CompletedDateUtc);
+      }
+      if (Instructions.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Instructions);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -1237,6 +1226,9 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
         }
         CompletedDateUtc.MergeFrom(other.CompletedDateUtc);
       }
+      if (other.Instructions.Length != 0) {
+        Instructions = other.Instructions;
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -1248,11 +1240,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1305,6 +1293,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
             input.ReadMessage(CompletedDateUtc);
             break;
           }
+          case 90: {
+            Instructions = input.ReadString();
+            break;
+          }
         }
       }
     #endif
@@ -1316,11 +1308,7 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
+        switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1371,6 +1359,10 @@ namespace ClearMeasure.Bootcamp.UI.Server.Grpc {
               CompletedDateUtc = new global::Google.Protobuf.WellKnownTypes.Timestamp();
             }
             input.ReadMessage(CompletedDateUtc);
+            break;
+          }
+          case 90: {
+            Instructions = input.ReadString();
             break;
           }
         }

--- a/src/UI/Server/Grpc/WorkOrdersGrpcService.cs
+++ b/src/UI/Server/Grpc/WorkOrdersGrpcService.cs
@@ -42,6 +42,7 @@ public class WorkOrdersGrpcService(IBus bus) : WorkOrders.WorkOrdersBase
             Number = source.Number ?? "",
             Title = source.Title ?? "",
             Description = source.Description ?? "",
+            Instructions = source.Instructions ?? "",
             RoomNumber = source.RoomNumber ?? "",
             StatusKey = source.Status.Key,
             CreatorUsername = source.Creator?.UserName ?? "",

--- a/src/UI/Server/Protos/workorders.proto
+++ b/src/UI/Server/Protos/workorders.proto
@@ -36,4 +36,5 @@ message WorkOrder {
   optional google.protobuf.Timestamp assigned_date_utc = 8;
   optional google.protobuf.Timestamp created_date_utc = 9;
   optional google.protobuf.Timestamp completed_date_utc = 10;
+  string instructions = 11;
 }

--- a/src/UnitTests/Core/Model/WorkOrderTests.cs
+++ b/src/UnitTests/Core/Model/WorkOrderTests.cs
@@ -12,6 +12,7 @@ public class WorkOrderTests
         Assert.That(workOrder.Id, Is.EqualTo(Guid.Empty));
         Assert.That(workOrder.Title, Is.EqualTo(string.Empty));
         Assert.That(workOrder.Description, Is.EqualTo(string.Empty));
+        Assert.That(workOrder.Instructions, Is.EqualTo(null));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Draft));
         Assert.That(workOrder.Number, Is.EqualTo(null));
         Assert.That(workOrder.Creator, Is.EqualTo(null));
@@ -44,10 +45,12 @@ public class WorkOrderTests
         workOrder.Number = "Number";
         workOrder.Creator = creator;
         workOrder.Assignee = assignee;
+        workOrder.Instructions = "Step one";
 
         Assert.That(workOrder.Id, Is.EqualTo(guid));
         Assert.That(workOrder.Title, Is.EqualTo("Title"));
         Assert.That(workOrder.Description, Is.EqualTo("Description"));
+        Assert.That(workOrder.Instructions, Is.EqualTo("Step one"));
         Assert.That(workOrder.Status, Is.EqualTo(WorkOrderStatus.Complete));
         Assert.That(workOrder.Number, Is.EqualTo("Number"));
         Assert.That(workOrder.Creator, Is.EqualTo(creator));
@@ -70,6 +73,26 @@ public class WorkOrderTests
         var order = new WorkOrder();
         order.Description = longText;
         Assert.That(order.Description.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldTruncateTo4000CharactersOnInstructions()
+    {
+        var longText = new string('x', 4001);
+        var order = new WorkOrder();
+        order.Instructions = longText;
+        Assert.That(order.Instructions!.Length, Is.EqualTo(4000));
+    }
+
+    [Test]
+    public void ShouldNormalizeWhitespaceOnlyInstructionsToNull()
+    {
+        var order = new WorkOrder();
+        order.Instructions = "";
+        Assert.That(order.Instructions, Is.Null);
+
+        order.Instructions = "   ";
+        Assert.That(order.Instructions, Is.Null);
     }
 
     [Test]

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageInstructionsTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageInstructionsTests.cs
@@ -1,0 +1,106 @@
+using Bunit;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using MediatR;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Palermo.BlazorMvc;
+using Shouldly;
+using Toolbelt.Blazor.Extensions.DependencyInjection;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
+
+[TestFixture]
+public class WorkOrderManageInstructionsTests
+{
+    [Test]
+    public void ShouldRenderInstructionsTextAreaBetweenDescriptionAndRoomWhenEditable()
+    {
+        using var ctx = new TestContext();
+
+        var user = new Employee("jpalermo", "Jeffrey", "Palermo", "jp@example.com");
+        user.Id = Guid.NewGuid();
+
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IWorkOrderBuilder>(new StubWorkOrderBuilder());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
+        ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
+        ctx.Services.AddSpeechSynthesis();
+
+        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            component.Find($"[data-testid='{WorkOrderManage.Elements.Description}']").ShouldNotBeNull();
+            component.Find($"[data-testid='{WorkOrderManage.Elements.Instructions}']").ShouldNotBeNull();
+            component.Find($"[data-testid='{WorkOrderManage.Elements.RoomNumber}']").ShouldNotBeNull();
+        });
+
+        var markup = component.Markup;
+        var descIndex = markup.IndexOf($"data-testid=\"{WorkOrderManage.Elements.Description}\"", StringComparison.Ordinal);
+        var instrIndex = markup.IndexOf($"data-testid=\"{WorkOrderManage.Elements.Instructions}\"", StringComparison.Ordinal);
+        var roomIndex = markup.IndexOf($"data-testid=\"{WorkOrderManage.Elements.RoomNumber}\"", StringComparison.Ordinal);
+        descIndex.ShouldBeGreaterThan(0);
+        instrIndex.ShouldBeGreaterThan(descIndex);
+        roomIndex.ShouldBeGreaterThan(instrIndex);
+
+        var textarea = component.Find($"textarea[data-testid='{WorkOrderManage.Elements.Instructions}']");
+        (textarea.GetAttribute("class") ?? "").ShouldContain("input-textarea");
+    }
+
+    private class StubBus() : Bus(null!)
+    {
+        public override Task Publish(INotification notification) => Task.CompletedTask;
+
+        public override Task<TResponse> Send<TResponse>(IRequest<TResponse> request)
+        {
+            if (request is EmployeeGetAllQuery)
+            {
+                var employees = Array.Empty<Employee>();
+                return Task.FromResult<TResponse>((TResponse)(object)employees);
+            }
+
+            if (request is WorkOrderAttachmentsQuery)
+            {
+                var attachments = Array.Empty<WorkOrderAttachment>();
+                return Task.FromResult<TResponse>((TResponse)(object)attachments);
+            }
+
+            throw new NotImplementedException($"Unhandled request type: {request.GetType().Name}");
+        }
+    }
+
+    private class StubWorkOrderBuilder : IWorkOrderBuilder
+    {
+        public WorkOrder CreateNewWorkOrder(Employee creator)
+        {
+            return new WorkOrder
+            {
+                Id = Guid.NewGuid(),
+                Number = "WO-TEST",
+                Status = WorkOrderStatus.Draft,
+                Creator = creator,
+                Title = "Test title"
+            };
+        }
+    }
+
+    private class StubUserSession(Employee user) : IUserSession
+    {
+        public Task<Employee?> GetCurrentUserAsync() => Task.FromResult<Employee?>(user);
+    }
+
+    private class StubTranslationService : ITranslationService
+    {
+        public Task<string> TranslateAsync(string text, string targetLanguageCode) => Task.FromResult(text);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional **Instructions** on work orders (max 4000 characters): persisted end-to-end from domain through EF and DbUp migration `028_AddInstructionsToWorkOrder.sql`, editable on **Maintain work order** between Description and Room with `[StringLength(4000)]` validation, read-only as static text when the screen is read-only (with `white-space: pre-wrap` for multi-line notes). gRPC `WorkOrder` message gains field **11** `instructions`; MCP `create-work-order` accepts optional `instructions` after `roomNumber` so positional callers (e.g. `TestHost`) remain correct. LLM tool description mentions instructions.

## Follow-up (CI)

- Restored parameter order on `WorkOrderTools.CreateWorkOrder` (`roomNumber` then `instructions`).
- `ValidationSummary` uses `CssClass="validation-summary"` so Playwright acceptance tests can assert validation.
- Added MCP integration tests for instructions on get/create.

## Testing

- Integration: `McpWorkOrderToolTests` extended; MCP subset run locally.
- CI should re-run on branch push.

Closes #6178
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ece5eac-e5b5-4e5e-a175-c25557d8c679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ece5eac-e5b5-4e5e-a175-c25557d8c679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

