### PR TITLE
New API endpoint GET /api/version for build and deployment metadata (#6743)

### DIFF
--- a/src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class VersionEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        var payload = await DeserializeVersionPayload(response);
+        AssertRequiredFields(payload);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        var payload = await DeserializeVersionPayload(response);
+        AssertRequiredFields(payload);
+    }
+
+    [Test]
+    public async Task Should_ReturnEquivalentPayload_When_UnversionedAndVersionedPaths()
+    {
+        var unversioned = await DeserializeVersionPayload(await _client!.GetAsync("/api/version"));
+        var versioned = await DeserializeVersionPayload(await _client.GetAsync("/api/v1.0/version"));
+
+        unversioned.AssemblyVersion.ShouldBe(versioned.AssemblyVersion);
+        unversioned.InformationalVersion.ShouldBe(versioned.InformationalVersion);
+        unversioned.BuildConfiguration.ShouldBe(versioned.BuildConfiguration);
+        unversioned.Environment.ShouldBe(versioned.Environment);
+        unversioned.MachineName.ShouldBe(versioned.MachineName);
+        unversioned.FrameworkDescription.ShouldBe(versioned.FrameworkDescription);
+    }
+
+    [Test]
+    public async Task Should_ExposeTestingEnvironment_When_HostUsesTestingEnvironment()
+    {
+        var payload = await DeserializeVersionPayload(await _client!.GetAsync("/api/version"));
+
+        payload.Environment.ShouldBe("Testing");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_VersionAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/version");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        AssertRequiredFields(await DeserializeVersionPayload(unversioned));
+
+        var versioned = await client.GetAsync("/api/v1.0/version");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        AssertRequiredFields(await DeserializeVersionPayload(versioned));
+    }
+
+    [Test]
+    public async Task Should_IncludeSupportedVersionsHeader_When_GetVersionedRoute()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues("api-supported-versions", out var values).ShouldBeTrue();
+        values.ShouldNotBeNull();
+        string.Join(", ", values!).ShouldContain("1.0");
+    }
+
+    [Test]
+    public async Task Should_IncludeEtagHeader_When_GetVersion()
+    {
+        var response = await _client!.GetAsync("/api/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+    }
+
+    private static async Task<VersionMetadataResponse> DeserializeVersionPayload(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var payload = JsonSerializer.Deserialize<VersionMetadataResponse>(
+            json,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        return payload!;
+    }
+
+    private static void AssertRequiredFields(VersionMetadataResponse payload)
+    {
+        payload.AssemblyVersion.ShouldNotBeNullOrEmpty();
+        payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+        payload.BuildConfiguration.ShouldNotBeNullOrEmpty();
+        payload.Environment.ShouldNotBeNullOrEmpty();
+        payload.MachineName.ShouldNotBeNullOrEmpty();
+        payload.FrameworkDescription.ShouldNotBeNullOrEmpty();
+    }
+}

--- a/src/UI/Api/Controllers/VersionController.cs
+++ b/src/UI/Api/Controllers/VersionController.cs
@@ -31,9 +31,11 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
         var assembly = Assembly.GetExecutingAssembly();
         var assemblyVersion = assembly.GetName().Version?.ToString();
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var buildConfiguration = assembly.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration;
         var payload = new VersionMetadataResponse(
             AssemblyVersion: assemblyVersion,
             InformationalVersion: informationalVersion,
+            BuildConfiguration: buildConfiguration,
             Environment: hostEnvironment.EnvironmentName,
             MachineName: Environment.MachineName,
             FrameworkDescription: RuntimeInformation.FrameworkDescription);
@@ -48,9 +50,16 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
 /// <summary>
 /// JSON payload for <c>GET /api/version</c> and <c>GET /api/v1.0/version</c>.
 /// </summary>
+/// <param name="AssemblyVersion">Four-part assembly version stamped at compile time (for example via <c>/p:Version=</c> in CI).</param>
+/// <param name="InformationalVersion">Informational or semantic version from <see cref="AssemblyInformationalVersionAttribute"/>.</param>
+/// <param name="BuildConfiguration">MSBuild configuration (Debug or Release) from <see cref="AssemblyConfigurationAttribute"/>.</param>
+/// <param name="Environment">ASP.NET Core host environment name (Development, Staging, Production, Testing, etc.).</param>
+/// <param name="MachineName">Name of the machine or container hosting the process.</param>
+/// <param name="FrameworkDescription">Runtime framework description from <see cref="RuntimeInformation.FrameworkDescription"/>.</param>
 public record VersionMetadataResponse(
     string? AssemblyVersion,
     string? InformationalVersion,
+    string? BuildConfiguration,
     string? Environment,
     string MachineName,
     string FrameworkDescription);

--- a/src/UnitTests/UI.Api/VersionControllerTests.cs
+++ b/src/UnitTests/UI.Api/VersionControllerTests.cs
@@ -32,6 +32,7 @@ public class VersionControllerTests
         payload.ShouldNotBeNull();
         payload!.AssemblyVersion.ShouldNotBeNullOrEmpty();
         payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+        payload.BuildConfiguration.ShouldNotBeNullOrEmpty();
         payload.Environment.ShouldBe("TestEnvironment");
         payload.MachineName.ShouldBe(Environment.MachineName);
         payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -60,6 +60,17 @@ public class ApiVersioningEndpointTests
     }
 
     [Test]
+    public async Task Should_Return200_When_GetVersion_UnversionedPath()
+    {
+        var response = await _client!.GetAsync("/api/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+    }
+
+    [Test]
     public async Task Should_Return200_When_GetTime_V1Path()
     {
         var response = await _client!.GetAsync("/api/v1.0/time");
@@ -73,7 +84,7 @@ public class ApiVersioningEndpointTests
     [Test]
     public async Task Should_IncludeSupportedVersionsHeader_When_GetVersionedEndpoint()
     {
-        var response = await _client!.GetAsync("/api/v1.0/health");
+        var response = await _client!.GetAsync("/api/v1.0/version");
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Headers.TryGetValues("api-supported-versions", out var values).ShouldBeTrue();


### PR DESCRIPTION
## Summary

Adds `buildConfiguration` to the existing `GET /api/version` and `GET /api/v1.0/version` endpoints so operators and integrations can read compile-time MSBuild configuration alongside assembly version, informational version, and runtime environment metadata.

## Changes

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/VersionController.cs` | Reads `AssemblyConfigurationAttribute` and exposes `buildConfiguration` in JSON payload; XML docs on `VersionMetadataResponse` |
| `src/UnitTests/UI.Api/VersionControllerTests.cs` | Asserts `BuildConfiguration` is non-empty in controller unit test |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | Adds unversioned route test; fixes `api-supported-versions` header test to target version route |
| `src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs` | New integration tests for unversioned/versioned routes, payload equivalence, Testing environment, API-key exemption, ETag, and supported-versions header |

## Testing

- `PrivateBuild.ps1` — clean, compile, unit tests, DB migration, integration tests (123 passed)
- Targeted filters: `Version*` unit tests (11 passed), `VersionEndpoint` integration tests (7 passed)
- Existing coverage retained: ETag 304, output cache, API key middleware, rate limiting

Closes #6743