### PR TITLE
New API endpoint GET /api/features/flags for runtime feature flag status (#6815)

### DIFF
--- a/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class FeatureFlagsEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetFeatureFlagsUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/features/flags");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("sampleFeatureA", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("sampleFeatureB", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeFalse();
+        doc.RootElement.TryGetProperty("environment", out _).ShouldBeFalse();
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetFeatureFlagsVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/features/flags");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("sampleFeatureA", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("sampleFeatureB", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_ExposeFeatureFlags_FromConfiguration_When_GetFeatureFlags()
+    {
+        var response = await _client!.GetAsync("/api/features/flags");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!["sampleFeatureA"].ShouldBeTrue();
+        payload["sampleFeatureB"].ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_ExposeFeatureFlags_FromOverriddenConfiguration_When_GetFeatureFlags()
+    {
+        await using var factory = new DiagnosticsWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["FeatureFlags:SampleFeatureA"] = "false",
+                    ["FeatureFlags:SampleFeatureB"] = "true"
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/features/flags");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<Dictionary<string, bool>>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!["sampleFeatureA"].ShouldBeFalse();
+        payload["sampleFeatureB"].ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabledAndEndpointProtected()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/features/flags");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/features/flags");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.GetAsync("/api/features/flags");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/features/flags");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_NotAlterDiagnostics_When_FeatureFlagsEndpointRegistered()
+    {
+        var diagnostics = await _client!.GetAsync("/api/diagnostics");
+        diagnostics.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var diagStream = await diagnostics.Content.ReadAsStreamAsync();
+        using var diagDoc = await JsonDocument.ParseAsync(diagStream);
+        diagDoc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeTrue();
+
+        var flags = await _client.GetAsync("/api/features/flags");
+        flags.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var flagsStream = await flags.Content.ReadAsStreamAsync();
+        using var flagsDoc = await JsonDocument.ParseAsync(flagsStream);
+        flagsDoc.RootElement.TryGetProperty("sampleFeatureA", out _).ShouldBeTrue();
+        flagsDoc.RootElement.TryGetProperty("featureFlags", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Should_Return304NotModified_When_IfNoneMatchMatchesEtag()
+    {
+        var first = await _client!.GetAsync("/api/features/flags");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var etag = first.Headers.ETag;
+        etag.ShouldNotBeNull();
+
+        using var second = new HttpRequestMessage(HttpMethod.Get, "/api/features/flags");
+        second.Headers.IfNoneMatch.Add(etag!);
+        var notModified = await _client.SendAsync(second);
+        notModified.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
+    }
+}

--- a/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api;
 using ClearMeasure.Bootcamp.UI.Shared;

--- a/src/UI/Api/Controllers/FeatureFlagsController.cs
+++ b/src/UI/Api/Controllers/FeatureFlagsController.cs
@@ -1,0 +1,32 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes runtime feature-flag status as a flat JSON object for operations and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/features/flags")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/features/flags")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class FeatureFlagsController(IOptions<DiagnosticsFeatureFlagsOptions> featureFlagsOptions) : ControllerBase
+{
+    /// <summary>
+    /// Returns a flat JSON object mapping feature-flag names to enabled/disabled booleans.
+    /// </summary>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var snapshot = FeatureFlagsSnapshot.FromOptions(featureFlagsOptions.Value);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(snapshot);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(snapshot);
+    }
+}

--- a/src/UI/Api/FeatureFlagsSnapshot.cs
+++ b/src/UI/Api/FeatureFlagsSnapshot.cs
@@ -1,0 +1,21 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Builds a flat feature-flag snapshot from <see cref="DiagnosticsFeatureFlagsOptions"/>.
+/// New flags require updates to both <see cref="DiagnosticsFeatureFlagsOptions"/> and this catalog.
+/// </summary>
+public static class FeatureFlagsSnapshot
+{
+    /// <summary>Canonical API keys exposed by <c>GET /api/features/flags</c> (camelCase JSON property names).</summary>
+    public static readonly IReadOnlyList<string> CatalogKeys = ["sampleFeatureA", "sampleFeatureB"];
+
+    /// <summary>
+    /// Returns a new dictionary mapping catalog keys to current option values.
+    /// </summary>
+    public static IReadOnlyDictionary<string, bool> FromOptions(DiagnosticsFeatureFlagsOptions options) =>
+        new Dictionary<string, bool>
+        {
+            ["sampleFeatureA"] = options.SampleFeatureA,
+            ["sampleFeatureB"] = options.SampleFeatureB
+        };
+}

--- a/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagsControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJson_WithFlatFeatureFlagMap_When_Called()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+        var controller = new FeatureFlagsController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<Dictionary<string, bool>>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!["sampleFeatureA"].ShouldBeTrue();
+        payload["sampleFeatureB"].ShouldBeFalse();
+    }
+
+    [Test]
+    public void Get_Should_Return304NotModified_When_IfNoneMatchMatchesEtag()
+    {
+        var flags = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+        var httpContext = new DefaultHttpContext();
+        var controller = new FeatureFlagsController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+
+        var first = controller.Get();
+        first.ShouldBeOfType<ContentResult>();
+        var etag = httpContext.Response.Headers.ETag.ToString();
+        etag.ShouldNotBeNullOrEmpty();
+
+        httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.IfNoneMatch = etag;
+        controller = new FeatureFlagsController(Options.Create(flags))
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+
+        var second = controller.Get();
+
+        second.ShouldBeOfType<StatusCodeResult>();
+        ((StatusCodeResult)second).StatusCode.ShouldBe(StatusCodes.Status304NotModified);
+    }
+}

--- a/src/UnitTests/UI.Api/FeatureFlagsSnapshotTests.cs
+++ b/src/UnitTests/UI.Api/FeatureFlagsSnapshotTests.cs
@@ -1,0 +1,44 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class FeatureFlagsSnapshotTests
+{
+    [Test]
+    public void Should_MapAllCatalogKeys_When_OptionsProvided()
+    {
+        var options = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+
+        var snapshot = FeatureFlagsSnapshot.FromOptions(options);
+
+        foreach (var key in FeatureFlagsSnapshot.CatalogKeys)
+        {
+            snapshot.ContainsKey(key).ShouldBeTrue();
+        }
+        snapshot.Count.ShouldBe(FeatureFlagsSnapshot.CatalogKeys.Count);
+    }
+
+    [Test]
+    public void Should_ReflectOptionValues_When_FlagsEnabledOrDisabled()
+    {
+        var options = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = true, SampleFeatureB = false };
+
+        var snapshot = FeatureFlagsSnapshot.FromOptions(options);
+
+        snapshot["sampleFeatureA"].ShouldBeTrue();
+        snapshot["sampleFeatureB"].ShouldBeFalse();
+    }
+
+    [Test]
+    public void Should_ReflectInvertedOptionValues_When_FlagsToggled()
+    {
+        var options = new DiagnosticsFeatureFlagsOptions { SampleFeatureA = false, SampleFeatureB = true };
+
+        var snapshot = FeatureFlagsSnapshot.FromOptions(options);
+
+        snapshot["sampleFeatureA"].ShouldBeFalse();
+        snapshot["sampleFeatureB"].ShouldBeTrue();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/features/flags", false)]
+    [TestCase("/api/v1.0/features/flags", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]


### PR DESCRIPTION
## Summary

Adds a dedicated read-only HTTP endpoint `GET /api/features/flags` (and versioned `GET /api/v1.0/features/flags`) that returns a flat JSON object mapping feature-flag names to boolean enabled/disabled values. Runtime values are sourced from the existing `FeatureFlags` configuration section bound to `DiagnosticsFeatureFlagsOptions`.

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/FeatureFlagsSnapshot.cs` | Static catalog and snapshot builder mapping options to flat dictionary |
| `src/UI/Api/Controllers/FeatureFlagsController.cs` | New controller with rate limiting, ETag conditional GET |
| `src/UnitTests/UI.Api/FeatureFlagsSnapshotTests.cs` | Unit tests for catalog keys and value mapping |
| `src/UnitTests/UI.Api/FeatureFlagsControllerTests.cs` | Unit tests for JSON contract and 304 ETag behavior |
| `src/IntegrationTests/Api/FeatureFlagsEndpointIntegrationTests.cs` | Integration tests for routes, config, API key, diagnostics regression |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Added test cases for protected feature-flags routes |

## Testing Notes

- Private build (`PrivateBuild.ps1`) passed: 271 unit tests, 123 integration tests
- Unit tests cover snapshot builder, controller JSON shape, and conditional GET (304)
- Integration tests cover unversioned/versioned routes, configuration overrides, API key enforcement, diagnostics regression, and ETag via HTTP
- No acceptance tests required (API-only, no UX change)

Closes #6815
