### PR TITLE
chore: fix nuget vulnerabilities — align OpenTelemetry packages

### DIFF
--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -42,8 +42,12 @@
 		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="4.9.2">
 			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtrans_transitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ChurchBulletin.ServiceDefaults/ChurchBulletin.ServiceDefaults.csproj
+++ b/src/ChurchBulletin.ServiceDefaults/ChurchBulletin.ServiceDefaults.csproj
@@ -13,14 +13,14 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
   </ItemGroup>

--- a/src/ChurchBulletin.ServiceDefaults/Extensions.cs
+++ b/src/ChurchBulletin.ServiceDefaults/Extensions.cs
@@ -79,7 +79,6 @@ public static class Extensions
                     })
                     .AddSqlClientInstrumentation(options =>
                     {
-                        options.SetDbStatementForText = true;
                         options.RecordException = true;
                     })
                     .AddEntityFrameworkCoreInstrumentation(options =>

--- a/src/DataAccess/DataAccess.csproj
+++ b/src/DataAccess/DataAccess.csproj
@@ -12,12 +12,13 @@
 	<ItemGroup>
     <PackageReference Include="ClearMeasureLabs.HostedEndpoint.SqlServerTransport" Version="1.0.30" />
     <PackageReference Include="MediatR" Version="12.4.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-		<PackageReference Include="NServiceBus.Persistence.Sql.TransactionalSession" Version="8.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="NServiceBus.Persistence.Sql.TransactionalSession" Version="8.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/McpServer/McpServer.csproj
+++ b/src/McpServer/McpServer.csproj
@@ -17,6 +17,10 @@
 		<PackageReference Include="MediatR" Version="12.4.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/UI/Server/UI.Server.csproj
+++ b/src/UI/Server/UI.Server.csproj
@@ -27,10 +27,10 @@
 		<PackageReference Include="ModelContextProtocol" Version="1.0.0" />
 		<PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.0.0" />
 		<PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
-		<PackageReference Include="OpenTelemetry" Version="1.12.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Align OpenTelemetry packages to available patched/nearest releases and remove invalid API usage in ChurchBulletin.ServiceDefaults.Extensions.cs.

Build: `dotnet build` passes locally; remaining advisory NU1902 warnings for OpenTelemetry.Exporter.OpenTelemetryProtocol require upstream fix.

Change summary:
- Update OpenTelemetry package versions in multiple .csproj files
- Remove invalid `SetDbStatementForText` call

CI: please run full build and tests.