### PR TITLE
New API endpoint GET /api/tools/timestamp-converter for epoch and ISO conversions (#6270)

### DIFF
--- a/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class TimestampConverterEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_ValidUnixEpochSeconds_Supplied()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?epoch=1774872000");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        using var doc = await ParseJsonAsync(response);
+        doc.RootElement.GetProperty("unixEpochSeconds").GetInt64().ShouldBe(1774872000);
+        doc.RootElement.GetProperty("iso8601Utc").GetString().ShouldNotBeNull();
+        doc.RootElement.GetProperty("iso8601Utc").GetString()!.ShouldContain("2026-03-30");
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_ValidUnixEpochMilliseconds_Supplied()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?epoch=1774872000000");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        using var doc = await ParseJsonAsync(response);
+        doc.RootElement.GetProperty("unixEpochSeconds").GetInt64().ShouldBe(1774872000);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_ValidIso8601_Supplied()
+    {
+        var encoded = Uri.EscapeDataString("2026-03-30T12:00:00Z");
+        var response = await _client!.GetAsync($"/api/tools/timestamp-converter?iso={encoded}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        using var doc = await ParseJsonAsync(response);
+        doc.RootElement.GetProperty("unixEpochSeconds").GetInt64().ShouldBe(1774872000);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_VersionedRoute_Supplied()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/tools/timestamp-converter?epoch=0");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        using var doc = await ParseJsonAsync(response);
+        doc.RootElement.GetProperty("unixEpochSeconds").GetInt64().ShouldBe(0);
+    }
+
+    [Test]
+    public async Task Should_Return400Problem_When_InputMissing()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var ct = response.Content.Headers.ContentType;
+        ct.ShouldNotBeNull();
+        ct!.MediaType.ShouldNotBeNull();
+        ct.MediaType.ShouldContain("application/problem");
+    }
+
+    [Test]
+    public async Task Should_Return400Problem_When_BothEpochAndIso_Supplied()
+    {
+        var encoded = Uri.EscapeDataString("2026-03-30T12:00:00Z");
+        var response = await _client!.GetAsync(
+            $"/api/tools/timestamp-converter?epoch=0&iso={encoded}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400Problem_When_UnparseableIso()
+    {
+        var encoded = Uri.EscapeDataString("not-valid");
+        var response = await _client!.GetAsync($"/api/tools/timestamp-converter?iso={encoded}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return400Problem_When_EpochOutOfRange()
+    {
+        var response = await _client!.GetAsync(
+            "/api/tools/timestamp-converter?epoch=9223372036854775807");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_ReuseDiagnosticsApiKeyBypass_When_TimestampConverterEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+
+        using (var anon = factory.CreateClient())
+        {
+            var ok = await anon.GetAsync("/api/tools/timestamp-converter?epoch=0");
+            ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        using var protectedClient = factory.CreateClient();
+        var diag = await protectedClient.GetAsync("/api/diagnostics");
+        diag.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(ApiKeyConstants.HeaderName, ApiKeyProtectedWebApplicationFactory.TestApiKey);
+        var diagnosticsOk = await withKey.GetAsync("/api/diagnostics");
+        diagnosticsOk.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private static async Task<JsonDocument> ParseJsonAsync(HttpResponseMessage response)
+    {
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+}

--- a/src/UI/Api/Controllers/TimestampConverterController.cs
+++ b/src/UI/Api/Controllers/TimestampConverterController.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Converts between Unix epoch values and ISO-8601 UTC instants for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/timestamp-converter")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/timestamp-converter")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class TimestampConverterController : ControllerBase
+{
+    /// <summary>
+    /// Converts exactly one supplied value: query <paramref name="epoch"/> (unix seconds or milliseconds via heuristic), or query <paramref name="iso"/>.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(TimestampConverterResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] long? epoch, [FromQuery] string? iso)
+    {
+        var hasEpoch = epoch.HasValue;
+        var isoTrimmed = iso?.Trim() ?? string.Empty;
+        var hasIso = isoTrimmed.Length > 0;
+
+        if (!hasEpoch && !hasIso)
+        {
+            return Problem(
+                detail: "Provide exactly one query parameter: 'epoch' (unix seconds or milliseconds) or 'iso' (ISO-8601 instant).",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (hasEpoch && hasIso)
+        {
+            return Problem(
+                detail: "Provide only one of 'epoch' or 'iso', not both.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        DateTimeOffset instant;
+        try
+        {
+            if (hasEpoch)
+            {
+                instant = TimestampConverterParsing.ParseUnixEpochNumeric(epoch!.Value).ToUniversalTime();
+            }
+            else
+            {
+                if (!TimestampConverterParsing.TryParseIso8601(isoTrimmed, out instant))
+                {
+                    return Problem(
+                        detail: "The 'iso' value could not be parsed as an ISO-8601 instant.",
+                        statusCode: StatusCodes.Status400BadRequest);
+                }
+
+                instant = instant.ToUniversalTime();
+            }
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return Problem(
+                detail: "The 'epoch' value is outside the representable UTC range.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var seconds = instant.ToUnixTimeSeconds();
+        var ms = instant.ToUnixTimeMilliseconds();
+        var iso8601Utc = instant.ToString("O", CultureInfo.InvariantCulture);
+        var rfc1123Utc = instant.ToString("R", CultureInfo.InvariantCulture);
+
+        var payload = new TimestampConverterResponse(
+            UnixEpochSeconds: seconds,
+            UnixEpochMilliseconds: ms,
+            Iso8601Utc: iso8601Utc,
+            Rfc1123Utc: rfc1123Utc,
+            UtcDisplay: instant.UtcDateTime.ToString("dddd, dd MMMM yyyy HH:mm:ss 'UTC'", CultureInfo.InvariantCulture));
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/TimestampConverterParsing.cs
+++ b/src/UI/Api/TimestampConverterParsing.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Parses unix epoch inputs (seconds or milliseconds heuristic) and ISO-8601 instants for timestamp conversion APIs.
+/// </summary>
+internal static class TimestampConverterParsing
+{
+    internal const long MillisecondsThreshold = 1_000_000_000_000L;
+
+    /// <summary>
+    /// Interprets a unix epoch numeric value as seconds unless its absolute value meets the millisecond heuristic threshold.
+    /// </summary>
+    internal static DateTimeOffset ParseUnixEpochNumeric(long raw)
+    {
+        if (Math.Abs(raw) >= MillisecondsThreshold)
+        {
+            return DateTimeOffset.FromUnixTimeMilliseconds(raw);
+        }
+
+        return DateTimeOffset.FromUnixTimeSeconds(raw);
+    }
+
+    /// <summary>
+    /// Parses an ISO-8601 instant using invariant culture rules suitable for APIs.
+    /// </summary>
+    internal static bool TryParseIso8601(string iso, out DateTimeOffset instant)
+    {
+        return DateTimeOffset.TryParse(
+            iso,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeUniversal,
+            out instant);
+    }
+}

--- a/src/UI/Api/TimestampConverterResponse.cs
+++ b/src/UI/Api/TimestampConverterResponse.cs
@@ -1,0 +1,11 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON body for unix and ISO conversions plus readable UTC representations.
+/// </summary>
+public sealed record TimestampConverterResponse(
+    long UnixEpochSeconds,
+    long UnixEpochMilliseconds,
+    string Iso8601Utc,
+    string Rfc1123Utc,
+    string UtcDisplay);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and timestamp-converter tool endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,12 +57,33 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionOrTimePath(value)
+            || IsPublicToolsTimestampConverterPath(value))
         {
             return false;
         }
 
         return true;
+    }
+
+    internal static bool IsPublicToolsTimestampConverterPath(string pathValue)
+    {
+        var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 3 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (segments.Length == 3)
+        {
+            return segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+                   && segments[2].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return segments.Length >= 4
+               && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase)
+               && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+               && segments[3].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase);
     }
 
     internal static bool IsPublicVersionOrTimePath(string pathValue)

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterControllerTests
+{
+    private static TimestampConverterController Controller()
+    {
+        return new TimestampConverterController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+    }
+
+    [Test]
+    public void Get_Should_Return200JsonAndEpochRoundTrip_When_ValidUnixSeconds()
+    {
+        var sut = Controller();
+        var result = sut.Get(epoch: 1774872000, iso: null);
+
+        var json = ShouldBeOkJson(result);
+        json.RootElement.GetProperty("unixEpochSeconds").GetInt64().ShouldBe(1774872000);
+        json.RootElement.GetProperty("unixEpochMilliseconds").GetInt64().ShouldBe(1774872000000);
+        json.RootElement.GetProperty("iso8601Utc").GetString().ShouldNotBeNull();
+        json.RootElement.GetProperty("iso8601Utc").GetString()!.ShouldContain("2026-03-30");
+        json.RootElement.GetProperty("rfc1123Utc").GetString().ShouldNotBeNullOrWhiteSpace();
+        var utcDisplay = json.RootElement.GetProperty("utcDisplay").GetString();
+        utcDisplay.ShouldNotBeNull();
+        utcDisplay!.ShouldContain("March");
+        utcDisplay.ShouldContain("UTC");
+    }
+
+    [Test]
+    public void Get_Should_Return200Json_When_ValidUnixMilliseconds()
+    {
+        var sut = Controller();
+        var result = sut.Get(epoch: 1774872000000L, iso: null);
+
+        var json = ShouldBeOkJson(result);
+        json.RootElement.GetProperty("unixEpochSeconds").GetInt64().ShouldBe(1774872000);
+    }
+
+    [Test]
+    public void Get_Should_Return200Json_When_ValidIso()
+    {
+        var sut = Controller();
+        var result = sut.Get(epoch: null, iso: "2026-03-30T12:00:00.0000000+00:00");
+
+        var json = ShouldBeOkJson(result);
+        json.RootElement.GetProperty("unixEpochSeconds").GetInt64().ShouldBe(1774872000);
+    }
+
+    [Test]
+    public void Get_Should_ReturnProblem_When_NeitherProvided()
+    {
+        var sut = Controller();
+        var result = sut.Get(epoch: null, iso: null);
+        ShouldBeProblem(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_ReturnProblem_When_BothProvided()
+    {
+        var sut = Controller();
+        var result = sut.Get(epoch: 0, iso: "2026-03-30T12:00:00Z");
+        ShouldBeProblem(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_ReturnProblem_When_IsoMalformed()
+    {
+        var sut = Controller();
+        var result = sut.Get(epoch: null, iso: "not-a-date");
+        ShouldBeProblem(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void Get_Should_ReturnProblem_When_EpochOutOfRange()
+    {
+        var sut = Controller();
+        var result = sut.Get(epoch: long.MaxValue, iso: null);
+        ShouldBeProblem(result, StatusCodes.Status400BadRequest);
+    }
+
+    private static JsonDocument ShouldBeOkJson(IActionResult result)
+    {
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        return JsonDocument.Parse(content.Content.ShouldNotBeNull());
+    }
+
+    private static void ShouldBeProblem(IActionResult result, int expectedStatus)
+    {
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(expectedStatus);
+        problem.Value.ShouldBeOfType<ProblemDetails>()!.Detail.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/src/UnitTests/UI.Api/TimestampConverterParsingTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterParsingTests.cs
@@ -1,0 +1,31 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterParsingTests
+{
+    [Test]
+    public void ParseUnixEpochNumeric_Should_UseSeconds_When_BelowMsThreshold()
+    {
+        var instant = TimestampConverterParsing.ParseUnixEpochNumeric(0);
+        instant.ToUnixTimeSeconds().ShouldBe(0);
+    }
+
+    [Test]
+    public void ParseUnixEpochNumeric_Should_UseMilliseconds_When_AtOrAboveMsThreshold()
+    {
+        var ms = 1774872000000L;
+        var instant = TimestampConverterParsing.ParseUnixEpochNumeric(ms);
+        instant.ToUnixTimeMilliseconds().ShouldBe(ms);
+    }
+
+    [Test]
+    public void TryParseIso8601_Should_ParseRoundTripZ()
+    {
+        var ok = TimestampConverterParsing.TryParseIso8601("2026-03-30T12:00:00Z", out var instant);
+        ok.ShouldBeTrue();
+        instant.ToUnixTimeSeconds().ShouldBe(1774872000);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/timestamp-converter", true)]
+    [TestCase("/api/v1.0/tools/timestamp-converter", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds **`GET /api/tools/timestamp-converter`** (and versioned **`GET /api/v1.0/tools/timestamp-converter`**) so callers can send **either** a Unix **`epoch`** (seconds, or milliseconds when `|epoch| >= 1_000_000_000_000`) **or** an **`iso`** ISO-8601 instant. Responses are JSON with **`unixEpochSeconds`**, **`unixEpochMilliseconds`**, **`iso8601Utc`** (round-trip `O` in UTC), **`rfc1123Utc`** (`R`), and **`utcDisplay`** for a readable UTC line.

Invalid combinations (both parameters, neither, malformed ISO, or epoch out of range) return **400** with **`ProblemDetails`** aligned with existing API controllers. The route uses **`EnableRateLimiting`** like other `/api/*` GETs and **`AllowAnonymous`**. Optional API-key middleware treats this path as **public**, same as `/api/time` and `/api/ping`, so integrators can use it without a key when middleware is enabled.

## Files changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/TimestampConverterController.cs` | Endpoint implementation |
| `src/UI/Api/TimestampConverterParsing.cs` | Internal epoch heuristic + ISO parse helper |
| `src/UI/Api/TimestampConverterResponse.cs` | JSON DTO shape |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Bypass API key for `tools/timestamp-converter` (unversioned + versioned) |
| `src/UnitTests/UI.Api/TimestampConverterControllerTests.cs` | Controller unit tests |
| `src/UnitTests/UI.Api/TimestampConverterParsingTests.cs` | Parsing heuristic tests |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Public-path whitelist cases |
| `src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs` | `WebApplicationFactory` HTTP tests + API-key parity |

## Testing

- `DATABASE_ENGINE=SQLite` **`PrivateBuild.ps1`**: succeeded (273 unit tests, 117 integration tests in this run).
- Focused filters before full build: `TimestampConverter` + updated middleware unit cases.

Closes #6270
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-055f6d75-9bff-4358-9eef-c6fb33627039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-055f6d75-9bff-4358-9eef-c6fb33627039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

