### PR TITLE
New API endpoint POST /api/tools/guid-generator for on-demand GUID creation (#6268)

### DIFF
--- a/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
@@ -1,0 +1,42 @@
+using System.Net;
+using System.Text.Json;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class GuidGeneratorEndpointIntegrationTests
+{
+    private DetailedHealthWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DetailedHealthWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_PostGuidGenerator()
+    {
+        var response = await _client!.PostAsync("/api/tools/guid-generator", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.GetProperty("count").GetInt32().ShouldBe(1);
+        doc.RootElement.GetProperty("guids").GetArrayLength().ShouldBe(1);
+    }
+}

--- a/src/UI/Api/Controllers/GuidGeneratorController.cs
+++ b/src/UI/Api/Controllers/GuidGeneratorController.cs
@@ -1,0 +1,62 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates one or more RFC 4122 GUIDs for API clients.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/guid-generator")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/guid-generator")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class GuidGeneratorController : ControllerBase
+{
+    private const int MinCount = 1;
+    private const int MaxCount = 100;
+
+    /// <summary>
+    /// Creates new GUIDs. Optional <c>count</c> in the query string (1–100, default 1) takes precedence
+    /// over an optional JSON body <c>{"count": n}</c>.
+    /// </summary>
+    [HttpPost]
+    [AllowAnonymous]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(GuidGeneratorResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Post([FromQuery] int? count, [FromBody] GuidGeneratorRequest? body)
+    {
+        var resolved = count ?? body?.Count;
+        if (!resolved.HasValue)
+            resolved = MinCount;
+
+        var c = resolved.Value;
+        if (c < MinCount || c > MaxCount)
+        {
+            return Problem(
+                detail: $"count must be between {MinCount} and {MaxCount} (inclusive).",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var guids = new string[c];
+        for (var i = 0; i < c; i++)
+            guids[i] = Guid.NewGuid().ToString("D");
+
+        return Ok(new GuidGeneratorResponse(c, guids));
+    }
+}
+
+/// <summary>
+/// Optional JSON body for POST <c>/api/tools/guid-generator</c>.
+/// </summary>
+public sealed record GuidGeneratorRequest(int? Count);
+
+/// <summary>
+/// Response payload listing generated GUIDs in the standard 32-digit hyphenated format.
+/// </summary>
+public sealed record GuidGeneratorResponse(int Count, IReadOnlyList<string> Guids);

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -92,4 +92,29 @@ public class ApiKeyAuthenticationWebTests
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return401_When_GuidGeneratorCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/api/tools/guid-generator", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_GuidGeneratorCalledWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var response = await client.PostAsync("/api/tools/guid-generator", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }

--- a/src/UnitTests/UI.Server/GuidGeneratorControllerWebTests.cs
+++ b/src/UnitTests/UI.Server/GuidGeneratorControllerWebTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public sealed class GuidGeneratorControllerWebTests
+{
+    private ApiVersioningRoutingWebApplicationFactory? _factory;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp() => _factory = new ApiVersioningRoutingWebApplicationFactory();
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _factory?.Dispose();
+
+    [Test]
+    public async Task Should_ReturnOneGuid_When_PostWithNoBody()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.PostAsync("/api/tools/guid-generator", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        dto.ShouldNotBeNull();
+        dto!.Count.ShouldBe(1);
+        dto.Guids.Count.ShouldBe(1);
+        Guid.TryParse(dto.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_ReturnOneGuid_When_PostWithEmptyJsonObject()
+    {
+        using var client = _factory!.CreateClient();
+        using var content = new StringContent("{}", Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/api/tools/guid-generator", content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        dto!.Count.ShouldBe(1);
+        dto.Guids.Count.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task Should_ReturnDistinctGuids_When_CountIsThree()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.PostAsync("/api/tools/guid-generator?count=3", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        dto!.Count.ShouldBe(3);
+        dto.Guids.Count.ShouldBe(3);
+        dto.Guids.Distinct().Count().ShouldBe(3);
+        dto.Guids.All(g => g.Length == 36 && g.Count(c => c == '-') == 4).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_MatchUnversioned_When_PostedToVersionedRoute()
+    {
+        using var client = _factory!.CreateClient();
+        var unversioned = await client.PostAsync("/api/tools/guid-generator?count=2", null);
+        var versioned = await client.PostAsync("/api/v1.0/tools/guid-generator?count=2", null);
+
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var a = await unversioned.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        var b = await versioned.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        a!.Count.ShouldBe(2);
+        b!.Count.ShouldBe(2);
+    }
+
+    [Test]
+    public async Task Should_UseQueryCount_When_BothQueryAndBodyPresent()
+    {
+        using var client = _factory!.CreateClient();
+        using var content = JsonContent.Create(new { count = 2 });
+        var response = await client.PostAsync("/api/tools/guid-generator?count=5", content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        dto!.Count.ShouldBe(5);
+        dto.Guids.Count.ShouldBe(5);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_CountIsZero()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.PostAsync("/api/tools/guid-generator?count=0", null);
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_CountExceedsMax()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.PostAsync("/api/tools/guid-generator?count=101", null);
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_CountIsNegative()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.PostAsync("/api/tools/guid-generator?count=-1", null);
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400OrUnprocessable_When_CountIsNotIntegerInQuery()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.PostAsync("/api/tools/guid-generator?count=abc", null);
+        (response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.UnprocessableEntity)
+            .ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `POST /api/tools/guid-generator` (and `POST /api/v1.0/tools/guid-generator`) to generate one or more RFC 4122 GUIDs as JSON. Optional `count` defaults to 1, is capped at 100, and can be supplied via query string or JSON body `{ "count": n }`. When both are present, **query wins**.

The route uses `[AllowAnonymous]`, `[EnableRateLimiting]` for `/api/*` sliding window limits, and returns `ProblemDetails` with HTTP 400 for invalid counts, matching existing bulk-import style errors. GUIDs are serialized with `ToString("D")`. When API key authentication is enabled, this path requires `X-Api-Key` like other non-public `/api/*` routes (not added to public path list).

## Files changed

- `src/UI/Api/Controllers/GuidGeneratorController.cs` — New controller, request/response records, POST handler.
- `src/UnitTests/UI.Server/GuidGeneratorControllerWebTests.cs` — Web tests (defaults, count, versioning, validation, query vs body precedence, non-integer query).
- `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` — 401 without key, 200 with key when API key enforcement is on.
- `src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs` — Smoke test through full host pipeline.

## Testing

- `DATABASE_ENGINE=SQLite` — `pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` (unit + integration tests green).
- Targeted runs: `GuidGenerator*` and extended API key web tests.

Closes #6268
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b970ef0-00b3-498b-b6a2-781d57fa8251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b970ef0-00b3-498b-b6a2-781d57fa8251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

