### PR TITLE
New API endpoint POST /api/tools/guid-generator for on-demand GUID creation (#6744)

### DIFF
--- a/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class GuidGeneratorEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndOneGuid_When_PostUnversionedWithEmptyBody()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        var payload = await DeserializeResponse(response);
+        payload.Count.ShouldBe(1);
+        payload.Guids.Count.ShouldBe(1);
+        Guid.TryParse(payload.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndOneGuid_When_PostVersionedWithEmptyBody()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/v1.0/tools/guid-generator", new { });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        var payload = await DeserializeResponse(response);
+        payload.Count.ShouldBe(1);
+        payload.Guids.Count.ShouldBe(1);
+        Guid.TryParse(payload.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndRequestedCount_When_CountProvided()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 5 });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await DeserializeResponse(response);
+        payload.Count.ShouldBe(5);
+        payload.Guids.Count.ShouldBe(5);
+        foreach (var guid in payload.Guids)
+        {
+            Guid.TryParse(guid, out _).ShouldBeTrue();
+        }
+    }
+
+    [Test]
+    public async Task Should_Return400_When_CountOutOfRange()
+    {
+        var zeroResponse = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 0 });
+        zeroResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        var aboveMaxResponse = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 101 });
+        aboveMaxResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.PostAsJsonAsync("/api/tools/guid-generator", new { });
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await DeserializeResponse(unversioned)).Guids.Count.ShouldBe(1);
+
+        var versioned = await client.PostAsJsonAsync("/api/v1.0/tools/guid-generator", new { });
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await DeserializeResponse(versioned)).Guids.Count.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task Should_Return401WithoutApiKey_When_NonWhitelistedApiRoute()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/tools/other-tool", new { });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_ReturnJsonWithExpectedPropertyNames_When_Success()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 2 });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var json = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.TryGetProperty("count", out _).ShouldBeTrue();
+        document.RootElement.TryGetProperty("guids", out var guidsElement).ShouldBeTrue();
+        guidsElement.ValueKind.ShouldBe(JsonValueKind.Array);
+        guidsElement.GetArrayLength().ShouldBe(2);
+    }
+
+    private static async Task<GuidGeneratorResponse> DeserializeResponse(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<GuidGeneratorResponse>(json, ConditionalGetEtag.JsonSerializerOptions)
+               ?? throw new InvalidOperationException("Failed to deserialize guid-generator response.");
+    }
+}

--- a/src/UI/Api/Controllers/GuidGeneratorController.cs
+++ b/src/UI/Api/Controllers/GuidGeneratorController.cs
@@ -1,0 +1,51 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates one or more RFC 4122 GUIDs on demand for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/guid-generator")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/guid-generator")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public sealed class GuidGeneratorController : ControllerBase
+{
+    private const int MinCount = 1;
+    private const int MaxCount = 100;
+
+    /// <summary>
+    /// Generates new GUID values. When omitted, <paramref name="request"/>.<c>Count</c> defaults to 1 (maximum 100).
+    /// </summary>
+    [HttpPost]
+    [AllowAnonymous]
+    [Consumes("application/json")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(GuidGeneratorResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Post([FromBody] GuidGeneratorRequest? request)
+    {
+        var count = request?.Count ?? 1;
+
+        if (count < MinCount || count > MaxCount)
+        {
+            return Problem(
+                detail: "Count must be between 1 and 100.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var guids = new List<string>(count);
+        for (var i = 0; i < count; i++)
+        {
+            guids.Add(Guid.NewGuid().ToString());
+        }
+
+        return Ok(new GuidGeneratorResponse(count, guids));
+    }
+}

--- a/src/UI/Api/GuidGeneratorModels.cs
+++ b/src/UI/Api/GuidGeneratorModels.cs
@@ -1,0 +1,11 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Optional JSON body for <c>POST /api/tools/guid-generator</c>.
+/// </summary>
+public sealed record GuidGeneratorRequest(int? Count);
+
+/// <summary>
+/// JSON response containing generated GUID strings.
+/// </summary>
+public sealed record GuidGeneratorResponse(int Count, IReadOnlyList<string> Guids);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and guid-generator endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicAnonymousApiPath(value))
         {
             return false;
         }
@@ -65,7 +65,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicAnonymousApiPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
@@ -81,13 +81,30 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
                    || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
         }
 
+        if (segments.Length == 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("guid-generator", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         if (segments.Length >= 3
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
             var leaf = segments[2];
-            return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+            if (leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
+                || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (segments.Length >= 4
+                && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+                && segments[3].Equals("guid-generator", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
         }
 
         return false;

--- a/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
+++ b/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
@@ -1,0 +1,96 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class GuidGeneratorControllerTests
+{
+    [Test]
+    public void Post_Should_ReturnSingleGuid_When_BodyNull()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(null);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Count.ShouldBe(1);
+        payload.Guids.Count.ShouldBe(1);
+        Guid.TryParse(payload.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Post_Should_ReturnSingleGuid_When_CountOmitted()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(null));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Count.ShouldBe(1);
+        payload.Guids.Count.ShouldBe(1);
+        Guid.TryParse(payload.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Post_Should_ReturnMultipleGuids_When_CountProvided()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(3));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Count.ShouldBe(3);
+        payload.Guids.Count.ShouldBe(3);
+        foreach (var guid in payload.Guids)
+        {
+            Guid.TryParse(guid, out _).ShouldBeTrue();
+        }
+    }
+
+    [Test]
+    public void Post_Should_ReturnBadRequest_When_CountZero()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(0));
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Post_Should_ReturnBadRequest_When_CountAbove100()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(101));
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Post_Should_ReturnDistinctGuids_When_CountGreaterThanOne()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(10));
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Distinct(StringComparer.Ordinal).Count().ShouldBe(10);
+    }
+
+    private static GuidGeneratorController CreateController() =>
+        new()
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,10 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/guid-generator", true)]
+    [TestCase("/api/v1.0/tools/guid-generator", true)]
+    [TestCase("/api/tools/other-tool", false)]
+    [TestCase("/api/guid-generator", false)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

## Summary

Adds a stateless, anonymous utility endpoint `POST /api/tools/guid-generator` (and versioned twin under `/api/v1.0/tools/guid-generator`) that generates one or more RFC 4122 v4 GUIDs on demand. Callers may optionally specify a `count` in the JSON body (default 1, maximum 100).

This follows the same pattern as existing operator utilities (`PingController`, `TimeController`, `VersionController`) but uses POST with an optional JSON body. No Core, DataAccess, database, MediatR, or Blazor UI changes.

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/GuidGeneratorModels.cs` | Request/response DTOs (`GuidGeneratorRequest`, `GuidGeneratorResponse`) |
| `src/UI/Api/Controllers/GuidGeneratorController.cs` | POST endpoint with count validation (1–100) and GUID generation |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Whitelist guid-generator paths for anonymous access when API key auth is enabled |
| `src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs` | 6 unit tests for controller logic and validation |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Extended path whitelist tests (positive and negative cases) |
| `src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs` | 7 integration tests for HTTP contract, versioning, validation, and API-key bypass |

## Testing Notes

- **Private build:** `pwsh -NoProfile -ExecutionPolicy Bypass -File ./PrivateBuild.ps1` — passed (274 unit tests, 123 integration tests)
- **Unit tests:** Default count, explicit count, validation (0 and 101), distinct GUIDs, middleware whitelist
- **Integration tests:** Unversioned and versioned routes, count parameter, 400 on out-of-range count, 200 without API key when middleware enabled, 401 on non-whitelisted route, camelCase JSON property names
- **Acceptance tests:** Skipped — no UI changes per UX design

Closes #6744
