### PR TITLE
New API endpoint GET /api/tools/random for configurable random data generation (#6272)

### DIFF
--- a/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ToolsRandomEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200_ForEachSupportedType_OnUnversionedRoute()
+    {
+        await AssertRandomResponseAsync("number", el =>
+        {
+            el.GetProperty("type").GetString().ShouldBe("number");
+            var n = el.GetProperty("value").GetInt32();
+            n.ShouldBeGreaterThanOrEqualTo(0);
+            n.ShouldBeLessThanOrEqualTo(int.MaxValue - 1);
+        });
+
+        await AssertRandomResponseAsync("string", el =>
+        {
+            el.GetProperty("type").GetString().ShouldBe("string");
+            var s = el.GetProperty("value").GetString();
+            s.ShouldNotBeNull();
+            s!.Length.ShouldBe(16);
+            Regex.IsMatch(s, @"^[A-Za-z0-9]{16}$").ShouldBeTrue();
+        });
+
+        await AssertRandomResponseAsync("uuid", el =>
+        {
+            el.GetProperty("type").GetString().ShouldBe("uuid");
+            var s = el.GetProperty("value").GetString();
+            Guid.TryParse(s, out _).ShouldBeTrue();
+        });
+
+        await AssertRandomResponseAsync("color", el =>
+        {
+            el.GetProperty("type").GetString().ShouldBe("color");
+            var s = el.GetProperty("value").GetString();
+            Regex.IsMatch(s!, "^#[0-9A-F]{6}$").ShouldBeTrue();
+        });
+    }
+
+    [Test]
+    public async Task Should_AcceptTypeCaseInsensitively_OnUnversionedRoute()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=NUMBER");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return200_ForSupportedTypes_OnVersionedV1Route()
+    {
+        var numberResponse = await _client!.GetAsync("/api/v1.0/tools/random?type=number");
+        numberResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var uuidResponse = await _client.GetAsync("/api/v1.0/tools/random?type=uuid");
+        uuidResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return400_WithProblemDetails_When_TypeInvalid()
+    {
+        var missing = await _client!.GetAsync("/api/tools/random");
+        missing.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        var empty = await _client.GetAsync("/api/tools/random?type=");
+        empty.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        var unknown = await _client.GetAsync("/api/tools/random?type=nope");
+        unknown.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        var mediaType = unknown.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("problem");
+    }
+
+    [Test]
+    public async Task Should_NotUseConditionalGetCaching_When_RepeatedGets()
+    {
+        var first = await _client!.GetAsync("/api/tools/random?type=uuid");
+        var second = await _client.GetAsync("/api/tools/random?type=uuid");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        second.StatusCode.ShouldBe(HttpStatusCode.OK);
+        first.Headers.Contains("ETag").ShouldBeFalse();
+        second.Headers.Contains("ETag").ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_AllowAnonymous_When_ApiKeyMiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/tools/random?type=number");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/tools/random?type=uuid");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private async Task AssertRandomResponseAsync(string type, Action<JsonElement> assert)
+    {
+        var response = await _client!.GetAsync($"/api/tools/random?type={type}");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        response.Headers.Contains("ETag").ShouldBeFalse();
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        assert(doc.RootElement);
+    }
+}

--- a/src/UI/Api/Controllers/ToolsRandomController.cs
+++ b/src/UI/Api/Controllers/ToolsRandomController.cs
@@ -1,0 +1,85 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates random values for integrations and developer tooling.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/random")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/random")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class ToolsRandomController : ControllerBase
+{
+    private const int RandomStringDefaultLength = 16;
+    private const string RandomStringCharset =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    private const int RandomNumberInclusiveMax = int.MaxValue - 1;
+
+    private const string AllowedTypesDescription =
+        "The type query parameter is required and must be one of: number, string, uuid, color (case-insensitive).";
+
+    /// <summary>
+    /// Returns a random value of the requested <paramref name="type"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>number</b> — inclusive integer from 0 through 2_147_483_646 (<see cref="int.MaxValue"/> minus 1), via <see cref="Random.Shared"/>.</para>
+    /// <para><b>string</b> — length 16, characters from A–Z, a–z, and 0–9.</para>
+    /// <para><b>uuid</b> — <see cref="Guid"/> in lowercase with hyphens, no braces (standard "D" format).</para>
+    /// <para><b>color</b> — CSS hex <c>#RRGGBB</c> using uppercase hexadecimal digits.</para>
+    /// </remarks>
+    [HttpGet]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(RandomToolResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return Problem(
+                detail: AllowedTypesDescription,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        switch (type.Trim().ToLowerInvariant())
+        {
+            case "number":
+                var n = Random.Shared.Next(RandomNumberInclusiveMax + 1);
+                return ConditionalGetEtag.JsonContent(new RandomToolResponse("number", n));
+            case "string":
+                var chars = new char[RandomStringDefaultLength];
+                for (var i = 0; i < chars.Length; i++)
+                {
+                    chars[i] = RandomStringCharset[Random.Shared.Next(RandomStringCharset.Length)];
+                }
+
+                return ConditionalGetEtag.JsonContent(new RandomToolResponse("string", new string(chars)));
+            case "uuid":
+                var id = Guid.NewGuid().ToString("D");
+                return ConditionalGetEtag.JsonContent(new RandomToolResponse("uuid", id));
+            case "color":
+                Span<byte> rgb = stackalloc byte[3];
+                Random.Shared.NextBytes(rgb);
+                var hex = Convert.ToHexString(rgb);
+                return ConditionalGetEtag.JsonContent(new RandomToolResponse("color", "#" + hex));
+            default:
+                return Problem(
+                    detail: $"Unknown type '{type.Trim()}'. {AllowedTypesDescription}",
+                    statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/tools/random</c> and <c>GET /api/v1.0/tools/random</c>.
+/// </summary>
+/// <param name="Type">Canonical type key (lowercase).</param>
+/// <param name="Value">Generated value; numeric types serialize as JSON numbers.</param>
+public record RandomToolResponse(string Type, object Value);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and tools random endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -84,13 +84,34 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         if (segments.Length >= 3
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
+            if (IsToolsRandomPath(segments))
+                return true;
+
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
         }
 
+        if (IsToolsRandomPath(segments))
+            return true;
+
         return false;
+    }
+
+    private static bool IsToolsRandomPath(string[] segments)
+    {
+        if (segments.Length < 3)
+            return false;
+
+        if (segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("random", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return segments.Length >= 4
+               && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+               && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+               && segments[3].Equals("random", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool FixedTimeEqualsUtf8(string expected, string provided)

--- a/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
+++ b/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsRandomControllerTests
+{
+    private static JsonSerializerOptions JsonOptions => ConditionalGetEtag.JsonSerializerOptions;
+
+    [Test]
+    public void Get_Should_Return200_WithValidJsonShape_When_TypeIsNumber()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("number");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<JsonElement>(content.Content!, JsonOptions);
+        payload.GetProperty("type").GetString().ShouldBe("number");
+        var n = payload.GetProperty("value").GetInt32();
+        n.ShouldBeGreaterThanOrEqualTo(0);
+        n.ShouldBeLessThanOrEqualTo(int.MaxValue - 1);
+    }
+
+    [Test]
+    public void Get_Should_Return200_WithValidJsonShape_When_TypeIsString()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("string");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        var payload = JsonSerializer.Deserialize<JsonElement>(content.Content!, JsonOptions);
+        payload.GetProperty("type").GetString().ShouldBe("string");
+        var s = payload.GetProperty("value").GetString();
+        s.ShouldNotBeNull();
+        s!.Length.ShouldBe(16);
+        Regex.IsMatch(s, @"^[A-Za-z0-9]{16}$").ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_Should_Return200_WithValidJsonShape_When_TypeIsUuid()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("uuid");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        var payload = JsonSerializer.Deserialize<JsonElement>(content.Content!, JsonOptions);
+        payload.GetProperty("type").GetString().ShouldBe("uuid");
+        var s = payload.GetProperty("value").GetString();
+        s.ShouldNotBeNull();
+        Guid.TryParse(s, out _).ShouldBeTrue();
+        s!.ShouldNotContain("{");
+    }
+
+    [Test]
+    public void Get_Should_Return200_WithValidJsonShape_When_TypeIsColor()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get("color");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        var payload = JsonSerializer.Deserialize<JsonElement>(content.Content!, JsonOptions);
+        payload.GetProperty("type").GetString().ShouldBe("color");
+        var s = payload.GetProperty("value").GetString();
+        s.ShouldNotBeNull();
+        Regex.IsMatch(s!, "^#[0-9A-F]{6}$").ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_Should_Return400_When_TypeIsMissing()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(null);
+
+        AssertProblem400(result);
+    }
+
+    [Test]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("foo")]
+    public void Get_Should_Return400_When_TypeIsEmptyOrUnknown(string? type)
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(type);
+
+        AssertProblem400(result);
+    }
+
+    [Test]
+    [TestCase("NUMBER")]
+    [TestCase("Uuid")]
+    [TestCase("CoLoR")]
+    public void Get_Should_AcceptTypeCaseInsensitively_When_TypeVariesByCasing(string type)
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(type);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+    }
+
+    private static ToolsRandomController CreateController() =>
+        new()
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+    private static void AssertProblem400(IActionResult result)
+    {
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+        var details = objectResult.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldNotBeNullOrWhiteSpace();
+        details.Detail!.ShouldContain("number");
+        details.Detail.ShouldContain("string");
+        details.Detail.ShouldContain("uuid");
+        details.Detail.ShouldContain("color");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -14,8 +14,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]
     [TestCase("/api/v1.0/time", true)]
-    [TestCase("/api/ping", true)]
-    [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/random", true)]
+    [TestCase("/api/v1.0/tools/random", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
## Summary

Implements anonymous `GET /api/tools/random` (and `GET /api/v1.0/tools/random`) with a required `type` query parameter: `number`, `string`, `uuid`, or `color` (case-insensitive). Responses are JSON `{ "type": "...", "value": ... }` using the same serializer options as other conditional-GET helpers (`ConditionalGetEtag.JsonSerializerOptions`). No ETags, `OutputCache`, or 304 behavior on this action.

`ApiKeyAuthenticationMiddleware` treats `/api/tools/random` and `/api/v1.0/tools/random` as public when optional API key enforcement is enabled, consistent with `ping`, `time`, and `version`.

## Files changed

| File | Change |
|------|--------|
| `src/UI/Api/Controllers/ToolsRandomController.cs` | New controller: random payloads, validation via `Problem(..., 400)`. |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Skip API key validation for tools random routes. |
| `src/UnitTests/UI.Api/ToolsRandomControllerTests.cs` | Controller unit tests. |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Path classification tests for tools random. |
| `src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs` | HTTP integration tests via `DiagnosticsWebApplicationFactory`. |

## Testing

- `DATABASE_ENGINE=SQLite pwsh ./PrivateBuild.ps1` — green.
- Targeted: `dotnet test` UnitTests + IntegrationTests filter `ToolsRandom`.

Closes #6272