### PR TITLE
New API endpoint GET /api/health/detailed for component-level health reporting (#6740)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Server;
 using Shouldly;
 
 namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
@@ -25,6 +26,12 @@ public class DetailedHealthEndpointIntegrationTests
         _client?.Dispose();
         _factory?.Dispose();
     }
+
+    [SetUp]
+    public void SetUp() => NeedsRebootHealthCheck.NeedsReboot = false;
+
+    [TearDown]
+    public void TearDown() => NeedsRebootHealthCheck.NeedsReboot = false;
 
     [Test]
     public async Task Should_Return200AndJson_When_GetSimpleHealth()
@@ -139,5 +146,80 @@ public class DetailedHealthEndpointIntegrationTests
                 || c.Status == ComponentHealthStatus.Degraded
                 || c.Status == ComponentHealthStatus.Unhealthy).ShouldBeTrue();
         }
+    }
+
+    [Test]
+    public async Task Should_Return200AndSamePayloadShape_When_LegacyAndV1DetailedPaths()
+    {
+        var legacy = await _client!.GetAsync("/api/health/detailed");
+        var v1 = await _client.GetAsync("/api/v1.0/health/detailed");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.Headers.TryGetValues("api-supported-versions", out var versions).ShouldBeTrue();
+        versions.ShouldNotBeNull();
+        string.Join(", ", versions!).ShouldContain("1.0");
+
+        var legacyReport = await legacy.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var v1Report = await v1.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        legacyReport.ShouldNotBeNull();
+        v1Report.ShouldNotBeNull();
+        legacyReport!.OverallStatus.ShouldBe(v1Report!.OverallStatus);
+        legacyReport.Components.Select(c => c.Name).ToHashSet()
+            .ShouldBe(v1Report.Components.Select(c => c.Name).ToHashSet());
+    }
+
+    [Test]
+    public async Task Should_Return200WithUnhealthyOverallStatus_When_ComponentFails()
+    {
+        var setResponse = await _client!.GetAsync("/_demo/setneedsreboot/true");
+        setResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var response = await _client.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        report!.OverallStatus.ShouldBe(ComponentHealthStatus.Unhealthy);
+        var needsReboot = report.Components.Single(c => c.Name == "NeedsReboot");
+        needsReboot.Status.ShouldBe(ComponentHealthStatus.Unhealthy);
+    }
+
+    [Test]
+    public async Task Should_ExcludeLiveTaggedChecks_When_BuildingDetailedReport()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        var names = report!.Components.Select(c => c.Name).ToHashSet();
+        names.ShouldNotContain("self");
+        names.ShouldContain("NeedsReboot");
+    }
+
+    [Test]
+    public async Task Should_SerializeCamelCaseProperties_When_DetailedHealthReturned()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("overallStatus", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("checkedAtUtc", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("components", out var components).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("OverallStatus", out _).ShouldBeFalse();
+        doc.RootElement.TryGetProperty("CheckedAtUtc", out _).ShouldBeFalse();
+
+        var first = components.EnumerateArray().First();
+        first.TryGetProperty("name", out _).ShouldBeTrue();
+        first.TryGetProperty("status", out _).ShouldBeTrue();
+        first.TryGetProperty("durationMs", out _).ShouldBeTrue();
+        first.TryGetProperty("Name", out _).ShouldBeFalse();
     }
 }

--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -230,7 +230,16 @@ public class DetailedHealthEndpointIntegrationTests
         first.TryGetProperty("name", out _).ShouldBeTrue();
         first.TryGetProperty("status", out _).ShouldBeTrue();
         first.TryGetProperty("durationMs", out _).ShouldBeTrue();
-        first.TryGetProperty("exceptionMessage", out _).ShouldBeFalse();
         first.TryGetProperty("Name", out _).ShouldBeFalse();
+        first.TryGetProperty("DurationMs", out _).ShouldBeFalse();
+
+        foreach (var component in components.EnumerateArray())
+        {
+            foreach (var property in component.EnumerateObject())
+            {
+                char.IsUpper(property.Name[0]).ShouldBeFalse(
+                    $"Property '{property.Name}' should be camelCase");
+            }
+        }
     }
 }

--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -28,10 +28,18 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [SetUp]
-    public void SetUp() => NeedsRebootHealthCheck.NeedsReboot = false;
+    public async Task SetUp()
+    {
+        NeedsRebootHealthCheck.NeedsReboot = false;
+        await _client!.GetAsync("/_demo/setneedsreboot/false");
+    }
 
     [TearDown]
-    public void TearDown() => NeedsRebootHealthCheck.NeedsReboot = false;
+    public async Task TearDown()
+    {
+        NeedsRebootHealthCheck.NeedsReboot = false;
+        await _client!.GetAsync("/_demo/setneedsreboot/false");
+    }
 
     [Test]
     public async Task Should_Return200AndJson_When_GetSimpleHealth()
@@ -210,16 +218,19 @@ public class DetailedHealthEndpointIntegrationTests
 
         var json = await response.Content.ReadAsStringAsync();
         using var doc = JsonDocument.Parse(json);
-        doc.RootElement.TryGetProperty("overallStatus", out _).ShouldBeTrue();
-        doc.RootElement.TryGetProperty("checkedAtUtc", out _).ShouldBeTrue();
-        doc.RootElement.TryGetProperty("components", out var components).ShouldBeTrue();
-        doc.RootElement.TryGetProperty("OverallStatus", out _).ShouldBeFalse();
-        doc.RootElement.TryGetProperty("CheckedAtUtc", out _).ShouldBeFalse();
+        var root = doc.RootElement;
+
+        root.TryGetProperty("overallStatus", out _).ShouldBeTrue();
+        root.TryGetProperty("checkedAtUtc", out _).ShouldBeTrue();
+        root.TryGetProperty("components", out var components).ShouldBeTrue();
+        root.TryGetProperty("OverallStatus", out _).ShouldBeFalse();
+        root.TryGetProperty("CheckedAtUtc", out _).ShouldBeFalse();
 
         var first = components.EnumerateArray().First();
         first.TryGetProperty("name", out _).ShouldBeTrue();
         first.TryGetProperty("status", out _).ShouldBeTrue();
         first.TryGetProperty("durationMs", out _).ShouldBeTrue();
+        first.TryGetProperty("exceptionMessage", out _).ShouldBeFalse();
         first.TryGetProperty("Name", out _).ShouldBeFalse();
     }
 }

--- a/src/UnitTests/Api/ApiRateLimitingWebTests.cs
+++ b/src/UnitTests/Api/ApiRateLimitingWebTests.cs
@@ -20,6 +20,21 @@ public class ApiRateLimitingWebTests
         };
 
     [Test]
+    public async Task Should_Return429WithRetryAfter_When_DetailedHealthExceedsSlidingWindowPermitLimit()
+    {
+        await using var factory = new TunableApiRateLimitWebApplicationFactory(StrictLimitSettings(2));
+        using var client = factory.CreateClient();
+
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var limited = await client.GetAsync("/api/health/detailed");
+        limited.StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+        limited.Headers.TryGetValues("Retry-After", out var retryValues).ShouldBeTrue();
+        retryValues!.First().ShouldBe("2");
+    }
+
+    [Test]
     public async Task Should_Return429WithRetryAfter_When_ApiRequestsExceedSlidingWindowPermitLimit()
     {
         await using var factory = new RateLimitedApiWebApplicationFactory();

--- a/src/UnitTests/Api/ApiRateLimitingWebTests.cs
+++ b/src/UnitTests/Api/ApiRateLimitingWebTests.cs
@@ -176,4 +176,16 @@ public class ApiRateLimitingWebTests
         for (var i = 0; i < 5; i++)
             (await client.GetAsync("/api/time")).StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return429_When_DetailedHealthRateLimitExceeded()
+    {
+        await using var factory = new TunableApiRateLimitWebApplicationFactory(StrictLimitSettings(2));
+        using var client = factory.CreateClient();
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        var blocked = await client.GetAsync("/api/health/detailed");
+        blocked.StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+        blocked.Headers.TryGetValues("Retry-After", out _).ShouldBeTrue();
+    }
 }

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -33,6 +33,33 @@ public class ApiKeyAuthenticationWebTests
     }
 
     [Test]
+    public async Task Should_Return401_When_ApiDetailedHealthCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/health/detailed");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiDetailedHealthCalledWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var unversioned = await client.GetAsync("/api/health/detailed");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/health/detailed");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
     public async Task Should_Return401_When_ApiDiagnosticsCalledWithoutKey()
     {
         await using var factory = new ApiKeyProtectedWebApplicationFactory();

--- a/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
+++ b/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 
 namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
@@ -54,7 +56,17 @@ public class EtagConditionalGetWebTests
     [Test]
     public async Task Should_Return304NotModified_When_DetailedHealthIfNoneMatchMatchesEtag()
     {
-        using var client = _factory!.CreateClient();
+        await using var factory = new ApiVersioningRoutingWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDetailedHealthReportProvider));
+                if (descriptor is not null)
+                    services.Remove(descriptor);
+                services.AddSingleton<IDetailedHealthReportProvider, StubFixedDetailedHealthReportProvider>();
+            });
+        });
+        using var client = factory.CreateClient();
         var first = await client.GetAsync("/api/health/detailed");
         first.StatusCode.ShouldBe(HttpStatusCode.OK);
         var etag = first.Headers.ETag;

--- a/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
+++ b/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
@@ -41,4 +41,29 @@ public class EtagConditionalGetWebTests
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Headers.ETag.ShouldNotBeNull();
     }
+
+    [Test]
+    public async Task Should_IncludeEtagHeader_When_GetDetailedHealth()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+    }
+
+    [Test]
+    public async Task Should_Return304NotModified_When_DetailedHealthIfNoneMatchMatchesEtag()
+    {
+        using var client = _factory!.CreateClient();
+        var first = await client.GetAsync("/api/health/detailed");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var etag = first.Headers.ETag;
+        etag.ShouldNotBeNull();
+
+        using var second = new HttpRequestMessage(HttpMethod.Get, "/api/health/detailed");
+        second.Headers.IfNoneMatch.Add(etag!);
+        var notModified = await client.SendAsync(second);
+        notModified.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
+    }
 }

--- a/src/UnitTests/UI.Server/StubFixedDetailedHealthReportProvider.cs
+++ b/src/UnitTests/UI.Server/StubFixedDetailedHealthReportProvider.cs
@@ -1,0 +1,27 @@
+using ClearMeasure.Bootcamp.UI.Api;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+/// <summary>
+/// Returns a fixed detailed health report so conditional GET / ETag tests are deterministic.
+/// </summary>
+internal sealed class StubFixedDetailedHealthReportProvider : IDetailedHealthReportProvider
+{
+    private static readonly DetailedHealthReport FixedReport = new()
+    {
+        OverallStatus = ComponentHealthStatus.Healthy,
+        CheckedAtUtc = new DateTime(2026, 7, 12, 12, 0, 0, DateTimeKind.Utc),
+        Components =
+        [
+            new ComponentHealthEntry
+            {
+                Name = "API",
+                Status = ComponentHealthStatus.Healthy,
+                DurationMs = 1.0
+            }
+        ]
+    };
+
+    public Task<DetailedHealthReport> GetReportAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(FixedReport);
+}


### PR DESCRIPTION
## Summary

Adds and completes test coverage for `GET /api/health/detailed` — a machine-oriented JSON endpoint that reports per-component health status for monitoring and load-balancer probes. The endpoint implementation (`DetailedHealthController`, `DetailedHealthReportProvider`, models, DI registration) was already present; this PR closes all gaps identified in the issue test design.

## What was implemented

- **Endpoint (pre-existing):** `GET /api/health/detailed` returns `overallStatus`, `checkedAtUtc`, and a `components` array with per-check details. Companion `GET /api/health` summary remains on the same controller.
- **New integration tests:** API versioning parity (`/api/health/detailed` vs `/api/v1.0/health/detailed`), unhealthy scenario via `NeedsReboot`, live-tag exclusion (`self` excluded, `NeedsReboot` included), camelCase JSON serialization.
- **New web/unit tests:** ETag header and 304 conditional GET (with stub provider for deterministic payload), API key auth on detailed route, rate limiting on detailed route.

## Files changed

| File | Description |
|------|-------------|
| `src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs` | Added versioning parity, unhealthy, live-tag exclusion, camelCase tests |
| `src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs` | Added ETag header and 304 tests for detailed health |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Added API key auth tests for detailed route |
| `src/UnitTests/Api/ApiRateLimitingWebTests.cs` | Added rate-limit test for detailed health |
| `src/UnitTests/UI.Server/StubFixedDetailedHealthReportProvider.cs` | Stub provider for deterministic ETag/304 testing |

## Testing notes

- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./PrivateBuild.ps1` — passed (270 unit + 120 integration tests)
- Acceptance tests skipped (no Blazor UX change)
- Verified: anonymous access (API key disabled), 200 with unhealthy payload, camelCase JSON, weak ETag/304, rate limiting 429, versioned route parity

Closes #6740