### PR TITLE
New API endpoint GET /api/status/environment for runtime environment diagnostics (#6273)

### DIFF
--- a/src/IntegrationTests/Api/EnvironmentStatusApiKeyProtectedWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/EnvironmentStatusApiKeyProtectedWebApplicationFactory.cs
@@ -1,0 +1,33 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server with API key middleware enabled for public-path verification.
+/// </summary>
+public sealed class EnvironmentStatusApiKeyProtectedWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "true",
+                ["ApiKeyAuthentication:ValidationKey"] = ApiKeyProtectedWebApplicationFactory.TestApiKey,
+                ["EnvironmentStatus:IncludedEnvironmentVariables:0"] = "ENV6273_INTEGRATION_PROBE"
+            });
+        });
+    }
+}

--- a/src/IntegrationTests/Api/EnvironmentStatusEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/EnvironmentStatusEndpointIntegrationTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class EnvironmentStatusEndpointIntegrationTests
+{
+    private const string ProbeName = "ENV6273_INTEGRATION_PROBE";
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable(ProbeName, null);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetEnvironmentStatusUnversioned()
+    {
+        await using var factory = new EnvironmentStatusWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/status/environment");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("osDescription", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("processorCount", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("clrVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("frameworkDescription", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("environmentVariables", out var envVars).ShouldBeTrue();
+        envVars.ValueKind.ShouldBe(JsonValueKind.Array);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetEnvironmentStatusVersioned()
+    {
+        await using var factory = new EnvironmentStatusWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1.0/status/environment");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+    }
+
+    [Test]
+    public async Task Should_NotExposeSecretVariableValue_When_ProbeIsSet()
+    {
+        Environment.SetEnvironmentVariable(ProbeName, "super-secret-token-must-not-appear-in-body");
+        await using var factory = new EnvironmentStatusWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/status/environment");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var raw = await response.Content.ReadAsStringAsync();
+        raw.ShouldNotContain("super-secret-token");
+        raw.ShouldNotContain("must-not-appear");
+
+        var payload = JsonSerializer.Deserialize<EnvironmentStatusResponse>(
+            raw,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.EnvironmentVariables.ShouldContain(e =>
+            e.Name == ProbeName && e.IsSet);
+    }
+
+    [Test]
+    public async Task Should_AllowAnonymous_When_ApiKeyMiddlewareEnabled()
+    {
+        Environment.SetEnvironmentVariable(ProbeName, null);
+        await using var factory = new EnvironmentStatusApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/status/environment");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/status/environment");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/IntegrationTests/Api/EnvironmentStatusWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/EnvironmentStatusWebApplicationFactory.cs
@@ -1,0 +1,32 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server for <c>/api/status/environment</c> integration tests with a dedicated allowlist entry.
+/// </summary>
+public sealed class EnvironmentStatusWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = "",
+                ["EnvironmentStatus:IncludedEnvironmentVariables:0"] = "ENV6273_INTEGRATION_PROBE"
+            });
+        });
+    }
+}

--- a/src/UI/Api/Controllers/EnvironmentStatusController.cs
+++ b/src/UI/Api/Controllers/EnvironmentStatusController.cs
@@ -1,0 +1,50 @@
+using System.Runtime.InteropServices;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a redacted snapshot of runtime and host environment metadata for operators and automation.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/status/environment")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/status/environment")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class EnvironmentStatusController(IOptions<EnvironmentStatusOptions> options) : ControllerBase
+{
+    /// <summary>
+    /// Returns OS description, processor count, CLR/runtime identifiers, and allowlisted environment variable presence (values omitted).
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var names = options.Value.IncludedEnvironmentVariables;
+        var entries = new List<EnvironmentVariableStatusEntry>(names.Count);
+        foreach (var name in names)
+        {
+            var raw = Environment.GetEnvironmentVariable(name);
+            var isSet = !string.IsNullOrEmpty(raw);
+            entries.Add(new EnvironmentVariableStatusEntry(name, isSet));
+        }
+
+        var payload = new EnvironmentStatusResponse(
+            OsDescription: RuntimeInformation.OSDescription,
+            ProcessorCount: Environment.ProcessorCount,
+            ClrVersion: Environment.Version.ToString(),
+            FrameworkDescription: RuntimeInformation.FrameworkDescription,
+            EnvironmentVariables: entries);
+
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/EnvironmentStatusModels.cs
+++ b/src/UI/Api/EnvironmentStatusModels.cs
@@ -1,0 +1,16 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/status/environment</c> and <c>GET /api/v1.0/status/environment</c>.
+/// </summary>
+public record EnvironmentStatusResponse(
+    string OsDescription,
+    int ProcessorCount,
+    string ClrVersion,
+    string FrameworkDescription,
+    IReadOnlyList<EnvironmentVariableStatusEntry> EnvironmentVariables);
+
+/// <summary>
+/// Presence of a single allowlisted environment variable without exposing its value.
+/// </summary>
+public record EnvironmentVariableStatusEntry(string Name, bool IsSet);

--- a/src/UI/Api/EnvironmentStatusOptions.cs
+++ b/src/UI/Api/EnvironmentStatusOptions.cs
@@ -1,0 +1,17 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Configuration for <c>GET /api/status/environment</c>: which environment variable names may appear
+/// (values are never exposed, only presence).
+/// </summary>
+public sealed class EnvironmentStatusOptions
+{
+    /// <summary>Configuration section name (root <c>EnvironmentStatus</c> in appsettings).</summary>
+    public const string SectionName = "EnvironmentStatus";
+
+    /// <summary>
+    /// Names of environment variables to report as <see cref="EnvironmentVariableStatusEntry"/> items.
+    /// Only these names are considered; full enumeration is never performed.
+    /// </summary>
+    public List<string> IncludedEnvironmentVariables { get; set; } = [];
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and environment status endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -71,6 +71,21 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
         {
             return false;
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("status", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("environment", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 4
+            && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("status", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals("environment", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         if (segments.Length == 2)

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -56,6 +56,22 @@ builder.Services.Configure<ApiKeyAuthenticationOptions>(
     builder.Configuration.GetSection(ApiKeyAuthenticationOptions.SectionName));
 builder.Services.Configure<DiagnosticsFeatureFlagsOptions>(
     builder.Configuration.GetSection(DiagnosticsFeatureFlagsOptions.SectionName));
+builder.Services.Configure<EnvironmentStatusOptions>(
+    builder.Configuration.GetSection(EnvironmentStatusOptions.SectionName));
+builder.Services.PostConfigure<EnvironmentStatusOptions>(o =>
+{
+    if (o.IncludedEnvironmentVariables.Count > 0)
+    {
+        return;
+    }
+
+    o.IncludedEnvironmentVariables =
+    [
+        "ASPNETCORE_ENVIRONMENT",
+        "DOTNET_ENVIRONMENT",
+        "DOTNET_RUNNING_IN_CONTAINER"
+    ];
+});
 builder.Services.PostConfigure<ApiKeyAuthenticationOptions>(o =>
     o.ValidationKey = string.IsNullOrWhiteSpace(o.ValidationKey) ? null : o.ValidationKey.Trim());
 builder.Services.AddRequestDecompression();

--- a/src/UI/Server/appsettings.json
+++ b/src/UI/Server/appsettings.json
@@ -41,6 +41,13 @@
     "SampleFeatureA": false,
     "SampleFeatureB": false
   },
+  "EnvironmentStatus": {
+    "IncludedEnvironmentVariables": [
+      "ASPNETCORE_ENVIRONMENT",
+      "DOTNET_ENVIRONMENT",
+      "DOTNET_RUNNING_IN_CONTAINER"
+    ]
+  },
   "Cors": {
     "Enabled": false,
     "AllowedOrigins": []

--- a/src/UnitTests/UI.Api/EnvironmentStatusControllerTests.cs
+++ b/src/UnitTests/UI.Api/EnvironmentStatusControllerTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EnvironmentStatusControllerTests
+{
+    private const string ProbeVariableName = "ENV_STATUS_UNIT_TEST_PROBE_6273";
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable(ProbeVariableName, null);
+    }
+
+    [Test]
+    public void Get_Should_ReturnOk_WithExpectedShape()
+    {
+        var options = Options.Create(new EnvironmentStatusOptions
+        {
+            IncludedEnvironmentVariables = ["ASPNETCORE_ENVIRONMENT"]
+        });
+        var controller = new EnvironmentStatusController(options)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<EnvironmentStatusResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.OsDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.OSDescription);
+        payload.ProcessorCount.ShouldBe(Environment.ProcessorCount);
+        payload.ClrVersion.ShouldBe(Environment.Version.ToString());
+        payload.FrameworkDescription.ShouldBe(
+            System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+        payload.EnvironmentVariables.Count.ShouldBe(1);
+        payload.EnvironmentVariables[0].Name.ShouldBe("ASPNETCORE_ENVIRONMENT");
+    }
+
+    [Test]
+    public void Get_Should_NeverExposeVariableValues_When_VariableIsSet()
+    {
+        Environment.SetEnvironmentVariable(ProbeVariableName, "classified-secret-value-6273");
+        var options = Options.Create(new EnvironmentStatusOptions
+        {
+            IncludedEnvironmentVariables = [ProbeVariableName]
+        });
+        var controller = new EnvironmentStatusController(options)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = (result as ContentResult)?.Content;
+        content.ShouldNotBeNull();
+        content!.ShouldNotContain("classified-secret");
+        content.ShouldNotContain("secret");
+        var payload = JsonSerializer.Deserialize<EnvironmentStatusResponse>(
+            content,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload!.EnvironmentVariables[0].IsSet.ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_Should_Return304_When_IfNoneMatchMatchesEtag()
+    {
+        var options = Options.Create(new EnvironmentStatusOptions
+        {
+            IncludedEnvironmentVariables = []
+        });
+        var controller = new EnvironmentStatusController(options)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+        var first = controller.Get();
+        var firstContent = first.ShouldBeOfType<ContentResult>();
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(
+            JsonSerializer.Deserialize<EnvironmentStatusResponse>(
+                firstContent.Content!,
+                ConditionalGetEtag.JsonSerializerOptions)!);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.IfNoneMatch = etag.ToString();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var second = controller.Get();
+        second.ShouldBeOfType<StatusCodeResult>();
+        ((StatusCodeResult)second).StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/status/environment", true)]
+    [TestCase("/api/v1.0/status/environment", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/status/environment` and `GET /api/v{version}/status/environment` returning a redacted JSON snapshot: OS description, processor count, CLR version, .NET framework description, and allowlisted environment variable **names** with `isSet` only (no values).

## Files changed

| Area | Change |
|------|--------|
| `src/UI/Api/Controllers/EnvironmentStatusController.cs` | New controller: dual routes, `[EnableRateLimiting]`, `[AllowAnonymous]`, weak ETag + 304 |
| `src/UI/Api/EnvironmentStatusOptions.cs`, `EnvironmentStatusModels.cs` | Options + response DTOs |
| `src/UI/Server/Program.cs` | Bind `EnvironmentStatus` section; `PostConfigure` default allowlist when empty |
| `src/UI/Server/appsettings.json` | Default `IncludedEnvironmentVariables` |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Treat status routes as public when API key is enabled |
| `src/UnitTests/UI.Api/EnvironmentStatusControllerTests.cs` | Shape, redaction, 304 |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | New public path cases |
| `src/IntegrationTests/Api/EnvironmentStatus*.cs` | HTTP contract, redaction, anonymous with API key on |

## Testing

- `DATABASE_ENGINE=SQLite pwsh -NoProfile -NonInteractive -File ./PrivateBuild.ps1` — passed (266 unit + 112 integration tests)
- Filtered: `EnvironmentStatusControllerTests`, `EnvironmentStatusEndpointIntegrationTests`

Closes #6273
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0881326d-dfba-42ec-84f9-8dd130528b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0881326d-dfba-42ec-84f9-8dd130528b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

