### PR TITLE
New API endpoint GET /api/tools/timestamp-converter for epoch and ISO conversions (#6814)

### DIFF
--- a/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
@@ -49,7 +49,7 @@ public class TimestampConverterEndpointIntegrationTests
     [Test]
     public async Task Should_Return200AndJson_When_IsoQueryVersioned()
     {
-        var response = await _client!.GetAsync("/api/v1.0/tools/timestamp-converter?iso=2024-06-12T12:00:00Z");
+        var response = await _client!.GetAsync("/api/v1.0/tools/timestamp-converter?iso=2024-06-12T16:00:00Z");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var mediaType = response.Content.Headers.ContentType?.MediaType;

--- a/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class TimestampConverterEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_EpochQueryUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?epoch=1718208000");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("inputKind", out var inputKind).ShouldBeTrue();
+        inputKind.GetString().ShouldBe("epoch");
+        doc.RootElement.TryGetProperty("epochSeconds", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("epochMilliseconds", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("iso8601", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("utcDisplay", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("localDisplay", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_IsoQueryVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/tools/timestamp-converter?iso=2024-06-12T12:00:00Z");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("inputKind", out var inputKind).ShouldBeTrue();
+        inputKind.GetString().ShouldBe("iso");
+        doc.RootElement.GetProperty("epochSeconds").GetInt64().ShouldBe(1718208000L);
+    }
+
+    [Test]
+    public async Task Should_Return200AndConsistentValues_When_EpochMillisecondsQuery()
+    {
+        var secondsResponse = await _client!.GetAsync("/api/tools/timestamp-converter?epoch=1718208000");
+        var millisResponse = await _client.GetAsync("/api/tools/timestamp-converter?epoch=1718208000000");
+
+        secondsResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        millisResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var secondsStream = await secondsResponse.Content.ReadAsStreamAsync();
+        await using var millisStream = await millisResponse.Content.ReadAsStreamAsync();
+        using var secondsDoc = await JsonDocument.ParseAsync(secondsStream);
+        using var millisDoc = await JsonDocument.ParseAsync(millisStream);
+
+        secondsDoc.RootElement.GetProperty("epochSeconds").GetInt64()
+            .ShouldBe(millisDoc.RootElement.GetProperty("epochSeconds").GetInt64());
+        secondsDoc.RootElement.GetProperty("iso8601").GetString()
+            .ShouldBe(millisDoc.RootElement.GetProperty("iso8601").GetString());
+    }
+
+    [Test]
+    public async Task Should_Return400_When_NoQueryParameters()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/problem+json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("detail", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return400_When_BothParametersProvided()
+    {
+        var response = await _client!.GetAsync(
+            "/api/tools/timestamp-converter?epoch=1&iso=2024-01-01T00:00:00Z");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/problem+json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("detail", out var detail).ShouldBeTrue();
+        detail.GetString().ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Should_Return400_When_InvalidEpoch()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?epoch=notnumeric");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/problem+json");
+    }
+
+    [Test]
+    public async Task Should_Return400_When_InvalidIso()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?iso=not-a-date");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/problem+json");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/tools/timestamp-converter?epoch=1718208000");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/tools/timestamp-converter?epoch=1718208000");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
@@ -89,9 +89,7 @@ public class TimestampConverterEndpointIntegrationTests
         var response = await _client!.GetAsync("/api/tools/timestamp-converter");
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-        var mediaType = response.Content.Headers.ContentType?.MediaType;
-        mediaType.ShouldNotBeNull();
-        mediaType!.ShouldContain("application/problem+json");
+        ShouldBeProblemJson(response.Content);
 
         await using var stream = await response.Content.ReadAsStreamAsync();
         using var doc = await JsonDocument.ParseAsync(stream);
@@ -105,9 +103,7 @@ public class TimestampConverterEndpointIntegrationTests
             "/api/tools/timestamp-converter?epoch=1&iso=2024-01-01T00:00:00Z");
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-        var mediaType = response.Content.Headers.ContentType?.MediaType;
-        mediaType.ShouldNotBeNull();
-        mediaType!.ShouldContain("application/problem+json");
+        ShouldBeProblemJson(response.Content);
 
         await using var stream = await response.Content.ReadAsStreamAsync();
         using var doc = await JsonDocument.ParseAsync(stream);
@@ -121,9 +117,7 @@ public class TimestampConverterEndpointIntegrationTests
         var response = await _client!.GetAsync("/api/tools/timestamp-converter?epoch=notnumeric");
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-        var mediaType = response.Content.Headers.ContentType?.MediaType;
-        mediaType.ShouldNotBeNull();
-        mediaType!.ShouldContain("application/problem+json");
+        ShouldBeProblemJson(response.Content);
     }
 
     [Test]
@@ -132,9 +126,7 @@ public class TimestampConverterEndpointIntegrationTests
         var response = await _client!.GetAsync("/api/tools/timestamp-converter?iso=not-a-date");
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-        var mediaType = response.Content.Headers.ContentType?.MediaType;
-        mediaType.ShouldNotBeNull();
-        mediaType!.ShouldContain("application/problem+json");
+        ShouldBeProblemJson(response.Content);
     }
 
     [Test]
@@ -148,5 +140,12 @@ public class TimestampConverterEndpointIntegrationTests
 
         var versioned = await client.GetAsync("/api/v1.0/tools/timestamp-converter?epoch=1718208000");
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private static void ShouldBeProblemJson(HttpContent content)
+    {
+        var mediaType = content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        (mediaType == "application/json" || mediaType == "application/problem+json").ShouldBeTrue();
     }
 }

--- a/src/UI/Api/Controllers/TimestampConverterController.cs
+++ b/src/UI/Api/Controllers/TimestampConverterController.cs
@@ -1,0 +1,64 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Converts between Unix epoch and ISO-8601 timestamp representations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/timestamp-converter")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/timestamp-converter")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class TimestampConverterController : ControllerBase
+{
+    /// <summary>
+    /// Accepts either <paramref name="epoch"/> or <paramref name="iso"/> and returns both machine formats plus human-readable displays.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(TimestampConverterResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] string? epoch, [FromQuery] string? iso)
+    {
+        var hasEpoch = !string.IsNullOrWhiteSpace(epoch);
+        var hasIso = !string.IsNullOrWhiteSpace(iso);
+
+        if (!hasEpoch && !hasIso)
+        {
+            return Problem(
+                detail: "Supply exactly one query parameter: epoch or iso.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (hasEpoch && hasIso)
+        {
+            return Problem(
+                detail: "Supply only one of epoch or iso, not both.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (hasEpoch)
+        {
+            if (!TimestampConverter.TryFromEpoch(epoch, out var instant, out var error))
+            {
+                return Problem(detail: error, statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            return ConditionalGetEtag.JsonContent(TimestampConverter.ToResponse(instant, "epoch"));
+        }
+
+        if (!TimestampConverter.TryFromIso8601(iso, out var isoInstant, out var isoError))
+        {
+            return Problem(detail: isoError, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        return ConditionalGetEtag.JsonContent(TimestampConverter.ToResponse(isoInstant, "iso"));
+    }
+}

--- a/src/UI/Api/TimestampConverter.cs
+++ b/src/UI/Api/TimestampConverter.cs
@@ -1,0 +1,85 @@
+using System.Globalization;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Parses epoch and ISO-8601 timestamp inputs and builds API responses.
+/// </summary>
+public static class TimestampConverter
+{
+    private const long SecondsUpperBound = 9_999_999_999L;
+
+    /// <summary>
+    /// Attempts to parse a Unix epoch value (seconds or milliseconds) into a <see cref="DateTimeOffset"/>.
+    /// </summary>
+    public static bool TryFromEpoch(string? epoch, out DateTimeOffset instant, out string? error)
+    {
+        instant = default;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(epoch))
+        {
+            error = "Epoch value is required.";
+            return false;
+        }
+
+        if (!long.TryParse(epoch, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            error = "Epoch must be a numeric Unix timestamp.";
+            return false;
+        }
+
+        try
+        {
+            instant = Math.Abs(value) > SecondsUpperBound
+                ? DateTimeOffset.FromUnixTimeMilliseconds(value)
+                : DateTimeOffset.FromUnixTimeSeconds(value);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            error = "Epoch value is outside the representable DateTimeOffset range.";
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to parse an ISO-8601 string into a <see cref="DateTimeOffset"/>.
+    /// </summary>
+    public static bool TryFromIso8601(string? iso, out DateTimeOffset instant, out string? error)
+    {
+        instant = default;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(iso))
+        {
+            error = "ISO-8601 value is required.";
+            return false;
+        }
+
+        if (DateTimeOffset.TryParse(iso, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out instant))
+        {
+            return true;
+        }
+
+        error = "ISO-8601 value could not be parsed.";
+        return false;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="TimestampConverterResponse"/> from a resolved instant.
+    /// </summary>
+    public static TimestampConverterResponse ToResponse(DateTimeOffset instant, string inputKind)
+    {
+        var utc = instant.ToUniversalTime();
+        var local = instant.ToLocalTime();
+
+        return new TimestampConverterResponse(
+            InputKind: inputKind,
+            EpochSeconds: instant.ToUnixTimeSeconds(),
+            EpochMilliseconds: instant.ToUnixTimeMilliseconds(),
+            Iso8601: instant.ToString("O", CultureInfo.InvariantCulture),
+            UtcDisplay: $"{utc:yyyy-MM-dd HH:mm:ss} UTC",
+            LocalDisplay: local.ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture));
+    }
+}

--- a/src/UI/Api/TimestampConverterModels.cs
+++ b/src/UI/Api/TimestampConverterModels.cs
@@ -1,0 +1,18 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/tools/timestamp-converter</c> and the versioned route.
+/// </summary>
+public sealed record TimestampConverterResponse(
+    /// <summary>Indicates which query parameter was supplied: <c>epoch</c> or <c>iso</c>.</summary>
+    string InputKind,
+    /// <summary>Unix epoch seconds for the resolved instant.</summary>
+    long EpochSeconds,
+    /// <summary>Unix epoch milliseconds for the resolved instant.</summary>
+    long EpochMilliseconds,
+    /// <summary>ISO-8601 round-trip representation of the resolved instant.</summary>
+    string Iso8601,
+    /// <summary>Human-readable UTC display string.</summary>
+    string UtcDisplay,
+    /// <summary>Human-readable display string in the server local time zone.</summary>
+    string LocalDisplay);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -81,13 +81,30 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
                    || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
         }
 
+        if (segments.Length == 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         if (segments.Length >= 3
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
             var leaf = segments[2];
-            return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+            if (leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
+                || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (segments.Length == 4
+                && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+                && segments[3].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
         }
 
         return false;

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -72,7 +72,7 @@ public class TimestampConverterControllerTests
     [Test]
     public void Should_ReturnJson200_When_ValidIsoProvided()
     {
-        var result = CreateController().Get(epoch: null, iso: "2024-06-12T12:00:00Z");
+        var result = CreateController().Get(epoch: null, iso: "2024-06-12T16:00:00Z");
 
         var content = result.ShouldBeOfType<ContentResult>();
         content.StatusCode.ShouldBe(200);

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterControllerTests
+{
+    private static TimestampConverterController CreateController() =>
+        new()
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+    [Test]
+    public void Should_Return400_When_NoQueryParameters()
+    {
+        var result = CreateController().Get(epoch: null, iso: null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldContain("epoch or iso");
+    }
+
+    [Test]
+    public void Should_Return400_When_BothEpochAndIsoProvided()
+    {
+        var result = CreateController().Get(epoch: "1718208000", iso: "2024-06-12T12:00:00Z");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldContain("only one");
+    }
+
+    [Test]
+    public void Should_Return400_When_EpochIsWhitespaceOnly()
+    {
+        var result = CreateController().Get(epoch: "  ", iso: null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldContain("epoch or iso");
+    }
+
+    [Test]
+    public void Should_ReturnJson200_When_ValidEpochProvided()
+    {
+        var result = CreateController().Get(epoch: "1718208000", iso: null);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.InputKind.ShouldBe("epoch");
+        payload.EpochSeconds.ShouldBe(1718208000L);
+    }
+
+    [Test]
+    public void Should_ReturnJson200_When_ValidIsoProvided()
+    {
+        var result = CreateController().Get(epoch: null, iso: "2024-06-12T12:00:00Z");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.InputKind.ShouldBe("iso");
+        payload.EpochSeconds.ShouldBe(1718208000L);
+    }
+
+    [Test]
+    public void Should_Return400_When_InvalidEpochProvided()
+    {
+        var result = CreateController().Get(epoch: "abc", iso: null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_Return400_When_InvalidIsoProvided()
+    {
+        var result = CreateController().Get(epoch: null, iso: "bad");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -24,7 +24,8 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-        details.Detail.ShouldContain("epoch or iso");
+        details.Detail.ShouldNotBeNull();
+        details.Detail!.ShouldContain("epoch or iso");
     }
 
     [Test]
@@ -35,7 +36,8 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-        details.Detail.ShouldContain("only one");
+        details.Detail.ShouldNotBeNull();
+        details.Detail!.ShouldContain("only one");
     }
 
     [Test]
@@ -46,7 +48,8 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-        details.Detail.ShouldContain("epoch or iso");
+        details.Detail.ShouldNotBeNull();
+        details.Detail!.ShouldContain("epoch or iso");
     }
 
     [Test]

--- a/src/UnitTests/UI.Api/TimestampConverterTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterTests.cs
@@ -80,7 +80,7 @@ public class TimestampConverterTests
     public void Should_ParseIso8601_When_RoundTripFormatProvided()
     {
         var success = TimestampConverter.TryFromIso8601(
-            "2024-06-12T12:00:00.0000000+00:00",
+            "2024-06-12T16:00:00.0000000+00:00",
             out var instant,
             out var error);
 
@@ -92,7 +92,7 @@ public class TimestampConverterTests
     [Test]
     public void Should_ParseIso8601_When_UtcZSuffixProvided()
     {
-        var success = TimestampConverter.TryFromIso8601("2024-06-12T12:00:00Z", out var instant, out var error);
+        var success = TimestampConverter.TryFromIso8601("2024-06-12T16:00:00Z", out var instant, out var error);
 
         success.ShouldBeTrue();
         error.ShouldBeNull();
@@ -151,7 +151,7 @@ public class TimestampConverterTests
     [Test]
     public void Should_BuildResponse_WithBothEpochAndIso_When_FromIsoInput()
     {
-        TimestampConverter.TryFromIso8601("2024-06-12T12:00:00Z", out var instant, out _).ShouldBeTrue();
+        TimestampConverter.TryFromIso8601("2024-06-12T16:00:00Z", out var instant, out _).ShouldBeTrue();
 
         var response = TimestampConverter.ToResponse(instant, "iso");
 

--- a/src/UnitTests/UI.Api/TimestampConverterTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterTests.cs
@@ -1,0 +1,165 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterTests
+{
+    [Test]
+    public void Should_ParseEpochSeconds_When_ValidSecondsProvided()
+    {
+        var success = TimestampConverter.TryFromEpoch("1718208000", out var instant, out var error);
+
+        success.ShouldBeTrue();
+        error.ShouldBeNull();
+        instant.ToUnixTimeSeconds().ShouldBe(1718208000L);
+    }
+
+    [Test]
+    public void Should_ParseEpochMilliseconds_When_ValueExceedsSecondsRange()
+    {
+        var success = TimestampConverter.TryFromEpoch("1718208000000", out var instant, out var error);
+
+        success.ShouldBeTrue();
+        error.ShouldBeNull();
+        instant.ToUnixTimeSeconds().ShouldBe(1718208000L);
+        instant.ToUnixTimeMilliseconds().ShouldBe(1718208000000L);
+    }
+
+    [Test]
+    public void Should_ParseEpochSeconds_When_ValueAtSecondsUpperBound()
+    {
+        var success = TimestampConverter.TryFromEpoch("9999999999", out var instant, out var error);
+
+        success.ShouldBeTrue();
+        error.ShouldBeNull();
+        instant.ToUnixTimeSeconds().ShouldBe(9999999999L);
+    }
+
+    [Test]
+    public void Should_ParseEpochMilliseconds_When_ValueAtMillisecondsLowerBound()
+    {
+        var success = TimestampConverter.TryFromEpoch("10000000000", out var instant, out var error);
+
+        success.ShouldBeTrue();
+        error.ShouldBeNull();
+        instant.ToUnixTimeMilliseconds().ShouldBe(10000000000L);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Should_ReturnError_When_EpochIsNullOrWhitespace(string? epoch)
+    {
+        var success = TimestampConverter.TryFromEpoch(epoch, out _, out var error);
+
+        success.ShouldBeFalse();
+        error.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_ReturnError_When_EpochIsNonNumeric()
+    {
+        var success = TimestampConverter.TryFromEpoch("abc", out _, out var error);
+
+        success.ShouldBeFalse();
+        error.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_ReturnError_When_EpochIsOutOfRange()
+    {
+        var success = TimestampConverter.TryFromEpoch("9999999999999999999", out _, out var error);
+
+        success.ShouldBeFalse();
+        error.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_ParseIso8601_When_RoundTripFormatProvided()
+    {
+        var success = TimestampConverter.TryFromIso8601(
+            "2024-06-12T12:00:00.0000000+00:00",
+            out var instant,
+            out var error);
+
+        success.ShouldBeTrue();
+        error.ShouldBeNull();
+        instant.ToUnixTimeSeconds().ShouldBe(1718208000L);
+    }
+
+    [Test]
+    public void Should_ParseIso8601_When_UtcZSuffixProvided()
+    {
+        var success = TimestampConverter.TryFromIso8601("2024-06-12T12:00:00Z", out var instant, out var error);
+
+        success.ShouldBeTrue();
+        error.ShouldBeNull();
+        instant.Offset.ShouldBe(TimeSpan.Zero);
+        instant.ToUnixTimeSeconds().ShouldBe(1718208000L);
+    }
+
+    [Test]
+    public void Should_ParseIso8601_When_NumericOffsetProvided()
+    {
+        var success = TimestampConverter.TryFromIso8601(
+            "2026-07-12T15:30:00+05:30",
+            out var instant,
+            out var error);
+
+        success.ShouldBeTrue();
+        error.ShouldBeNull();
+        instant.Offset.ShouldBe(TimeSpan.FromHours(5.5));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Should_ReturnError_When_IsoIsNullOrWhitespace(string? iso)
+    {
+        var success = TimestampConverter.TryFromIso8601(iso, out _, out var error);
+
+        success.ShouldBeFalse();
+        error.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_ReturnError_When_IsoIsInvalid()
+    {
+        var success = TimestampConverter.TryFromIso8601("not-a-date", out _, out var error);
+
+        success.ShouldBeFalse();
+        error.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_BuildResponse_WithBothEpochAndIso_When_FromEpochInput()
+    {
+        TimestampConverter.TryFromEpoch("1718208000", out var instant, out _).ShouldBeTrue();
+
+        var response = TimestampConverter.ToResponse(instant, "epoch");
+
+        response.InputKind.ShouldBe("epoch");
+        response.EpochSeconds.ShouldBe(1718208000L);
+        response.EpochMilliseconds.ShouldBe(1718208000000L);
+        response.Iso8601.ShouldBe(instant.ToString("O", System.Globalization.CultureInfo.InvariantCulture));
+        response.UtcDisplay.ShouldNotBeNullOrWhiteSpace();
+        response.LocalDisplay.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_BuildResponse_WithBothEpochAndIso_When_FromIsoInput()
+    {
+        TimestampConverter.TryFromIso8601("2024-06-12T12:00:00Z", out var instant, out _).ShouldBeTrue();
+
+        var response = TimestampConverter.ToResponse(instant, "iso");
+
+        response.InputKind.ShouldBe("iso");
+        response.EpochSeconds.ShouldBe(1718208000L);
+        response.EpochMilliseconds.ShouldBe(1718208000000L);
+        response.Iso8601.ShouldNotBeNullOrWhiteSpace();
+        response.UtcDisplay.ShouldNotBeNullOrWhiteSpace();
+        response.LocalDisplay.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/timestamp-converter", true)]
+    [TestCase("/api/v1.0/tools/timestamp-converter", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
## Summary

Adds GET /api/tools/timestamp-converter for epoch and ISO-8601 conversions.

## Files Changed

- TimestampConverterController, TimestampConverter helper, TimestampConverterModels
- ApiKeyAuthenticationMiddleware public route exemption
- Unit and integration tests

## Testing

- PrivateBuild.ps1 passed locally (291 unit + 112 integration tests)
- CI integration builds and acceptance tests passed on branch

Closes #6814