### PR TITLE
Fix work order search regression test assertion (#6701)

### DIFF
--- a/src/AcceptanceTests/WorkOrders/WorkOrderSearchTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderSearchTests.cs
@@ -23,10 +23,13 @@ public class WorkOrderSearchTests : AcceptanceTestBase
         var assigneeSelect = Page.Locator($"#{WorkOrderSearch.Elements.AssigneeSelect}");
 
         await Expect(creatorSelect.Locator("option").Filter(new() { HasText = "Timothy Lovejoy" })).ToHaveCountAsync(1);
-        await Expect(creatorSelect.Locator("option").Filter(new() { HasText = "TIMOTHY LOVEJOY" })).ToHaveCountAsync(0);
-
         await Expect(assigneeSelect.Locator("option").Filter(new() { HasText = "Timothy Lovejoy" })).ToHaveCountAsync(1);
-        await Expect(assigneeSelect.Locator("option").Filter(new() { HasText = "TIMOTHY LOVEJOY" })).ToHaveCountAsync(0);
+
+        var creatorTexts = await creatorSelect.Locator("option").AllInnerTextsAsync();
+        var assigneeTexts = await assigneeSelect.Locator("option").AllInnerTextsAsync();
+
+        creatorTexts.ShouldNotContain("TIMOTHY LOVEJOY JR");
+        assigneeTexts.ShouldNotContain("TIMOTHY LOVEJOY JR");
     }
 
     [Test, Retry(2)]


### PR DESCRIPTION
## Summary

Fixes failing acceptance test `Should_PreserveMixedCaseNames_InWorkOrderSearchDropdowns` on master after #6714 merge.

Playwright `HasText` is case-insensitive, so the negative assertion for `"TIMOTHY LOVEJOY"` incorrectly matched the mixed-case option `"Timothy Lovejoy Jr"`. Replaced with exact full-name checks via option text list.

Closes #6701