### PR TITLE
New API endpoint GET /api/echo with request reflection for debugging (#6742)

### DIFF
--- a/src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.ServiceDefaults;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class EchoEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetEchoUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("method", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("path", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("queryString", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("headers", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("correlationId", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("timestampUtc", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetEchoVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("method", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("path", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("queryString", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("headers", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("correlationId", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("timestampUtc", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_EchoQueryString_When_QueryParametersProvided()
+    {
+        var response = await _client!.GetAsync("/api/echo?foo=bar&baz=1");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.QueryString.ShouldBe("?foo=bar&baz=1");
+        payload.Query["foo"].ShouldBe("bar");
+        payload.Query["baz"].ShouldBe("1");
+    }
+
+    [Test]
+    public async Task Should_ReturnEmptyQueryString_When_NoQueryParameters()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.QueryString.ShouldBe("");
+        payload.Query.Count.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task Should_ReflectRequestMethodAndPath_When_GetIssued()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.UserAgent.ParseAdd("EchoTestAgent/1.0");
+
+        var response = await _client!.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Method.ShouldBe("GET");
+        payload.Path.ShouldBe("/api/echo");
+        payload.Scheme.ShouldBe("http");
+        payload.Host.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Should_ReturnCorrelationIdHeader_When_RequestProvidesHeader()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.Add(CorrelationIdConstants.HeaderName, "test-correlation-abc");
+
+        var response = await _client!.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        response.Headers.TryGetValues(CorrelationIdConstants.HeaderName, out var headerValues).ShouldBeTrue();
+        headerValues!.Single().ShouldBe("test-correlation-abc");
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.CorrelationId.ShouldBe("test-correlation-abc");
+    }
+
+    [Test]
+    public async Task Should_GenerateCorrelationId_When_RequestOmitsHeader()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        response.Headers.TryGetValues(CorrelationIdConstants.HeaderName, out var headerValues).ShouldBeTrue();
+        var correlationId = headerValues!.Single();
+        Guid.TryParse(correlationId, out _).ShouldBeTrue();
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.CorrelationId.ShouldBe(correlationId);
+    }
+
+    [Test]
+    public async Task Should_IncludeSelectedHeaders_When_DiagnosticHeadersPresent()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.Accept.ParseAdd("application/json");
+        request.Headers.UserAgent.ParseAdd("EchoTestAgent/1.0");
+        request.Headers.Add("X-Forwarded-For", "203.0.113.1");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "secret");
+        request.Headers.Add("Cookie", "session=abc");
+
+        var response = await _client!.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Headers["Accept"].ShouldBe("application/json");
+        payload.Headers["User-Agent"].ShouldBe("EchoTestAgent/1.0");
+        payload.Headers["X-Forwarded-For"].ShouldBe("203.0.113.1");
+        payload.Headers.ContainsKey("Authorization").ShouldBeFalse();
+        payload.Headers.ContainsKey("Cookie").ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_RedactApiKeyInJson_When_ValidKeySupplied()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var response = await client.GetAsync("/api/echo");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Headers.ContainsKey("X-Api-Key").ShouldBeTrue();
+        payload.Headers["X-Api-Key"].ShouldBe("[present]");
+        payload.Headers["X-Api-Key"].ShouldNotBe(ApiKeyProtectedWebApplicationFactory.TestApiKey);
+    }
+
+    [Test]
+    public async Task Should_Return401WithoutApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/echo");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/echo");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200WithApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await client.GetAsync("/api/echo");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await client.GetAsync("/api/v1.0/echo");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/UI/Api/Controllers/EchoController.cs
+++ b/src/UI/Api/Controllers/EchoController.cs
@@ -1,0 +1,49 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes request reflection for operator and developer diagnostics.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/echo")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/echo")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class EchoController(TimeProvider timeProvider) : ControllerBase
+{
+    private const string CorrelationIdHttpContextItemKey = "CorrelationId";
+
+    /// <summary>
+    /// Returns JSON reflecting key properties of the incoming HTTP request.
+    /// </summary>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var request = HttpContext.Request;
+        string? correlationId = null;
+        if (HttpContext.Items.TryGetValue(CorrelationIdHttpContextItemKey, out var item)
+            && item is string correlationIdValue
+            && !string.IsNullOrEmpty(correlationIdValue))
+        {
+            correlationId = correlationIdValue;
+        }
+
+        var payload = new EchoResponse(
+            Method: request.Method,
+            Scheme: request.Scheme,
+            Host: request.Host.Value ?? string.Empty,
+            Path: request.Path.Value ?? string.Empty,
+            PathBase: request.PathBase.Value ?? string.Empty,
+            QueryString: request.QueryString.Value ?? string.Empty,
+            Query: EchoRequestReflection.BuildQuery(request.Query),
+            Headers: EchoRequestReflection.BuildHeaders(request.Headers),
+            CorrelationId: correlationId,
+            TimestampUtc: timeProvider.GetUtcNow());
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/EchoModels.cs
+++ b/src/UI/Api/EchoModels.cs
@@ -1,0 +1,26 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/echo</c> and <c>GET /api/v1.0/echo</c> reflecting key properties of the incoming HTTP request.
+/// </summary>
+/// <param name="Method">HTTP method of the incoming request.</param>
+/// <param name="Scheme">Request scheme (for example <c>https</c>).</param>
+/// <param name="Host">Request host value.</param>
+/// <param name="Path">Request path.</param>
+/// <param name="PathBase">Application path base.</param>
+/// <param name="QueryString">Raw query string including leading <c>?</c>, or empty when absent.</param>
+/// <param name="Query">First value per query parameter key.</param>
+/// <param name="Headers">Selected, non-sensitive request headers for diagnostics.</param>
+/// <param name="CorrelationId">Correlation identifier from middleware when present.</param>
+/// <param name="TimestampUtc">UTC timestamp when the response was built.</param>
+public sealed record EchoResponse(
+    string Method,
+    string Scheme,
+    string Host,
+    string Path,
+    string PathBase,
+    string QueryString,
+    IReadOnlyDictionary<string, string> Query,
+    IReadOnlyDictionary<string, string> Headers,
+    string? CorrelationId,
+    DateTimeOffset TimestampUtc);

--- a/src/UI/Api/EchoRequestReflection.cs
+++ b/src/UI/Api/EchoRequestReflection.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Http;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Builds diagnostic header maps for <see cref="EchoResponse"/> without exposing secrets.
+/// </summary>
+internal static class EchoRequestReflection
+{
+    private const string ApiKeyHeaderName = "X-Api-Key";
+    private const string ApiKeyRedactedValue = "[present]";
+
+    private static readonly HashSet<string> HopByHopHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Connection",
+        "Keep-Alive",
+        "Proxy-Authenticate",
+        "Proxy-Authorization",
+        "TE",
+        "Trailer",
+        "Transfer-Encoding",
+        "Upgrade"
+    };
+
+    private static readonly HashSet<string> ExcludedHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        "Set-Cookie"
+    };
+
+    private static readonly HashSet<string> DiagnosticHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Accept",
+        "Accept-Encoding",
+        "Accept-Language",
+        "User-Agent",
+        "Content-Type",
+        ApiKeyHeaderName,
+        "X-Correlation-ID",
+        "X-Forwarded-For",
+        "X-Forwarded-Proto",
+        "X-Forwarded-Host",
+        "Origin",
+        "Referer",
+        "If-None-Match",
+        "Cache-Control"
+    };
+
+    /// <summary>
+    /// Returns the first query-string value per key from the request.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> BuildQuery(IQueryCollection query)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in query)
+        {
+            result[pair.Key] = pair.Value.ToString();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns selected diagnostic headers with sensitive values redacted or omitted.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> BuildHeaders(IHeaderDictionary headers)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in headers)
+        {
+            if (HopByHopHeaderNames.Contains(pair.Key) || ExcludedHeaderNames.Contains(pair.Key))
+            {
+                continue;
+            }
+
+            if (!DiagnosticHeaderNames.Contains(pair.Key))
+            {
+                continue;
+            }
+
+            if (pair.Key.Equals(ApiKeyHeaderName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!string.IsNullOrEmpty(pair.Value.ToString()))
+                {
+                    result[pair.Key] = ApiKeyRedactedValue;
+                }
+
+                continue;
+            }
+
+            var value = pair.Value.ToString();
+            if (!string.IsNullOrEmpty(value))
+            {
+                result[pair.Key] = value;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/UnitTests/Api/ApiRateLimitingWebTests.cs
+++ b/src/UnitTests/Api/ApiRateLimitingWebTests.cs
@@ -150,6 +150,15 @@ public class ApiRateLimitingWebTests
     }
 
     [Test]
+    public async Task RateLimiting_EchoRoute_EnforcesLimit()
+    {
+        await using var factory = new TunableApiRateLimitWebApplicationFactory(StrictLimitSettings(1));
+        using var client = factory.CreateClient();
+        (await client.GetAsync("/api/echo")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await client.GetAsync("/api/echo")).StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    [Test]
     public async Task RateLimiting_WhenDisabled_AllowsUnlimitedApiCalls()
     {
         var settings = new Dictionary<string, string?>(StrictLimitSettings(1))

--- a/src/UnitTests/UI.Api/EchoControllerTests.cs
+++ b/src/UnitTests/UI.Api/EchoControllerTests.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.ServiceDefaults;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EchoControllerTests
+{
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    [Test]
+    public void Get_Should_ReturnJson_WithRequestReflection_When_QueryAndHeadersPresent()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 7, 12, 15, 0, 0, TimeSpan.Zero));
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("localhost", 7174);
+        context.Request.Path = "/api/echo";
+        context.Request.PathBase = "/app";
+        context.Request.QueryString = new QueryString("?a=1&b=2");
+        context.Request.Headers.Accept = "application/json";
+        context.Request.Headers.UserAgent = "EchoTest/1.0";
+
+        var controller = new EchoController(clock)
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<EchoResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Method.ShouldBe("GET");
+        payload.Scheme.ShouldBe("https");
+        payload.Host.ShouldBe("localhost:7174");
+        payload.Path.ShouldBe("/api/echo");
+        payload.PathBase.ShouldBe("/app");
+        payload.QueryString.ShouldBe("?a=1&b=2");
+        payload.Query["a"].ShouldBe("1");
+        payload.Query["b"].ShouldBe("2");
+        payload.Headers["Accept"].ShouldBe("application/json");
+        payload.Headers["User-Agent"].ShouldBe("EchoTest/1.0");
+    }
+
+    [Test]
+    public void Get_Should_RedactSensitiveHeaders_When_AuthorizationOrApiKeyPresent()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 7, 12, 15, 0, 0, TimeSpan.Zero));
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Authorization = "Bearer secret";
+        context.Request.Headers.Cookie = "session=abc";
+        context.Request.Headers["X-Api-Key"] = "my-secret-key";
+        context.Request.Headers.UserAgent = "EchoTest/1.0";
+
+        var controller = new EchoController(clock)
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var payload = JsonSerializer.Deserialize<EchoResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Headers.ContainsKey("Authorization").ShouldBeFalse();
+        payload.Headers.ContainsKey("Cookie").ShouldBeFalse();
+        payload.Headers["X-Api-Key"].ShouldBe("[present]");
+        payload.Headers["User-Agent"].ShouldBe("EchoTest/1.0");
+    }
+
+    [Test]
+    public void Get_Should_UseCorrelationIdFromHttpContextItems_When_Set()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 7, 12, 15, 0, 0, TimeSpan.Zero));
+        var context = new DefaultHttpContext();
+        context.Items[CorrelationIdConstants.HttpContextItemKey] = "test-correlation-abc";
+
+        var controller = new EchoController(clock)
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var payload = JsonSerializer.Deserialize<EchoResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.CorrelationId.ShouldBe("test-correlation-abc");
+    }
+
+    [Test]
+    public void Get_Should_ReturnNullCorrelationId_When_ItemNotSet()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 7, 12, 15, 0, 0, TimeSpan.Zero));
+        var context = new DefaultHttpContext();
+
+        var controller = new EchoController(clock)
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var payload = JsonSerializer.Deserialize<EchoResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.CorrelationId.ShouldBeNull();
+    }
+
+    [Test]
+    public void Get_Should_UseInjectedTimeProvider_ForTimestampUtc()
+    {
+        var expected = new DateTimeOffset(2026, 7, 12, 12, 30, 45, TimeSpan.Zero);
+        var clock = new FixedUtcTimeProvider(expected);
+        var context = new DefaultHttpContext();
+
+        var controller = new EchoController(clock)
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var payload = JsonSerializer.Deserialize<EchoResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.TimestampUtc.ShouldBe(expected);
+    }
+}

--- a/src/UnitTests/UI.Api/EchoRequestReflectionTests.cs
+++ b/src/UnitTests/UI.Api/EchoRequestReflectionTests.cs
@@ -1,0 +1,98 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EchoRequestReflectionTests
+{
+    [Test]
+    public void BuildHeaders_Should_IncludeDiagnosticHeaders_When_Present()
+    {
+        var headers = new HeaderDictionary
+        {
+            ["Accept"] = "application/json",
+            ["User-Agent"] = "EchoTest/1.0",
+            ["X-Forwarded-For"] = "203.0.113.1",
+            ["Cache-Control"] = "no-cache"
+        };
+
+        var result = EchoRequestReflection.BuildHeaders(headers);
+
+        result["Accept"].ShouldBe("application/json");
+        result["User-Agent"].ShouldBe("EchoTest/1.0");
+        result["X-Forwarded-For"].ShouldBe("203.0.113.1");
+        result["Cache-Control"].ShouldBe("no-cache");
+    }
+
+    [Test]
+    public void BuildHeaders_Should_OmitHopByHopHeaders_When_Present()
+    {
+        var headers = new HeaderDictionary
+        {
+            ["Connection"] = "keep-alive",
+            ["Keep-Alive"] = "timeout=5",
+            ["Proxy-Authorization"] = "Basic abc",
+            ["Transfer-Encoding"] = "chunked",
+            ["User-Agent"] = "EchoTest/1.0"
+        };
+
+        var result = EchoRequestReflection.BuildHeaders(headers);
+
+        result.ContainsKey("Connection").ShouldBeFalse();
+        result.ContainsKey("Keep-Alive").ShouldBeFalse();
+        result.ContainsKey("Proxy-Authorization").ShouldBeFalse();
+        result.ContainsKey("Transfer-Encoding").ShouldBeFalse();
+        result["User-Agent"].ShouldBe("EchoTest/1.0");
+    }
+
+    [Test]
+    public void BuildHeaders_Should_RedactSensitiveHeaders_When_Present()
+    {
+        var headers = new HeaderDictionary
+        {
+            ["Authorization"] = "Bearer secret",
+            ["Cookie"] = "session=abc",
+            ["Set-Cookie"] = "session=abc",
+            ["X-Api-Key"] = "my-secret-key",
+            ["User-Agent"] = "EchoTest/1.0"
+        };
+
+        var result = EchoRequestReflection.BuildHeaders(headers);
+
+        result.ContainsKey("Authorization").ShouldBeFalse();
+        result.ContainsKey("Cookie").ShouldBeFalse();
+        result.ContainsKey("Set-Cookie").ShouldBeFalse();
+        result["X-Api-Key"].ShouldBe("[present]");
+        result["User-Agent"].ShouldBe("EchoTest/1.0");
+    }
+
+    [Test]
+    public void BuildHeaders_Should_ReturnEmptyDictionary_When_NoIncludedHeaders()
+    {
+        var headers = new HeaderDictionary
+        {
+            ["X-Custom-Header"] = "value"
+        };
+
+        var result = EchoRequestReflection.BuildHeaders(headers);
+
+        result.Count.ShouldBe(0);
+    }
+
+    [Test]
+    public void BuildQuery_Should_ReturnFirstValuePerKey_When_QueryPresent()
+    {
+        var query = new QueryCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+        {
+            ["foo"] = "bar",
+            ["baz"] = "1"
+        });
+
+        var result = EchoRequestReflection.BuildQuery(query);
+
+        result["foo"].ShouldBe("bar");
+        result["baz"].ShouldBe("1");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/echo", false)]
+    [TestCase("/api/v1.0/echo", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -60,6 +60,33 @@ public class ApiKeyAuthenticationWebTests
     }
 
     [Test]
+    public async Task Should_Return401_When_ApiEchoCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiEchoCalledWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var unversioned = await client.GetAsync("/api/echo");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/echo");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
     public async Task Should_Return401_When_WrongKey()
     {
         await using var factory = new ApiKeyProtectedWebApplicationFactory();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/echo` and `GET /api/v1.0/echo` diagnostic endpoints on UI.Server that return JSON reflecting key properties of the incoming HTTP request (method, path, query, selected headers, correlation ID, timestamp). Useful for debugging proxies, API keys, and client configuration.

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/EchoModels.cs` | `EchoResponse` record with camelCase JSON properties |
| `src/UI/Api/EchoRequestReflection.cs` | Header/query builder with sensitive-value redaction |
| `src/UI/Api/Controllers/EchoController.cs` | Controller with dual routes, rate limiting, API key protection |
| `src/UnitTests/UI.Api/EchoControllerTests.cs` | Controller unit tests |
| `src/UnitTests/UI.Api/EchoRequestReflectionTests.cs` | Header reflection helper unit tests |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Echo path validation cases |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | 401/200 API key web tests for echo |
| `src/UnitTests/Api/ApiRateLimitingWebTests.cs` | Rate-limit smoke test for echo route |
| `src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs` | Full-pipeline integration tests |

## Testing Notes

- Private build passed: 279 unit tests, 127 integration tests (all green)
- Echo-specific tests cover request reflection, query parsing, correlation ID propagation, header redaction (`Authorization`, `Cookie`, `X-Api-Key`), API key middleware (401 without key, 200 with key), and rate limiting
- No Playwright acceptance tests required (backend-only diagnostic endpoint, no UI changes)

Closes #6742
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa536032-c59d-46ca-afeb-71a6edb7c6c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa536032-c59d-46ca-afeb-71a6edb7c6c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

