### PR TITLE
Add navigate hide button (#6477)

### DIFF
--- a/src/AcceptanceTests/App/NavRailToggleTests.cs
+++ b/src/AcceptanceTests/App/NavRailToggleTests.cs
@@ -1,0 +1,69 @@
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UI.Shared;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
+
+[TestFixture]
+public class NavRailToggleTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task NavRail_ShouldCollapseMainColumn_OnWideViewportWhenToggledAfterLogin()
+    {
+        await LoginAsCurrentUser();
+
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+        await toggle.WaitForAsync();
+
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("true");
+        (await toggle.GetAttributeAsync("title"))!.ShouldContain("Hide");
+
+        await toggle.EvaluateAsync("el => el.click()");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("false");
+        (await toggle.GetAttributeAsync("title"))!.ShouldContain("Show");
+        var collapsedAppClass = (await Page.Locator(".modern-app").GetAttributeAsync("class")) ?? "";
+        collapsedAppClass.ShouldContain("rail-collapsed");
+
+        var hiddenRailClass = (await Page.Locator("#app-navigation-rail").GetAttributeAsync("class")) ?? "";
+        hiddenRailClass.ShouldContain("rail-hidden");
+
+        await toggle.EvaluateAsync("el => el.click()");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("true");
+        var expandedAppClass = (await Page.Locator(".modern-app").GetAttributeAsync("class")) ?? "";
+        expandedAppClass.ShouldNotContain("rail-collapsed");
+    }
+
+    [Test, Retry(2)]
+    public async Task NavRail_ShouldOpenOverlay_OnNarrowViewportWhenToggledAfterLogin()
+    {
+        await Page.SetViewportSizeAsync(375, 667);
+        await Page.ReloadAsync();
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await LoginAsCurrentUser();
+
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+        await toggle.WaitForAsync();
+
+        var rail = Page.Locator("#app-navigation-rail");
+
+        await Expect(rail).Not.ToHaveClassAsync(new Regex(@"\bopen\b"));
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("false");
+
+        await toggle.EvaluateAsync("el => el.click()");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(rail).ToHaveClassAsync(new Regex(@"\bopen\b"));
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("true");
+
+        await toggle.EvaluateAsync("el => el.click()");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(rail).Not.ToHaveClassAsync(new Regex(@"\bopen\b"));
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("false");
+    }
+}

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -40,7 +40,7 @@
                         }
                         else
                         {
-                            <i class="bi bi-list" aria-hidden="true"></i>
+                            <span class="navbar-toggler-icon nav-rail-hamburger-icon" aria-hidden="true"></span>
                         }
                     </button>
                     <div class="header-title">

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -78,6 +78,9 @@
 .sidebar-nav {
     flex: 1;
     padding: 1rem 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
 }
 
 /* Sidebar Footer */
@@ -201,9 +204,21 @@
     outline-offset: 2px;
 }
 
+.nav-rail-toggle .nav-rail-hamburger-icon,
+.nav-rail-toggle i {
+    flex-shrink: 0;
+}
+
 .nav-rail-toggle i {
     font-size: 1.35rem;
     line-height: 1;
+}
+
+.nav-rail-toggle .navbar-toggler-icon.nav-rail-hamburger-icon {
+    width: 1.35rem;
+    height: 1.35rem;
+    vertical-align: middle;
+    background-size: 100%;
 }
 
 .header-title {
@@ -527,6 +542,10 @@
 :global(html[data-theme="dark"]) .nav-rail-toggle:hover {
     background: #4a5568;
     border-color: #718096;
+}
+
+:global(html[data-theme="dark"]) .nav-rail-toggle .navbar-toggler-icon.nav-rail-hamburger-icon {
+    filter: invert(98%) saturate(460%) hue-rotate(175deg);
 }
 
 :global(html[data-theme="dark"]) .user-section,

--- a/src/UI.Shared/NavMenu.Razor.cs
+++ b/src/UI.Shared/NavMenu.Razor.cs
@@ -11,15 +11,6 @@ public partial class NavMenu : AppComponentBase,
 {
     [Inject] public IUserSession? UserSession { get; set; }
 
-    private bool collapseNavMenu = true;
-
-    private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
-
-    private void ToggleNavMenu()
-    {
-        collapseNavMenu = !collapseNavMenu;
-    }
-
     private Employee? CurrentUser { get; set; }
 
     protected override async Task OnInitializedAsync()

--- a/src/UI.Shared/NavMenu.razor
+++ b/src/UI.Shared/NavMenu.razor
@@ -1,13 +1,4 @@
-<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">Menu</a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-    </div>
-</div>
-
-<div class="@NavMenuCssClass nav-scrollable" @onclick="ToggleNavMenu">
+<div class="nav-scrollable">
     <nav class="flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">

--- a/src/UI.Shared/NavMenu.razor.css
+++ b/src/UI.Shared/NavMenu.razor.css
@@ -1,54 +1,33 @@
-﻿/* Navigation Toggle Button */
-.navbar-toggler {
-    appearance: none;
-    cursor: pointer;
-    width: 3.5rem;
-    height: 2.5rem;
-    color: #2d3748;
-    position: absolute;
-    top: 0.5rem;
-    right: 1rem;
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    border-radius: 6px;
-    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2845, 55, 72, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.75rem rgba(255, 255, 255, 0.8);
-    transition: all 0.2s ease-in-out;
-}
+﻿/* Navigation column (whole-rail collapse is driven by MainLayout nav-rail toggle) */
 
-.navbar-toggler:hover {
-    background-color: rgba(255, 255, 255, 0.9);
-    border-color: rgba(0, 0, 0, 0.3);
-}
-
-.navbar-toggler:checked {
-    background-color: rgba(255, 255, 255, 1);
-}
-
-/* Top Navigation Bar */
-.top-row {
-    min-height: 3.5rem;
-    background: rgba(255, 255, 255, 0.8);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.navbar-brand {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: #2d3748 !important;
-    text-decoration: none;
-}
-
-/* Navigation Items Container */
 .nav-scrollable {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
     background: transparent;
-    min-height: calc(100vh - 3.5rem);
-    display: none;
+}
+
+.nav-scrollable::-webkit-scrollbar {
+    width: 6px;
+}
+
+.nav-scrollable::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.nav-scrollable::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 3px;
+}
+
+.nav-scrollable::-webkit-scrollbar-thumb:hover {
+    background: rgba(0, 0, 0, 0.3);
 }
 
 .nav-scrollable nav {
-    padding: 1rem 0;
+    padding: 0 0 1rem;
 }
 
-/* Individual Navigation Items */
 .nav-item {
     margin: 0.25rem 0;
 }
@@ -95,7 +74,6 @@
     border-radius: 0 2px 2px 0;
 }
 
-/* Navigation Icons */
 .nav-icon {
     font-size: 1.25rem;
     width: 1.5rem;
@@ -115,7 +93,6 @@
     transform: scale(1.1);
 }
 
-/* Navigation Text */
 .nav-text {
     flex: 1;
     word-wrap: break-word;
@@ -125,7 +102,6 @@
     color: inherit;
 }
 
-/* Modern Icon Styles for Specific Items */
 .nav-item .nav-link[href=""] .nav-icon {
     color: #4a5568;
 }
@@ -162,24 +138,6 @@
     color: #dd6b20;
 }
 
-/* Mobile Toggle State */
-.navbar-toggler:checked ~ .nav-scrollable {
-    display: block;
-    animation: slideDown 0.3s ease-out;
-}
-
-@keyframes slideDown {
-    from {
-        opacity: 0;
-        transform: translateY(-10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-/* Responsive Design */
 @media (max-width: 640px) {
     .nav-item .nav-link {
         padding: 0.875rem 1rem;
@@ -198,43 +156,15 @@
     }
 }
 
-@media (min-width: 641px) {
-    .navbar-toggler {
-        display: none;
-    }
-
-    .nav-scrollable {
-        display: block !important;
-        height: calc(100vh - 3.5rem);
-        overflow-y: auto;
-        box-shadow: none;
-    }
-    
-    .nav-scrollable::-webkit-scrollbar {
-        width: 6px;
-    }
-    
-    .nav-scrollable::-webkit-scrollbar-track {
-        background: transparent;
-    }
-    
-    .nav-scrollable::-webkit-scrollbar-thumb {
-        background: rgba(0, 0, 0, 0.2);
-        border-radius: 3px;
-    }
-    
-    .nav-scrollable::-webkit-scrollbar-thumb:hover {
-        background: rgba(0, 0, 0, 0.3);
-    }
-}
-
-/* Focus states for accessibility */
 .nav-item .nav-link:focus {
     outline: 2px solid #4a5568;
     outline-offset: 2px;
 }
 
-.navbar-toggler:focus {
-    outline: 2px solid #2d3748;
-    outline-offset: 2px;
+:global(html[data-theme="dark"]) .nav-scrollable::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+:global(html[data-theme="dark"]) .nav-scrollable::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.3);
 }


### PR DESCRIPTION
## Summary

Adds a standard Bootstrap-style hamburger icon on the header nav-rail toggle when the left sidebar is collapsed so the hide/show affordance matches the conceptual design (`MainLayout`). Removes the duplicate `navbar-toggler` strip from `NavMenu` so collapsing the rail is driven only by the top-left toggle; adjusts `sidebar-nav` flex layout so the link list fills the sidebar and scrolls. Adds Playwright coverage for wide (rail-collapsed) and narrow (`open`) overlay breakpoints.

Closes #6477

## Files

| Area | Changes |
|------|---------|
| `src/UI.Shared/MainLayout.razor` | Bootstrap `navbar-toggler-icon` when rail hidden (hamburger affordance). |
| `src/UI.Shared/MainLayout.razor.css` | `.sidebar-nav` flex child layout; sizing for `.nav-rail-toggle` hamburger span; dark-mode filter for SVG icon contrast. |
| `src/UI.Shared/NavMenu.razor` | Removed redundant top-row/menu toggler markup. |
| `src/UI.Shared/NavMenu.Razor.cs` | Removed obsolete collapse-toggle state. |
| `src/UI.Shared/NavMenu.razor.css` | Sidebar-only scroll/nav styles without inner mobile collapse duplication. |
| `src/AcceptanceTests/App/NavRailToggleTests.cs` | New tests: collapse on desktop viewport; overlay on 375×667 viewport. |

## Testing

- `DATABASE_ENGINE=SQLite ./PrivateBuild.ps1` — green.
- Unit: `dotnet test src/UnitTests --configuration Release --filter FullyQualifiedName~MainLayoutTests`
- Acceptance: `dotnet test src/AcceptanceTests --configuration Debug --filter FullyQualifiedName~NavRailToggleTests` plus Playwright `chromium` install.
