### PR TITLE
fix: correct nav rail acceptance test assertions (#6720)

### DIFF
--- a/src/AcceptanceTests/App/NavRailToggleTests.cs
+++ b/src/AcceptanceTests/App/NavRailToggleTests.cs
@@ -22,14 +22,14 @@ public class NavRailToggleTests : AcceptanceTestBase
         await Task.Delay(GetInputDelayMs());
 
         var rail = Page.Locator("#app-navigation-rail");
-        await Expect(rail).ToHaveClassAsync("rail-hidden");
-        await Expect(Page.Locator(".modern-app")).ToHaveClassAsync("rail-collapsed");
+        (await rail.GetAttributeAsync("class"))!.ShouldContain("rail-hidden");
+        (await Page.Locator(".modern-app").GetAttributeAsync("class"))!.ShouldContain("rail-collapsed");
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
 
-        await Expect(rail).Not.ToHaveClassAsync("rail-hidden");
-        await Expect(Page.Locator(".modern-app")).Not.ToHaveClassAsync("rail-collapsed");
+        (await rail.GetAttributeAsync("class"))!.ShouldNotContain("rail-hidden");
+        (await Page.Locator(".modern-app").GetAttributeAsync("class"))!.ShouldNotContain("rail-collapsed");
         Page.Url.ShouldBe(urlBefore);
     }
 
@@ -71,7 +71,7 @@ public class NavRailToggleTests : AcceptanceTestBase
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
 
-        await Expect(Page.Locator(".modern-app")).ToHaveClassAsync("rail-collapsed");
+        (await Page.Locator(".modern-app").GetAttributeAsync("class"))!.ShouldContain("rail-collapsed");
         await Expect(Page.GetByTestId(nameof(WorkOrderSearch.Elements.SearchButton))).ToBeVisibleAsync();
         Page.Url.ShouldBe(urlBefore);
     }
@@ -79,10 +79,12 @@ public class NavRailToggleTests : AcceptanceTestBase
     [Test, Retry(2)]
     public async Task ShouldOpenAndCloseMobileOverlay_WhenNarrowViewport()
     {
-        await Page.SetViewportSizeAsync(375, 667);
         await LoginAsCurrentUser();
         await Click(nameof(NavMenu.Elements.Search));
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        await Page.SetViewportSizeAsync(375, 667);
         await Task.Delay(GetInputDelayMs());
 
         var rail = Page.Locator("#app-navigation-rail");
@@ -90,11 +92,11 @@ public class NavRailToggleTests : AcceptanceTestBase
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
-        await Expect(rail).ToHaveClassAsync("open");
+        (await rail.GetAttributeAsync("class"))!.ShouldContain("open");
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
-        await Expect(rail).Not.ToHaveClassAsync("open");
+        (await rail.GetAttributeAsync("class"))!.ShouldNotContain("open");
         await Expect(toggle).ToBeFocusedAsync();
     }
 
@@ -109,10 +111,10 @@ public class NavRailToggleTests : AcceptanceTestBase
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
-        await Expect(Page.Locator("#app-navigation-rail")).ToHaveClassAsync("rail-hidden");
+        (await Page.Locator("#app-navigation-rail").GetAttributeAsync("class"))!.ShouldContain("rail-hidden");
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
-        await Expect(Page.Locator("#app-navigation-rail")).Not.ToHaveClassAsync("rail-hidden");
+        (await Page.Locator("#app-navigation-rail").GetAttributeAsync("class"))!.ShouldNotContain("rail-hidden");
     }
 }

--- a/src/AcceptanceTests/App/NavRailToggleTests.cs
+++ b/src/AcceptanceTests/App/NavRailToggleTests.cs
@@ -22,14 +22,14 @@ public class NavRailToggleTests : AcceptanceTestBase
         await Task.Delay(GetInputDelayMs());
 
         var rail = Page.Locator("#app-navigation-rail");
-        await Expect(rail).ToHaveClassAsync(new Regex("rail-hidden"));
-        await Expect(Page.Locator(".modern-app")).ToHaveClassAsync(new Regex("rail-collapsed"));
+        await Expect(rail).ToHaveClassAsync("rail-hidden");
+        await Expect(Page.Locator(".modern-app")).ToHaveClassAsync("rail-collapsed");
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
 
-        await Expect(rail).Not.ToHaveClassAsync(new Regex("rail-hidden"));
-        await Expect(Page.Locator(".modern-app")).Not.ToHaveClassAsync(new Regex("rail-collapsed"));
+        await Expect(rail).Not.ToHaveClassAsync("rail-hidden");
+        await Expect(Page.Locator(".modern-app")).Not.ToHaveClassAsync("rail-collapsed");
         Page.Url.ShouldBe(urlBefore);
     }
 
@@ -71,7 +71,7 @@ public class NavRailToggleTests : AcceptanceTestBase
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
 
-        await Expect(Page.Locator(".modern-app")).ToHaveClassAsync(new Regex("rail-collapsed"));
+        await Expect(Page.Locator(".modern-app")).ToHaveClassAsync("rail-collapsed");
         await Expect(Page.GetByTestId(nameof(WorkOrderSearch.Elements.SearchButton))).ToBeVisibleAsync();
         Page.Url.ShouldBe(urlBefore);
     }
@@ -90,11 +90,11 @@ public class NavRailToggleTests : AcceptanceTestBase
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
-        await Expect(rail).ToHaveClassAsync(new Regex("open"));
+        await Expect(rail).ToHaveClassAsync("open");
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
-        await Expect(rail).Not.ToHaveClassAsync(new Regex("open"));
+        await Expect(rail).Not.ToHaveClassAsync("open");
         await Expect(toggle).ToBeFocusedAsync();
     }
 
@@ -109,10 +109,10 @@ public class NavRailToggleTests : AcceptanceTestBase
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
-        await Expect(Page.Locator("#app-navigation-rail")).ToHaveClassAsync(new Regex("rail-hidden"));
+        await Expect(Page.Locator("#app-navigation-rail")).ToHaveClassAsync("rail-hidden");
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());
-        await Expect(Page.Locator("#app-navigation-rail")).Not.ToHaveClassAsync(new Regex("rail-hidden"));
+        await Expect(Page.Locator("#app-navigation-rail")).Not.ToHaveClassAsync("rail-hidden");
     }
 }

--- a/src/AcceptanceTests/App/NavRailToggleTests.cs
+++ b/src/AcceptanceTests/App/NavRailToggleTests.cs
@@ -1,0 +1,118 @@
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
+
+[TestFixture]
+public class NavRailToggleTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldHideAndShowNavigationRail_OnWideViewport_AfterLogin()
+    {
+        await LoginAsCurrentUser();
+        await Click(nameof(NavMenu.Elements.Search));
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var urlBefore = Page.Url;
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+        await Expect(toggle).ToBeVisibleAsync();
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+
+        var rail = Page.Locator("#app-navigation-rail");
+        await Expect(rail).ToHaveClassAsync(new Regex("rail-hidden"));
+        await Expect(Page.Locator(".modern-app")).ToHaveClassAsync(new Regex("rail-collapsed"));
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+
+        await Expect(rail).Not.ToHaveClassAsync(new Regex("rail-hidden"));
+        await Expect(Page.Locator(".modern-app")).Not.ToHaveClassAsync(new Regex("rail-collapsed"));
+        Page.Url.ShouldBe(urlBefore);
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldKeepAriaExpandedInSyncWithNavVisibility()
+    {
+        await LoginAsCurrentUser();
+        await Click(nameof(NavMenu.Elements.Search));
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("true");
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("false");
+        (await toggle.GetAttributeAsync("title"))!.ShouldContain("Show");
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+
+        (await toggle.GetAttributeAsync("aria-expanded")).ShouldBe("true");
+        (await toggle.GetAttributeAsync("title"))!.ShouldContain("Hide");
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldExpandContentArea_WhenNavHidden_OnWorkOrderPage()
+    {
+        await LoginAsCurrentUser();
+        await Click(nameof(NavMenu.Elements.Search));
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var urlBefore = Page.Url;
+        await Expect(Page.GetByTestId(nameof(WorkOrderSearch.Elements.SearchButton))).ToBeVisibleAsync();
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+
+        await Expect(Page.Locator(".modern-app")).ToHaveClassAsync(new Regex("rail-collapsed"));
+        await Expect(Page.GetByTestId(nameof(WorkOrderSearch.Elements.SearchButton))).ToBeVisibleAsync();
+        Page.Url.ShouldBe(urlBefore);
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldOpenAndCloseMobileOverlay_WhenNarrowViewport()
+    {
+        await Page.SetViewportSizeAsync(375, 667);
+        await LoginAsCurrentUser();
+        await Click(nameof(NavMenu.Elements.Search));
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var rail = Page.Locator("#app-navigation-rail");
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+        await Expect(rail).ToHaveClassAsync(new Regex("open"));
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+        await Expect(rail).Not.ToHaveClassAsync(new Regex("open"));
+        await Expect(toggle).ToBeFocusedAsync();
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldShowNavRailToggle_OnAnonymousLandingPage()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+        await Expect(toggle).ToBeVisibleAsync();
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+        await Expect(Page.Locator("#app-navigation-rail")).ToHaveClassAsync(new Regex("rail-hidden"));
+
+        await Click(nameof(MainLayout.Elements.NavRailToggle));
+        await Task.Delay(GetInputDelayMs());
+        await Expect(Page.Locator("#app-navigation-rail")).Not.ToHaveClassAsync(new Regex("rail-hidden"));
+    }
+}

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -59,6 +59,35 @@ public class MainLayoutTests
         toggle.GetAttribute("title")!.ShouldContain("Show");
         layout.Find(".modern-app").ClassList.ShouldContain("rail-collapsed");
         layout.Find("#app-navigation-rail").ClassList.ShouldContain("rail-hidden");
+
+        toggle.Click();
+
+        toggle.GetAttribute("aria-expanded").ShouldBe("true");
+        toggle.GetAttribute("title")!.ShouldContain("Hide");
+        layout.Find(".modern-app").ClassList.ShouldNotContain("rail-collapsed");
+        layout.Find("#app-navigation-rail").ClassList.ShouldNotContain("rail-hidden");
+    }
+
+    [Test]
+    public void ShouldRenderCorrectIconForNavVisibility()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+        component.WaitForAssertion(() =>
+        {
+            layout.Find($"[data-testid='{nameof(MainLayout.Elements.NavRailToggle)}']").ShouldNotBeNull();
+        });
+
+        component.InvokeAsync(() => layout.Instance.OnViewportChanged(false)).GetAwaiter().GetResult();
+
+        var toggle = layout.Find($"[data-testid='{nameof(MainLayout.Elements.NavRailToggle)}']");
+        toggle.InnerHtml.ShouldContain("bi-chevron-double-left");
+
+        toggle.Click();
+
+        toggle.InnerHtml.ShouldContain("bi-list");
     }
 
     [Test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Hotfix Summary

Fixes master build failure (run 28893673875) after #6733 merge. Acceptance tests failed because:

1. Playwright `ToHaveClassAsync("rail-hidden")` requires an exact class string match, but the sidebar has multiple classes (`modern-sidebar rail-hidden`).
2. Mobile overlay test attempted to click a hidden Search nav link at narrow viewport before opening the sidebar.

## Changes

- `src/AcceptanceTests/App/NavRailToggleTests.cs` — use class attribute `ShouldContain`/`ShouldNotContain` checks; navigate to Search before narrowing viewport

Closes #6720
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08476e89-ae15-45cc-be9c-0c0ac1e0461f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08476e89-ae15-45cc-be9c-0c0ac1e0461f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

