### PR TITLE
Force capitalize all names in the login drop-down (#6261)

### DIFF
--- a/src/UnitTests/UI.Shared/LoginDisplayNameFormatterTests.cs
+++ b/src/UnitTests/UI.Shared/LoginDisplayNameFormatterTests.cs
@@ -35,4 +35,10 @@ public class LoginDisplayNameFormatterTests
     {
         LoginDisplayNameFormatter.FormatForLoginDropdown("  \t ").ShouldBe("  \t ".ToUpperInvariant());
     }
+
+    [Test]
+    public void FormatForLoginDropdown_HyphenAndApostrophe_UppercasesAllLetters()
+    {
+        LoginDisplayNameFormatter.FormatForLoginDropdown("Jean-Luc O'Brien").ShouldBe("JEAN-LUC O'BRIEN");
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #6261 requires display-only **consistent casing** for **Select Church Member** on the login route so mixed-case locally stored names match mainframe **all-caps** names, without changing stored data or any other UI.

`Login.razor` already binds option **values** to `employee.UserName` and option **labels** to `GetLoginDropdownDisplayName(employee)`, which delegates to `LoginDisplayNameFormatter.FormatForLoginDropdown` (`ToUpperInvariant()`). That wiring matches the work item technical design; no Razor or domain changes were required.

This PR adds a focused **unit test** for hyphen and apostrophe in composed display names so the formatter stays regression-safe.

## Files changed

| File | Change |
|------|--------|
| `src/UnitTests/UI.Shared/LoginDisplayNameFormatterTests.cs` | New test `FormatForLoginDropdown_HyphenAndApostrophe_UppercasesAllLetters` |

## Testing

- `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` with `DATABASE_ENGINE=SQLite` — **green** (262 unit, 108 integration tests).

Closes #6261

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-228b7cf4-5ef6-4b0b-b3bb-1d982f54a06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-228b7cf4-5ef6-4b0b-b3bb-1d982f54a06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

