### PR TITLE
New API endpoint GET /api/tools/timestamp-converter for epoch and ISO conversions (#6746)

### DIFF
--- a/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/TimestampConverterEndpointIntegrationTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class TimestampConverterEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetUnversionedWithEpoch()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?epoch=1711792800");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        var payload = await DeserializeAsync(response);
+        payload.InputKind.ShouldBe("epoch");
+        payload.EpochSeconds.ShouldBe(1711792800);
+        payload.Iso8601Utc.ShouldNotBeNullOrWhiteSpace();
+        payload.Utc.ShouldNotBeNullOrWhiteSpace();
+        payload.Local.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetVersionedWithIso()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/tools/timestamp-converter?iso=2026-07-12T15:00:00Z");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await DeserializeAsync(response);
+        payload.InputKind.ShouldBe("iso");
+        payload.EpochSeconds.ShouldBe(new DateTimeOffset(2026, 7, 12, 15, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds());
+    }
+
+    [Test]
+    public async Task Should_Return400Problem_When_NoQueryParameters()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("detail");
+    }
+
+    [Test]
+    public async Task Should_Return400Problem_When_BothEpochAndIsoProvided()
+    {
+        var response = await _client!.GetAsync(
+            "/api/tools/timestamp-converter?epoch=1&iso=2026-01-01T00:00:00Z");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("mutually exclusive");
+    }
+
+    [Test]
+    public async Task Should_Return400Problem_When_EpochInvalid()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?epoch=not-a-number");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("detail");
+    }
+
+    [Test]
+    public async Task Should_Return400Problem_When_IsoInvalid()
+    {
+        var response = await _client!.GetAsync("/api/tools/timestamp-converter?iso=garbage");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("ISO-8601");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/tools/timestamp-converter?epoch=1711792800");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/tools/timestamp-converter?epoch=1711792800");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private static async Task<TimestampConverterResponse> DeserializeAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            json,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        return payload!;
+    }
+}

--- a/src/UI/Api/Controllers/TimestampConverterController.cs
+++ b/src/UI/Api/Controllers/TimestampConverterController.cs
@@ -1,0 +1,62 @@
+using System.Net.Mime;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Converts between Unix epoch timestamps and ISO-8601 strings for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/timestamp-converter")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/timestamp-converter")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class TimestampConverterController : ControllerBase
+{
+    /// <summary>
+    /// Converts a Unix epoch value or ISO-8601 string to normalized machine-readable and human-readable formats.
+    /// Local time reflects the server host time zone, not the caller's time zone.
+    /// </summary>
+    /// <param name="epoch">Unix epoch in seconds or milliseconds (auto-detected by magnitude).</param>
+    /// <param name="iso">ISO-8601 date-time string (for example <c>2026-07-12T15:00:00Z</c>).</param>
+    [HttpGet]
+    [AllowAnonymous]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(TimestampConverterResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public IActionResult Get([FromQuery] string? epoch, [FromQuery] string? iso)
+    {
+        var hasEpoch = !string.IsNullOrWhiteSpace(epoch);
+        var hasIso = !string.IsNullOrWhiteSpace(iso);
+
+        if (!hasEpoch && !hasIso)
+        {
+            return Problem(
+                detail: "Provide exactly one query parameter: epoch (Unix seconds or milliseconds) or iso (ISO-8601 string).",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (hasEpoch && hasIso)
+        {
+            return Problem(
+                detail: "The epoch and iso query parameters are mutually exclusive; provide only one.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var result = hasEpoch
+            ? TimestampConverter.TryConvertFromEpoch(epoch)
+            : TimestampConverter.TryConvertFromIso(iso);
+
+        if (!result.Success)
+        {
+            return Problem(detail: result.ErrorDetail, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        return ConditionalGetEtag.JsonContent(result.Payload!);
+    }
+}

--- a/src/UI/Api/TimestampConverter.cs
+++ b/src/UI/Api/TimestampConverter.cs
@@ -1,0 +1,91 @@
+using System.Globalization;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Converts between Unix epoch values and ISO-8601 timestamps.
+/// </summary>
+public static class TimestampConverter
+{
+    private const long MillisecondMagnitudeThreshold = 1_000_000_000_000L;
+    private const int MaxIsoInputLength = 256;
+
+    /// <summary>
+    /// Attempts to convert a Unix epoch string (seconds or milliseconds, auto-detected by magnitude).
+    /// </summary>
+    public static TimestampConversionResult TryConvertFromEpoch(string? epoch)
+    {
+        if (string.IsNullOrWhiteSpace(epoch))
+        {
+            return TimestampConversionResult.Fail(
+                "Epoch value is required. Provide a signed integer in seconds or milliseconds.");
+        }
+
+        var trimmed = epoch.Trim();
+        if (!long.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rawValue))
+        {
+            return TimestampConversionResult.Fail(
+                "Epoch must be a signed integer (seconds or milliseconds). Decimal values are not accepted.");
+        }
+
+        var isMilliseconds = Math.Abs(rawValue) >= MillisecondMagnitudeThreshold;
+        DateTimeOffset dto;
+        try
+        {
+            dto = isMilliseconds
+                ? DateTimeOffset.FromUnixTimeMilliseconds(rawValue)
+                : DateTimeOffset.FromUnixTimeSeconds(rawValue);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return TimestampConversionResult.Fail(
+                "Epoch value is out of the representable date range.");
+        }
+
+        return TimestampConversionResult.Ok(BuildResponse(dto, "epoch"));
+    }
+
+    /// <summary>
+    /// Attempts to convert an ISO-8601 string to epoch and human-readable representations.
+    /// </summary>
+    public static TimestampConversionResult TryConvertFromIso(string? iso)
+    {
+        if (string.IsNullOrWhiteSpace(iso))
+        {
+            return TimestampConversionResult.Fail(
+                "ISO-8601 value is required. Examples: 2026-07-12T15:00:00Z, 2026-07-12T15:00:00+00:00.");
+        }
+
+        var trimmed = iso.Trim();
+        if (trimmed.Length > MaxIsoInputLength)
+        {
+            return TimestampConversionResult.Fail(
+                $"ISO-8601 input must not exceed {MaxIsoInputLength} characters.");
+        }
+
+        if (!DateTimeOffset.TryParse(
+                trimmed,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind | DateTimeStyles.AssumeUniversal,
+                out var dto))
+        {
+            return TimestampConversionResult.Fail(
+                "ISO-8601 value could not be parsed. Accepted examples: 2026-07-12T15:00:00Z, 2026-07-12T15:00:00+00:00.");
+        }
+
+        return TimestampConversionResult.Ok(BuildResponse(dto, "iso"));
+    }
+
+    private static TimestampConverterResponse BuildResponse(DateTimeOffset dto, string inputKind)
+    {
+        var utc = dto.ToUniversalTime();
+        return new TimestampConverterResponse(
+            InputKind: inputKind,
+            EpochSeconds: utc.ToUnixTimeSeconds(),
+            EpochMilliseconds: utc.ToUnixTimeMilliseconds(),
+            Iso8601Utc: utc.ToString("O", CultureInfo.InvariantCulture),
+            Utc: utc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture),
+            Local: dto.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss K", CultureInfo.InvariantCulture),
+            LocalTimeZoneId: TimeZoneInfo.Local.Id);
+    }
+}

--- a/src/UI/Api/TimestampConverterModels.cs
+++ b/src/UI/Api/TimestampConverterModels.cs
@@ -1,0 +1,34 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/tools/timestamp-converter</c> and the versioned route.
+/// </summary>
+public sealed record TimestampConverterResponse(
+    string InputKind,
+    long EpochSeconds,
+    long EpochMilliseconds,
+    string Iso8601Utc,
+    string Utc,
+    string Local,
+    string LocalTimeZoneId);
+
+/// <summary>
+/// Outcome of a timestamp conversion attempt.
+/// </summary>
+public sealed record TimestampConversionResult(
+    bool Success,
+    TimestampConverterResponse? Payload,
+    string? ErrorDetail)
+{
+    /// <summary>
+    /// Creates a successful conversion result.
+    /// </summary>
+    public static TimestampConversionResult Ok(TimestampConverterResponse payload) =>
+        new(true, payload, null);
+
+    /// <summary>
+    /// Creates a failed conversion result with a client-facing error detail.
+    /// </summary>
+    public static TimestampConversionResult Fail(string errorDetail) =>
+        new(false, null, errorDetail);
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -85,12 +85,21 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
             var leaf = segments[2];
-            return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+            if (leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
+                || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
+                || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return segments.Length == 4
+                   && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+                   && segments[3].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase);
         }
 
-        return false;
+        return segments.Length == 3
+               && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+               && segments[2].Equals("timestamp-converter", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool FixedTimeEqualsUtf8(string expected, string provided)

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -58,7 +58,8 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-        details.Detail.ShouldContain("exactly one");
+        details.Detail.ShouldNotBeNull();
+        details.Detail!.ShouldContain("exactly one");
     }
 
     [Test]
@@ -71,7 +72,8 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-        details.Detail.ShouldContain("mutually exclusive");
+        details.Detail.ShouldNotBeNull();
+        details.Detail!.ShouldContain("mutually exclusive");
     }
 
     [Test]
@@ -97,7 +99,8 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-        details.Detail.ShouldContain("ISO-8601");
+        details.Detail.ShouldNotBeNull();
+        details.Detail!.ShouldContain("ISO-8601");
     }
 
     private static TimestampConverterController CreateController() =>

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterControllerTests
+{
+    [Test]
+    public void Should_Return200WithJson_When_EpochQueryProvided()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(epoch: "1711792800", iso: null);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.InputKind.ShouldBe("epoch");
+        payload.EpochSeconds.ShouldBe(1711792800);
+        payload.Iso8601Utc.ShouldNotBeNullOrWhiteSpace();
+        payload.Utc.ShouldNotBeNullOrWhiteSpace();
+        payload.Local.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_Return200WithJson_When_IsoQueryProvided()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(epoch: null, iso: "2026-07-12T15:00:00Z");
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        var payload = JsonSerializer.Deserialize<TimestampConverterResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.InputKind.ShouldBe("iso");
+    }
+
+    [Test]
+    public void Should_Return400Problem_When_NeitherParameterProvided()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(epoch: null, iso: null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldContain("exactly one");
+    }
+
+    [Test]
+    public void Should_Return400Problem_When_BothParametersProvided()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(epoch: "1", iso: "2026-01-01T00:00:00Z");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldContain("mutually exclusive");
+    }
+
+    [Test]
+    public void Should_Return400Problem_When_EpochInvalid()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(epoch: "abc", iso: null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_Return400Problem_When_IsoInvalid()
+    {
+        var controller = CreateController();
+
+        var result = controller.Get(epoch: null, iso: "garbage");
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+        var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+        details.Detail.ShouldContain("ISO-8601");
+    }
+
+    private static TimestampConverterController CreateController() =>
+        new()
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+}

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -72,11 +72,7 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-<<<<<<< HEAD
-        details.Detail.ShouldNotBeNull();
-=======
         details.Detail.ShouldNotBeNullOrWhiteSpace();
->>>>>>> 7e403d64 (fix: resolve nullable warnings in timestamp converter tests (#6746) [AB#6746])
         details.Detail!.ShouldContain("mutually exclusive");
     }
 
@@ -103,11 +99,7 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-<<<<<<< HEAD
-        details.Detail.ShouldNotBeNull();
-=======
         details.Detail.ShouldNotBeNullOrWhiteSpace();
->>>>>>> 7e403d64 (fix: resolve nullable warnings in timestamp converter tests (#6746) [AB#6746])
         details.Detail!.ShouldContain("ISO-8601");
     }
 

--- a/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterControllerTests.cs
@@ -58,7 +58,7 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
-        details.Detail.ShouldNotBeNull();
+        details.Detail.ShouldNotBeNullOrWhiteSpace();
         details.Detail!.ShouldContain("exactly one");
     }
 
@@ -72,7 +72,11 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+<<<<<<< HEAD
         details.Detail.ShouldNotBeNull();
+=======
+        details.Detail.ShouldNotBeNullOrWhiteSpace();
+>>>>>>> 7e403d64 (fix: resolve nullable warnings in timestamp converter tests (#6746) [AB#6746])
         details.Detail!.ShouldContain("mutually exclusive");
     }
 
@@ -99,7 +103,11 @@ public class TimestampConverterControllerTests
         var problem = result.ShouldBeOfType<ObjectResult>();
         problem.StatusCode.ShouldBe(400);
         var details = problem.Value.ShouldBeOfType<ProblemDetails>();
+<<<<<<< HEAD
         details.Detail.ShouldNotBeNull();
+=======
+        details.Detail.ShouldNotBeNullOrWhiteSpace();
+>>>>>>> 7e403d64 (fix: resolve nullable warnings in timestamp converter tests (#6746) [AB#6746])
         details.Detail!.ShouldContain("ISO-8601");
     }
 

--- a/src/UnitTests/UI.Api/TimestampConverterTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterTests.cs
@@ -81,7 +81,8 @@ public class TimestampConverterTests
         var result = TimestampConverter.TryConvertFromIso("not-a-date");
 
         result.Success.ShouldBeFalse();
-        result.ErrorDetail.ShouldContain("ISO-8601");
+        result.ErrorDetail.ShouldNotBeNull();
+        result.ErrorDetail!.ShouldContain("ISO-8601");
     }
 
     [Test]

--- a/src/UnitTests/UI.Api/TimestampConverterTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterTests.cs
@@ -1,0 +1,115 @@
+using System.Globalization;
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class TimestampConverterTests
+{
+    private static readonly DateTimeOffset FixedInstant =
+        new(2024, 3, 30, 10, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public void Should_ReturnSuccess_When_ValidEpochSecondsProvided()
+    {
+        var result = TimestampConverter.TryConvertFromEpoch("1711792800");
+
+        result.Success.ShouldBeTrue();
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.InputKind.ShouldBe("epoch");
+        result.Payload.EpochSeconds.ShouldBe(FixedInstant.ToUnixTimeSeconds());
+        result.Payload.EpochMilliseconds.ShouldBe(FixedInstant.ToUnixTimeMilliseconds());
+        result.Payload.Iso8601Utc.ShouldBe(FixedInstant.ToString("O", CultureInfo.InvariantCulture));
+        result.Payload.Utc.ShouldBe("2024-03-30 10:00:00 UTC");
+    }
+
+    [Test]
+    public void Should_ReturnSuccess_When_ValidEpochMillisecondsProvided()
+    {
+        var result = TimestampConverter.TryConvertFromEpoch("1711792800000");
+
+        result.Success.ShouldBeTrue();
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.EpochSeconds.ShouldBe(FixedInstant.ToUnixTimeSeconds());
+        result.Payload.EpochMilliseconds.ShouldBe(FixedInstant.ToUnixTimeMilliseconds());
+        result.Payload.InputKind.ShouldBe("epoch");
+    }
+
+    [Test]
+    public void Should_ReturnFailure_When_EpochIsNonNumeric()
+    {
+        TimestampConverter.TryConvertFromEpoch("abc").Success.ShouldBeFalse();
+        TimestampConverter.TryConvertFromEpoch("12.5").Success.ShouldBeFalse();
+        TimestampConverter.TryConvertFromEpoch("   ").Success.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Should_ReturnFailure_When_EpochOutOfRange()
+    {
+        var result = TimestampConverter.TryConvertFromEpoch("9223372036854775807");
+
+        result.Success.ShouldBeFalse();
+        result.ErrorDetail.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Should_ReturnSuccess_When_ValidIso8601WithZSuffix()
+    {
+        var result = TimestampConverter.TryConvertFromIso("2026-07-12T15:00:00Z");
+
+        result.Success.ShouldBeTrue();
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.InputKind.ShouldBe("iso");
+        result.Payload.Iso8601Utc.ShouldBe("2026-07-12T15:00:00.0000000+00:00");
+        result.Payload.EpochSeconds.ShouldBe(new DateTimeOffset(2026, 7, 12, 15, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds());
+    }
+
+    [Test]
+    public void Should_ReturnSuccess_When_ValidIso8601WithOffset()
+    {
+        var result = TimestampConverter.TryConvertFromIso("2026-07-12T15:00:00+05:30");
+
+        result.Success.ShouldBeTrue();
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.Iso8601Utc.ShouldBe("2026-07-12T09:30:00.0000000+00:00");
+    }
+
+    [Test]
+    public void Should_ReturnFailure_When_IsoIsMalformed()
+    {
+        var result = TimestampConverter.TryConvertFromIso("not-a-date");
+
+        result.Success.ShouldBeFalse();
+        result.ErrorDetail.ShouldContain("ISO-8601");
+    }
+
+    [Test]
+    public void Should_ReturnFailure_When_IsoIsEmpty()
+    {
+        TimestampConverter.TryConvertFromIso(null).Success.ShouldBeFalse();
+        TimestampConverter.TryConvertFromIso("").Success.ShouldBeFalse();
+        TimestampConverter.TryConvertFromIso("   ").Success.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Should_NormalizeToUtc_When_IsoHasLocalOffset()
+    {
+        var result = TimestampConverter.TryConvertFromIso("2026-07-12T15:00:00+05:30");
+
+        result.Success.ShouldBeTrue();
+        result.Payload!.Iso8601Utc.ShouldEndWith("+00:00");
+        result.Payload.EpochSeconds.ShouldBe(
+            new DateTimeOffset(2026, 7, 12, 9, 30, 0, TimeSpan.Zero).ToUnixTimeSeconds());
+    }
+
+    [Test]
+    public void Should_IncludeLocalTimeZoneId_When_ConversionSucceeds()
+    {
+        var result = TimestampConverter.TryConvertFromEpoch("1711792800");
+
+        result.Success.ShouldBeTrue();
+        result.Payload!.LocalTimeZoneId.ShouldBe(TimeZoneInfo.Local.Id);
+        result.Payload.Local.ShouldNotBeNullOrWhiteSpace();
+    }
+}

--- a/src/UnitTests/UI.Api/TimestampConverterTests.cs
+++ b/src/UnitTests/UI.Api/TimestampConverterTests.cs
@@ -81,7 +81,7 @@ public class TimestampConverterTests
         var result = TimestampConverter.TryConvertFromIso("not-a-date");
 
         result.Success.ShouldBeFalse();
-        result.ErrorDetail.ShouldNotBeNull();
+        result.ErrorDetail.ShouldNotBeNullOrWhiteSpace();
         result.ErrorDetail!.ShouldContain("ISO-8601");
     }
 

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/timestamp-converter", true)]
+    [TestCase("/api/v1.0/tools/timestamp-converter", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -107,4 +107,17 @@ public class ApiKeyAuthenticationWebTests
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
     }
+
+    [Test]
+    public async Task Should_Return200_When_TimestampConverterWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/tools/timestamp-converter?epoch=1711792800");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/tools/timestamp-converter?epoch=1711792800");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a stateless, anonymous utility endpoint at GET /api/tools/timestamp-converter (and versioned GET /api/v1.0/tools/timestamp-converter) that converts between Unix epoch values and ISO-8601 strings.

## Files Changed

- src/UI/Api/TimestampConverter.cs — conversion logic
- src/UI/Api/TimestampConverterModels.cs — response DTOs
- src/UI/Api/Controllers/TimestampConverterController.cs — GET endpoint
- src/UI/Server/ApiKeyAuthenticationMiddleware.cs — public-path exemption
- Unit and integration tests

## Testing Notes

- PrivateBuild.ps1 passed (283 unit + 123 integration tests)
- Targeted TimestampConverter tests: 24 total

Closes #6746