### PR TITLE
New API endpoint GET /api/version for build and deployment metadata (#6267)

### DIFF
--- a/src/UI/Api/Controllers/VersionController.cs
+++ b/src/UI/Api/Controllers/VersionController.cs
@@ -21,19 +21,26 @@ namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
 public class VersionController(IHostEnvironment hostEnvironment) : ControllerBase
 {
     /// <summary>
-    /// Returns assembly, runtime, and host metadata.
+    /// Returns assembly, runtime, and host metadata from the application entry assembly when present (for example UI.Server), with a fallback to this assembly for unit-test and tool hosts.
     /// </summary>
     [HttpGet]
     [AllowAnonymous]
     [OutputCache(PolicyName = OutputCachePolicyNames.VersionMetadata)]
     public IActionResult Get()
     {
-        var assembly = Assembly.GetExecutingAssembly();
+        var assembly = Assembly.GetEntryAssembly() ?? typeof(VersionController).Assembly;
         var assemblyVersion = assembly.GetName().Version?.ToString();
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var buildConfiguration =
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
         var payload = new VersionMetadataResponse(
             AssemblyVersion: assemblyVersion,
             InformationalVersion: informationalVersion,
+            BuildConfiguration: buildConfiguration,
             Environment: hostEnvironment.EnvironmentName,
             MachineName: Environment.MachineName,
             FrameworkDescription: RuntimeInformation.FrameworkDescription);
@@ -48,9 +55,16 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
 /// <summary>
 /// JSON payload for <c>GET /api/version</c> and <c>GET /api/v1.0/version</c>.
 /// </summary>
+/// <param name="AssemblyVersion">File/assembly version from the host entry assembly when available.</param>
+/// <param name="InformationalVersion">Source control / informational version from the host entry assembly when available.</param>
+/// <param name="BuildConfiguration">Whether this binary was built as Debug or Release.</param>
+/// <param name="Environment">Current host environment name (for example Development, Production).</param>
+/// <param name="MachineName">Machine name of the running host process.</param>
+/// <param name="FrameworkDescription">.NET runtime description string.</param>
 public record VersionMetadataResponse(
     string? AssemblyVersion,
     string? InformationalVersion,
+    string BuildConfiguration,
     string? Environment,
     string MachineName,
     string FrameworkDescription);

--- a/src/UnitTests/UI.Api/VersionControllerTests.cs
+++ b/src/UnitTests/UI.Api/VersionControllerTests.cs
@@ -32,6 +32,11 @@ public class VersionControllerTests
         payload.ShouldNotBeNull();
         payload!.AssemblyVersion.ShouldNotBeNullOrEmpty();
         payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+#if DEBUG
+        payload.BuildConfiguration.ShouldBe("Debug");
+#else
+        payload.BuildConfiguration.ShouldBe("Release");
+#endif
         payload.Environment.ShouldBe("TestEnvironment");
         payload.MachineName.ShouldBe(Environment.MachineName);
         payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the existing anonymous `GET /api/version` (and `GET /api/v1.0/version`) contract so operators see version metadata from the **host entry assembly** (typically UI.Server when the API runs in the Blazor host), with a safe fallback when `GetEntryAssembly()` is null. Adds **`buildConfiguration`** (`"Debug"` or `"Release"`) so deployment checks can distinguish compiled configuration without new MSBuild plumbing.

## Files changed

- `src/UI/Api/Controllers/VersionController.cs` — resolve assembly via `Assembly.GetEntryAssembly() ?? typeof(VersionController).Assembly`; populate `BuildConfiguration` with `#if DEBUG`; extend `VersionMetadataResponse` and XML documentation.
- `src/UnitTests/UI.Api/VersionControllerTests.cs` — assert `BuildConfiguration` matches the test run configuration.

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — build succeeded; unit tests 261 passed; integration tests 108 passed.

Closes #6267
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b12b2fc-9c32-4feb-9595-ff6d57bd53ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b12b2fc-9c32-4feb-9595-ff6d57bd53ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

