### PR TITLE
New API endpoint GET /api/status/environment for runtime environment diagnostics (#6817)

### DIFF
--- a/src/IntegrationTests/Api/EnvironmentStatusEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/EnvironmentStatusEndpointIntegrationTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class EnvironmentStatusEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/status/environment");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("osDescription", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("processorCount", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("clrVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("environmentVariables", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/status/environment");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("osDescription", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("processorCount", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("clrVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("environmentVariables", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_ExposeRuntimeMetadata_FromHost_When_GetEnvironmentStatus()
+    {
+        var response = await _client!.GetAsync("/api/status/environment");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EnvironmentStatusResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.OsDescription.ShouldNotBeNullOrWhiteSpace();
+        payload.ProcessorCount.ShouldBeGreaterThanOrEqualTo(1);
+        payload.ClrVersion.ShouldNotBeNullOrWhiteSpace();
+        payload.ClrVersion.ShouldContain(Environment.Version.Major.ToString());
+    }
+
+    [Test]
+    public async Task Should_RedactSensitiveValues_When_ConfigurationContainsSecrets()
+    {
+        const string connectionString = "Server=integration-secret-host;Password=integration-secret-pwd";
+        const string openAiKey = "sk-integration-test-secret";
+        const string appInsights = "InstrumentationKey=integration-secret-key";
+        const string validationKey = "integration-validation-secret";
+
+        await using var factory = new DiagnosticsWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:SqlConnectionString"] = connectionString,
+                    ["AI_OpenAI_ApiKey"] = openAiKey,
+                    ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = appInsights,
+                    ["ApiKeyAuthentication:ValidationKey"] = validationKey
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/status/environment");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.ShouldNotContain(connectionString);
+        body.ShouldNotContain(openAiKey);
+        body.ShouldNotContain(appInsights);
+        body.ShouldNotContain(validationKey);
+
+        var payload = JsonSerializer.Deserialize<EnvironmentStatusResponse>(
+            body,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        foreach (var value in payload!.EnvironmentVariables.Values)
+        {
+            value.ShouldBe(EnvironmentStatusResponseBuilder.RedactedEnvironmentVariableValue);
+        }
+    }
+
+    [Test]
+    public async Task Should_IncludeAllCuratedKeys_When_GetEnvironmentStatus()
+    {
+        var response = await _client!.GetAsync("/api/status/environment");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EnvironmentStatusResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.EnvironmentVariables.Count.ShouldBe(10);
+        payload.EnvironmentVariables.ShouldContainKey("ASPNETCORE_ENVIRONMENT");
+        payload.EnvironmentVariables.ShouldContainKey("DATABASE_ENGINE");
+        payload.EnvironmentVariables.ShouldContainKey("ConnectionStrings__SqlConnectionString");
+        payload.EnvironmentVariables.ShouldContainKey("APPLICATIONINSIGHTS_CONNECTION_STRING");
+        payload.EnvironmentVariables.ShouldContainKey("AI_OpenAI_ApiKey");
+        payload.EnvironmentVariables.ShouldContainKey("AI_OpenAI_Url");
+        payload.EnvironmentVariables.ShouldContainKey("AI_OpenAI_Model");
+        payload.EnvironmentVariables.ShouldContainKey("ApiKeyAuthentication__Enabled");
+        payload.EnvironmentVariables.ShouldContainKey("ApiKeyAuthentication__ValidationKey");
+        payload.EnvironmentVariables.ShouldContainKey("OTEL_EXPORTER_OTLP_ENDPOINT");
+        foreach (var value in payload.EnvironmentVariables.Values)
+        {
+            value.ShouldBe(EnvironmentStatusResponseBuilder.RedactedEnvironmentVariableValue);
+        }
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/status/environment");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/status/environment");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.GetAsync("/api/status/environment");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/status/environment");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/UI/Api/Controllers/StatusEnvironmentController.cs
+++ b/src/UI/Api/Controllers/StatusEnvironmentController.cs
@@ -1,0 +1,29 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes runtime environment metadata for operations and support diagnostics.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/status/environment")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/status/environment")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class StatusEnvironmentController(IConfiguration configuration) : ControllerBase
+{
+    /// <summary>
+    /// Returns OS description, processor count, CLR version, and curated environment variable names with redacted values.
+    /// Supports <c>GET /api/status/environment</c> and <c>GET /api/v1.0/status/environment</c>.
+    /// </summary>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var payload = EnvironmentStatusResponseBuilder.Build(configuration);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/EnvironmentStatusModels.cs
+++ b/src/UI/Api/EnvironmentStatusModels.cs
@@ -1,0 +1,14 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/status/environment</c> and <c>GET /api/v1.0/status/environment</c>.
+/// </summary>
+/// <param name="OsDescription">Operating system description from the runtime.</param>
+/// <param name="ProcessorCount">Logical processor count for the current process.</param>
+/// <param name="ClrVersion">CLR version string for the running application.</param>
+/// <param name="EnvironmentVariables">Curated environment variable names mapped to redacted placeholder values.</param>
+public sealed record EnvironmentStatusResponse(
+    string OsDescription,
+    int ProcessorCount,
+    string ClrVersion,
+    IReadOnlyDictionary<string, string> EnvironmentVariables);

--- a/src/UI/Api/EnvironmentStatusResponseBuilder.cs
+++ b/src/UI/Api/EnvironmentStatusResponseBuilder.cs
@@ -1,0 +1,63 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Builds the runtime environment status snapshot with redacted configuration values.
+/// </summary>
+public static class EnvironmentStatusResponseBuilder
+{
+    /// <summary>
+    /// Placeholder returned for every curated environment variable value.
+    /// </summary>
+    public const string RedactedEnvironmentVariableValue = "(redacted)";
+
+    private static readonly string[] CuratedEnvironmentVariableNames =
+    [
+        "ASPNETCORE_ENVIRONMENT",
+        "DATABASE_ENGINE",
+        "ConnectionStrings__SqlConnectionString",
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "AI_OpenAI_ApiKey",
+        "AI_OpenAI_Url",
+        "AI_OpenAI_Model",
+        "ApiKeyAuthentication__Enabled",
+        "ApiKeyAuthentication__ValidationKey",
+        "OTEL_EXPORTER_OTLP_ENDPOINT"
+    ];
+
+    /// <summary>
+    /// Returns OS, processor, CLR metadata and a curated dictionary of redacted environment variable values.
+    /// </summary>
+    /// <param name="configuration">Application configuration used to resolve curated keys.</param>
+    public static EnvironmentStatusResponse Build(IConfiguration configuration)
+    {
+        var environmentVariables = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var name in CuratedEnvironmentVariableNames)
+        {
+            _ = ResolveConfiguredValue(configuration, name);
+            environmentVariables[name] = RedactedEnvironmentVariableValue;
+        }
+
+        return new EnvironmentStatusResponse(
+            RuntimeInformation.OSDescription,
+            Environment.ProcessorCount,
+            Environment.Version.ToString(),
+            environmentVariables);
+    }
+
+    private static string? ResolveConfiguredValue(IConfiguration configuration, string name)
+    {
+        var configurationKey = name.Replace("__", ":", StringComparison.Ordinal);
+        var fromConfiguration = configuration[configurationKey];
+        if (!string.IsNullOrEmpty(fromConfiguration))
+            return fromConfiguration;
+
+        var directConfiguration = configuration[name];
+        if (!string.IsNullOrEmpty(directConfiguration))
+            return directConfiguration;
+
+        return Environment.GetEnvironmentVariable(name);
+    }
+}

--- a/src/UnitTests/UI.Api/EnvironmentStatusResponseBuilderTests.cs
+++ b/src/UnitTests/UI.Api/EnvironmentStatusResponseBuilderTests.cs
@@ -1,0 +1,114 @@
+using System.Runtime.InteropServices;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EnvironmentStatusResponseBuilderTests
+{
+    private static readonly string[] CuratedEnvironmentVariableNames =
+    [
+        "ASPNETCORE_ENVIRONMENT",
+        "DATABASE_ENGINE",
+        "ConnectionStrings__SqlConnectionString",
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "AI_OpenAI_ApiKey",
+        "AI_OpenAI_Url",
+        "AI_OpenAI_Model",
+        "ApiKeyAuthentication__Enabled",
+        "ApiKeyAuthentication__ValidationKey",
+        "OTEL_EXPORTER_OTLP_ENDPOINT"
+    ];
+
+    [Test]
+    public void Should_ReturnOsProcessorAndClrMetadata_When_BuildCalled()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        var response = EnvironmentStatusResponseBuilder.Build(configuration);
+
+        response.OsDescription.ShouldBe(RuntimeInformation.OSDescription);
+        response.ProcessorCount.ShouldBe(Environment.ProcessorCount);
+        response.ClrVersion.ShouldBe(Environment.Version.ToString());
+    }
+
+    [Test]
+    public void Should_RedactAllEnvironmentVariableValues_When_VariablesAreSet()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_ENVIRONMENT"] = "Production",
+                ["DATABASE_ENGINE"] = "SqlServer",
+                ["ConnectionStrings:SqlConnectionString"] = "Server=secret;",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "InstrumentationKey=abc",
+                ["AI_OpenAI_ApiKey"] = "super-secret-key",
+                ["AI_OpenAI_Url"] = "https://secret.openai.azure.com",
+                ["AI_OpenAI_Model"] = "gpt-secret",
+                ["ApiKeyAuthentication:Enabled"] = "true",
+                ["ApiKeyAuthentication:ValidationKey"] = "validation-secret",
+                ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://otel-secret.example"
+            })
+            .Build();
+
+        var response = EnvironmentStatusResponseBuilder.Build(configuration);
+
+        foreach (var value in response.EnvironmentVariables.Values)
+        {
+            value.ShouldBe(EnvironmentStatusResponseBuilder.RedactedEnvironmentVariableValue);
+        }
+
+        response.EnvironmentVariables.Values.ShouldNotContain("Production");
+        response.EnvironmentVariables.Values.ShouldNotContain("SqlServer");
+        response.EnvironmentVariables.Values.ShouldNotContain("Server=secret;");
+        response.EnvironmentVariables.Values.ShouldNotContain("super-secret-key");
+        response.EnvironmentVariables.Values.ShouldNotContain("validation-secret");
+    }
+
+    [Test]
+    public void Should_IncludeCuratedVariableNames_When_VariablesUnset()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        var response = EnvironmentStatusResponseBuilder.Build(configuration);
+
+        response.EnvironmentVariables.Count.ShouldBe(CuratedEnvironmentVariableNames.Length);
+        foreach (var name in CuratedEnvironmentVariableNames)
+        {
+            response.EnvironmentVariables.ContainsKey(name).ShouldBeTrue();
+            response.EnvironmentVariables[name].ShouldBe(EnvironmentStatusResponseBuilder.RedactedEnvironmentVariableValue);
+        }
+    }
+
+    [Test]
+    public void Should_PreferConfigurationOverEnvironment_When_BothPresent()
+    {
+        const string envVarName = "ConnectionStrings__SqlConnectionString";
+        const string configurationValue = "Server=config-secret;";
+        const string environmentValue = "Server=env-secret;";
+        Environment.SetEnvironmentVariable(envVarName, environmentValue);
+        try
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:SqlConnectionString"] = configurationValue
+                })
+                .Build();
+
+            var response = EnvironmentStatusResponseBuilder.Build(configuration);
+
+            response.EnvironmentVariables.ShouldContainKey(envVarName);
+            response.EnvironmentVariables[envVarName]
+                .ShouldBe(EnvironmentStatusResponseBuilder.RedactedEnvironmentVariableValue);
+            response.EnvironmentVariables.Values.ShouldNotContain(configurationValue);
+            response.EnvironmentVariables.Values.ShouldNotContain(environmentValue);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, null);
+        }
+    }
+}

--- a/src/UnitTests/UI.Api/StatusEnvironmentControllerTests.cs
+++ b/src/UnitTests/UI.Api/StatusEnvironmentControllerTests.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class StatusEnvironmentControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJson_WithExpectedShape_When_Called()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_ENVIRONMENT"] = "UnitTestEnv"
+            })
+            .Build();
+        var controller = new StatusEnvironmentController(configuration)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<EnvironmentStatusResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.OsDescription.ShouldNotBeNullOrWhiteSpace();
+        payload.ProcessorCount.ShouldBeGreaterThan(0);
+        payload.ClrVersion.ShouldNotBeNullOrWhiteSpace();
+        payload.EnvironmentVariables.Count.ShouldBe(10);
+        payload.EnvironmentVariables.ShouldContainKey("ASPNETCORE_ENVIRONMENT");
+        payload.EnvironmentVariables["ASPNETCORE_ENVIRONMENT"]
+            .ShouldBe(EnvironmentStatusResponseBuilder.RedactedEnvironmentVariableValue);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/status/environment", false)]
+    [TestCase("/api/v1.0/status/environment", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]


### PR DESCRIPTION
## Summary

Adds GET /api/status/environment and GET /api/v1.0/status/environment for runtime environment diagnostics.

Closes #6817

## Testing

- Private build passed locally
- Unit and integration tests for redaction, routes, and API key enforcement