### PR TITLE
New API endpoint GET /api/features/flags for runtime feature flag status (#6747)

### DIFF
--- a/src/IntegrationTests/Api/FeatureFlagsApiKeyProtectedWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/FeatureFlagsApiKeyProtectedWebApplicationFactory.cs
@@ -1,0 +1,34 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Same as <see cref="FeatureFlagsWebApplicationFactory"/> with API key validation enabled.
+/// </summary>
+public sealed class FeatureFlagsApiKeyProtectedWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "true",
+                ["ApiKeyAuthentication:ValidationKey"] = ApiKeyProtectedWebApplicationFactory.TestApiKey,
+                ["FeatureFlags:SampleFeatureA"] = "true",
+                ["FeatureFlags:SampleFeatureB"] = "false"
+            });
+        });
+    }
+}

--- a/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class FeatureFlagsEndpointIntegrationTests
+{
+    private FeatureFlagsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new FeatureFlagsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetFeatureFlagsUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/features/flags");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetFeatureFlagsVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/features/flags");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+    }
+
+    [Test]
+    public async Task Should_ExposeFlatCamelCaseFlagProperties_When_GetFeatureFlags()
+    {
+        var response = await _client!.GetAsync("/api/features/flags");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("sampleFeatureA", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("sampleFeatureB", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeFalse();
+        doc.RootElement.TryGetProperty("environment", out _).ShouldBeFalse();
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_ExposeFeatureFlags_FromConfiguration_When_GetFeatureFlags()
+    {
+        var response = await _client!.GetAsync("/api/features/flags");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!["sampleFeatureA"].ShouldBeTrue();
+        payload["sampleFeatureB"].ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_ExposeFeatureFlags_FromOverriddenConfiguration_When_GetFeatureFlags()
+    {
+        await using var factory = new FeatureFlagsWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["FeatureFlags:SampleFeatureA"] = "false",
+                    ["FeatureFlags:SampleFeatureB"] = "true"
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/features/flags");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!["sampleFeatureA"].ShouldBeFalse();
+        payload["sampleFeatureB"].ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_AlignWithDiagnosticsFlagValues_When_BothEndpointsCalled()
+    {
+        await using var factory = new FeatureFlagsWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["FeatureFlags:SampleFeatureA"] = "false",
+                    ["FeatureFlags:SampleFeatureB"] = "true"
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var flagsResponse = await client.GetAsync("/api/features/flags");
+        flagsResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var flags = await flagsResponse.Content.ReadFromJsonAsync<Dictionary<string, bool>>(
+            ConditionalGetEtag.JsonSerializerOptions);
+
+        var diagnosticsResponse = await client.GetAsync("/api/diagnostics");
+        diagnosticsResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var diagnostics = await diagnosticsResponse.Content.ReadFromJsonAsync<DiagnosticsResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        flags.ShouldNotBeNull();
+        diagnostics.ShouldNotBeNull();
+        flags!["sampleFeatureA"].ShouldBe(diagnostics!.FeatureFlags.SampleFeatureA);
+        flags["sampleFeatureB"].ShouldBe(diagnostics.FeatureFlags.SampleFeatureB);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabledAndFeatureFlagsProtected()
+    {
+        await using var factory = new FeatureFlagsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/features/flags");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/features/flags");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.GetAsync("/api/features/flags");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/features/flags");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return304NotModified_When_IfNoneMatchMatchesEtag()
+    {
+        var first = await _client!.GetAsync("/api/features/flags");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var etag = first.Headers.ETag?.Tag;
+        etag.ShouldNotBeNullOrWhiteSpace();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/features/flags");
+        request.Headers.TryAddWithoutValidation("If-None-Match", etag);
+        var second = await _client.SendAsync(request);
+
+        second.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await second.Content.ReadAsStringAsync()).ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task Should_NotAlterDiagnosticsEndpoint_When_FeatureFlagsRouteAdded()
+    {
+        var response = await _client!.GetAsync("/api/diagnostics");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("environment", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeTrue();
+    }
+}

--- a/src/IntegrationTests/Api/FeatureFlagsWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/FeatureFlagsWebApplicationFactory.cs
@@ -1,0 +1,33 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server for <c>/api/features/flags</c> integration tests with explicit feature-flag configuration.
+/// </summary>
+public sealed class FeatureFlagsWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", "Data Source=:memory:");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = "Data Source=:memory:",
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = "",
+                ["FeatureFlags:SampleFeatureA"] = "true",
+                ["FeatureFlags:SampleFeatureB"] = "false"
+            });
+        });
+    }
+}

--- a/src/UI/Api/Controllers/FeaturesController.cs
+++ b/src/UI/Api/Controllers/FeaturesController.cs
@@ -1,0 +1,32 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes runtime feature-flag status for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/features")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/features")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class FeaturesController(IOptions<DiagnosticsFeatureFlagsOptions> featureFlagsOptions) : ControllerBase
+{
+    /// <summary>
+    /// Returns a flat JSON object of all cataloged feature flags and their current enabled/disabled status.
+    /// </summary>
+    [HttpGet("flags")]
+    public IActionResult GetFlags()
+    {
+        var payload = FeatureFlagStatusResolver.Resolve(featureFlagsOptions.Value);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/FeatureFlagCatalog.cs
+++ b/src/UI/Api/FeatureFlagCatalog.cs
@@ -1,0 +1,17 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Static catalog of known feature-flag keys and how each resolves from <see cref="DiagnosticsFeatureFlagsOptions"/>.
+/// </summary>
+public static class FeatureFlagCatalog
+{
+    /// <summary>
+    /// Known feature-flag keys (camelCase JSON contract) mapped to value resolvers.
+    /// </summary>
+    public static IReadOnlyDictionary<string, Func<DiagnosticsFeatureFlagsOptions, bool>> Entries { get; } =
+        new Dictionary<string, Func<DiagnosticsFeatureFlagsOptions, bool>>(StringComparer.Ordinal)
+        {
+            ["sampleFeatureA"] = options => options.SampleFeatureA,
+            ["sampleFeatureB"] = options => options.SampleFeatureB,
+        };
+}

--- a/src/UI/Api/FeatureFlagStatusResolver.cs
+++ b/src/UI/Api/FeatureFlagStatusResolver.cs
@@ -1,0 +1,18 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Resolves current enabled/disabled status for all cataloged feature flags from configuration options.
+/// </summary>
+public static class FeatureFlagStatusResolver
+{
+    /// <summary>
+    /// Returns a flat dictionary of catalog keys to current boolean values from <paramref name="options"/>.
+    /// </summary>
+    public static IReadOnlyDictionary<string, bool> Resolve(DiagnosticsFeatureFlagsOptions options)
+    {
+        var result = new Dictionary<string, bool>(StringComparer.Ordinal);
+        foreach (var (key, getter) in FeatureFlagCatalog.Entries)
+            result[key] = getter(options);
+        return result;
+    }
+}

--- a/src/UnitTests/UI.Api/FeatureFlagStatusResolverTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagStatusResolverTests.cs
@@ -1,0 +1,38 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagStatusResolverTests
+{
+    [Test]
+    public void Should_ReturnAllCatalogKeys_When_ResolveCalled()
+    {
+        var options = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+
+        var result = FeatureFlagStatusResolver.Resolve(options);
+
+        result.Keys.OrderBy(k => k).ShouldBe(FeatureFlagCatalog.Entries.Keys.OrderBy(k => k).ToArray());
+    }
+
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void Should_MapSampleFeatureAAndB_FromOptionsPermutations_When_ResolveCalled(
+        bool sampleFeatureA,
+        bool sampleFeatureB)
+    {
+        var options = new DiagnosticsFeatureFlagsOptions
+        {
+            SampleFeatureA = sampleFeatureA,
+            SampleFeatureB = sampleFeatureB
+        };
+
+        var result = FeatureFlagStatusResolver.Resolve(options);
+
+        result["sampleFeatureA"].ShouldBe(sampleFeatureA);
+        result["sampleFeatureB"].ShouldBe(sampleFeatureB);
+    }
+}

--- a/src/UnitTests/UI.Api/FeaturesControllerTests.cs
+++ b/src/UnitTests/UI.Api/FeaturesControllerTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeaturesControllerTests
+{
+    [Test]
+    public void Should_Return200AndFlatJsonDictionary_When_GetFlagsCalled()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+        var controller = CreateController(flags);
+
+        var result = controller.GetFlags();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<Dictionary<string, bool>>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!["sampleFeatureA"].ShouldBeTrue();
+        payload["sampleFeatureB"].ShouldBeFalse();
+    }
+
+    [Test]
+    public void Should_MatchResolverOutput_When_GetFlagsCalled()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = false, SampleFeatureB = true };
+        var controller = CreateController(flags);
+
+        var result = controller.GetFlags();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var payload = JsonSerializer.Deserialize<Dictionary<string, bool>>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        var expected = FeatureFlagStatusResolver.Resolve(flags);
+        payload!.Count.ShouldBe(expected.Count);
+        foreach (var (key, value) in expected)
+            payload[key].ShouldBe(value);
+    }
+
+    [Test]
+    public void Should_IncludeEtagOrConditionalGetBehavior_When_GetFlagsCalled()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+        var httpContext = new DefaultHttpContext();
+        var controller = CreateController(flags, httpContext);
+
+        var first = controller.GetFlags();
+        first.ShouldBeOfType<ContentResult>();
+        httpContext.Response.Headers.ETag.ToString().ShouldNotBeNullOrWhiteSpace();
+
+        var etag = httpContext.Response.Headers.ETag.ToString();
+        var secondContext = new DefaultHttpContext();
+        secondContext.Request.Headers.IfNoneMatch = etag;
+        var secondController = CreateController(flags, secondContext);
+
+        var second = secondController.GetFlags();
+
+        second.ShouldBeOfType<StatusCodeResult>();
+        ((StatusCodeResult)second).StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+
+    private static FeaturesController CreateController(
+        DiagnosticsFeatureFlagsOptions flags,
+        HttpContext? httpContext = null)
+    {
+        return new FeaturesController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext ?? new DefaultHttpContext()
+            }
+        };
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/features/flags", false)]
+    [TestCase("/api/v1.0/features/flags", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]


### PR DESCRIPTION
## Summary

Adds `GET /api/features/flags` and `GET /api/v1.0/features/flags` — a dedicated, read-only HTTP API that returns a flat JSON object of all statically cataloged feature-flag names and their current enabled/disabled values resolved from `DiagnosticsFeatureFlagsOptions` / `FeatureFlags` configuration.

This endpoint is intended for operators, deployment verification, and monitoring integrations. No Blazor UI changes.

Closes #6747

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/FeatureFlagCatalog.cs` | Static catalog of known feature-flag keys and value resolvers |
| `src/UI/Api/FeatureFlagStatusResolver.cs` | Resolves current flag values from configuration options |
| `src/UI/Api/Controllers/FeaturesController.cs` | New controller with conditional GET / weak ETag support |
| `src/UnitTests/UI.Api/FeatureFlagStatusResolverTests.cs` | Unit tests for catalog resolution |
| `src/UnitTests/UI.Api/FeaturesControllerTests.cs` | Unit tests for controller JSON shape, resolver alignment, ETag/304 |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Confirms flags routes are protected when API key auth is enabled |
| `src/IntegrationTests/Api/FeatureFlagsWebApplicationFactory.cs` | Integration test host with feature-flag configuration |
| `src/IntegrationTests/Api/FeatureFlagsApiKeyProtectedWebApplicationFactory.cs` | Integration test host with API-key auth enabled |
| `src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs` | HTTP integration tests for unversioned/versioned routes, config overrides, API key, ETag 304, diagnostics regression |

## Testing Notes

- **Private build:** `PrivateBuild.ps1` — 274 unit tests and 125 integration tests passed
- **Unit tests:** Resolver catalog coverage, controller flat JSON contract, ETag conditional GET (304), API-key path classification
- **Integration tests:** Unversioned and versioned routes, camelCase flat JSON (`sampleFeatureA`, `sampleFeatureB`), configuration overrides, alignment with `/api/diagnostics`, API-key enforcement, `If-None-Match` → 304, diagnostics endpoint regression guard
- **Acceptance tests:** Skipped (API-only; no UX change)

## Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied
