### PR TITLE
Force capitalize all names in the login drop-down (#6701)

### DIFF
--- a/src/AcceptanceTests/Authentication/LoginTests.cs
+++ b/src/AcceptanceTests/Authentication/LoginTests.cs
@@ -1,4 +1,5 @@
 using ClearMeasure.Bootcamp.UI.Shared.Components;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
 
 namespace ClearMeasure.Bootcamp.AcceptanceTests.Authentication;
 
@@ -15,9 +16,40 @@ public class LoginTests : AcceptanceTestBase
     }
 
     [Test, Retry(2)]
+    public async Task Should_DisplayUppercaseNames_InLoginDropdown()
+    {
+        await Page.GotoAsync("/login");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var userSelect = Page.GetByTestId(nameof(Login.Elements.User));
+        var placeholderOption = userSelect.Locator("option[value='']");
+        await Expect(placeholderOption).ToHaveTextAsync("-- Select a parishioner or staff member --");
+
+        var homerOption = userSelect.Locator("option[value='hsimpson']");
+        await Expect(homerOption).ToHaveTextAsync("HOMER SIMPSON");
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_LoginSuccessfully_UsingUsernameValue_NotDisplayLabel()
+    {
+        await Page.GotoAsync("/login");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var userSelect = Page.GetByTestId(nameof(Login.Elements.User));
+        var homerOption = userSelect.Locator("option[value='hsimpson']");
+        await Expect(homerOption).ToHaveTextAsync("HOMER SIMPSON");
+
+        await Select(nameof(Login.Elements.User), "hsimpson");
+        await Click(nameof(Login.Elements.LoginButton));
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var welcomeTextLocator = Page.GetByTestId(nameof(Logout.Elements.WelcomeText));
+        await Expect(welcomeTextLocator).ToHaveTextAsync("Welcome hsimpson!");
+    }
+
+    [Test, Retry(2)]
     public async Task LoginWithUsernameOnlyForwardsToHomePage()
     {
-        // Act: Go to home page
         await Page.GotoAsync("/");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         await TakeScreenshotAsync(1);
@@ -29,21 +61,17 @@ public class LoginTests : AcceptanceTestBase
             await Page.WaitForURLAsync("**/");
         }
 
-        // Click Login link in top bar
         await Click(nameof(LoginLink.Elements.LoginLink));
         await Page.WaitForURLAsync("**/login");
         await TakeScreenshotAsync(2);
 
-        // Fill in username only
-        await Select(nameof(UI.Shared.Pages.Login.Elements.User), "hsimpson");
+        await Select(nameof(Login.Elements.User), "hsimpson");
         await TakeScreenshotAsync(3);
 
-        // Submit form
-        await Click(nameof(UI.Shared.Pages.Login.Elements.LoginButton));
+        await Click(nameof(Login.Elements.LoginButton));
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         await TakeScreenshotAsync(4);
 
-        // Assert: Should be redirected to home and see welcome message
         var welcomeTextLocator = Page.GetByTestId(nameof(Logout.Elements.WelcomeText));
         await Expect(welcomeTextLocator).ToHaveTextAsync("Welcome hsimpson!");
     }

--- a/src/AcceptanceTests/WorkOrders/WorkOrderSearchTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSearchTests.cs
@@ -14,6 +14,22 @@ public class WorkOrderSearchTests : AcceptanceTestBase
     }
 
     [Test, Retry(2)]
+    public async Task Should_PreserveMixedCaseNames_InWorkOrderSearchDropdowns()
+    {
+        await Click(nameof(NavMenu.Elements.Search));
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var creatorSelect = Page.Locator($"#{WorkOrderSearch.Elements.CreatorSelect}");
+        var assigneeSelect = Page.Locator($"#{WorkOrderSearch.Elements.AssigneeSelect}");
+
+        await Expect(creatorSelect.Locator("option").Filter(new() { HasText = "Timothy Lovejoy" })).ToHaveCountAsync(1);
+        await Expect(creatorSelect.Locator("option").Filter(new() { HasText = "TIMOTHY LOVEJOY" })).ToHaveCountAsync(0);
+
+        await Expect(assigneeSelect.Locator("option").Filter(new() { HasText = "Timothy Lovejoy" })).ToHaveCountAsync(1);
+        await Expect(assigneeSelect.Locator("option").Filter(new() { HasText = "TIMOTHY LOVEJOY" })).ToHaveCountAsync(0);
+    }
+
+    [Test, Retry(2)]
     public async Task ShouldLoadDropDownsInitiallyOnLoad()
     {
         // Act

--- a/src/IntegrationTests/DataAccess/EmployeeQueryHandlerTests.cs
+++ b/src/IntegrationTests/DataAccess/EmployeeQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.Core.Queries;
 using ClearMeasure.Bootcamp.DataAccess.Handlers;
@@ -96,6 +97,54 @@ public class EmployeeQueryHandlerTests
         {
             var rehydratedEmployee = context.Set<Employee>().First(e => e.Id == employee.Id);
             rehydratedEmployee.PreferredLanguage.ShouldBe("en-US");
+        }
+    }
+
+    [Test]
+    public async Task Should_ReturnStoredEmployeeNames_Unchanged_When_EmployeeGetAllQueryHandled()
+    {
+        new DatabaseTests().Clean();
+
+        var one = new Employee("1", "first1", "last1", "email1");
+        var two = new Employee("2", "First2", "Last2", "email2");
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(one);
+            context.Add(two);
+            context.SaveChanges();
+        }
+
+        var dataContext = TestHost.GetRequiredService<DataContext>();
+        var handler = new EmployeeQueryHandler(dataContext);
+        var employees = await handler.Handle(new EmployeeGetAllQuery());
+
+        employees.Length.ShouldBe(2);
+        employees[0].FirstName.ShouldBe("first1");
+        employees[0].LastName.ShouldBe("last1");
+        employees[1].FirstName.ShouldBe("First2");
+        employees[1].LastName.ShouldBe("Last2");
+    }
+
+    [Test]
+    public async Task Should_NotMutateEmployeeRecords_When_LoginPageLoadsEmployees()
+    {
+        new DatabaseTests().Clean();
+
+        var homer = new Employee("hsimpson", "Homer", "Simpson", "homer@test.com");
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(homer);
+            context.SaveChanges();
+        }
+
+        var bus = TestHost.GetRequiredService<IBus>();
+        _ = await bus.Send(new EmployeeGetAllQuery());
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            var rehydrated = context.Set<Employee>().Single(e => e.UserName == "hsimpson");
+            rehydrated.FirstName.ShouldBe("Homer");
+            rehydrated.LastName.ShouldBe("Simpson");
         }
     }
 }


### PR DESCRIPTION
## Summary

Verifies and completes test coverage for display-only uppercase formatting of employee full names in the login page **Select Church Member** drop-down. The core implementation (`LoginDisplayNameFormatter`, `Login.razor` wiring) was already present on master; this PR adds the missing integration and acceptance tests specified in the test design.

## Files Changed

| File | Description |
|------|-------------|
| `src/IntegrationTests/DataAccess/EmployeeQueryHandlerTests.cs` | Added integration tests confirming stored employee names are unchanged by `EmployeeGetAllQuery` and login data path |
| `src/AcceptanceTests/Authentication/LoginTests.cs` | Added acceptance tests for uppercase login dropdown labels and username-based auth binding |
| `src/AcceptanceTests/WorkOrders/WorkOrderSearchTests.cs` | Added regression test confirming work-order search dropdowns preserve mixed-case names |

## Testing Notes

- **PrivateBuild.ps1**: All 262 unit tests and 116 integration tests passed
- **Unit tests** (pre-existing): `LoginDisplayNameFormatterTests`, `LoginPageTests.ShouldDisplayUppercaseLabelsInLoginDropdown_ForMixedAndAllCapsNames`
- **New integration tests**: `Should_ReturnStoredEmployeeNames_Unchanged_When_EmployeeGetAllQueryHandled`, `Should_NotMutateEmployeeRecords_When_LoginPageLoadsEmployees`
- **New acceptance tests**: `Should_DisplayUppercaseNames_InLoginDropdown`, `Should_LoginSuccessfully_UsingUsernameValue_NotDisplayLabel`, `Should_PreserveMixedCaseNames_InWorkOrderSearchDropdowns`

Closes #6701
