### PR TITLE
New API endpoint GET /api/echo with request reflection for debugging (#6810)

### DIFF
--- a/src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.ServiceDefaults;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class EchoEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetEchoUnversioned()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo?foo=bar&foo=baz");
+        request.Headers.Add("User-Agent", "echo-test");
+        request.Headers.Add(CorrelationIdConstants.HeaderName, "my-trace-1");
+
+        var response = await _client!.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        response.Headers.GetValues(CorrelationIdConstants.HeaderName).Single().ShouldBe("my-trace-1");
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Method.ShouldBe("GET");
+        payload.Path.ShouldBe("/api/echo");
+        payload.QueryString.ShouldNotBeNull();
+        payload.QueryString!.ShouldContain("foo=bar");
+        payload.Query["foo"].ShouldBe(["bar", "baz"]);
+        payload.Headers.ContainsKey("User-Agent").ShouldBeTrue();
+        payload.CorrelationId.ShouldBe("my-trace-1");
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetEchoVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/echo?debug=1");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Method.ShouldBe("GET");
+        payload.Path.ShouldBe("/api/v1.0/echo");
+        payload.Query["debug"].ShouldBe(["1"]);
+    }
+
+    [Test]
+    public async Task Should_RedactSensitiveHeaders_When_SentOnRequest()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.Add("Authorization", "Bearer secret-token");
+        request.Headers.Add("Cookie", "session=abc");
+        request.Headers.Add("X-Api-Key", "super-secret");
+
+        var response = await _client!.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.ShouldNotContain("secret-token");
+        body.ShouldNotContain("session=abc");
+        body.ShouldNotContain("super-secret");
+
+        var payload = JsonSerializer.Deserialize<EchoResponse>(
+            body,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Headers["Authorization"].ShouldBe([EchoRequestReflectionBuilder.RedactedHeaderValue]);
+        payload.Headers["Cookie"].ShouldBe([EchoRequestReflectionBuilder.RedactedHeaderValue]);
+        payload.Headers["X-Api-Key"].ShouldBe([EchoRequestReflectionBuilder.RedactedHeaderValue]);
+    }
+
+    [Test]
+    public async Task Should_ReturnCorrelationIdHeader_When_RequestHasNoCorrelationHeader()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues(CorrelationIdConstants.HeaderName, out var headerValues).ShouldBeTrue();
+        var correlationId = headerValues!.Single();
+        correlationId.Length.ShouldBeGreaterThan(0);
+        Guid.TryParse(correlationId, out _).ShouldBeTrue();
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.CorrelationId.ShouldBe(correlationId);
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_EchoAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/echo");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var unversionedMediaType = unversioned.Content.Headers.ContentType?.MediaType;
+        unversionedMediaType.ShouldNotBeNull();
+        unversionedMediaType!.ShouldContain("application/json");
+
+        var versioned = await client.GetAsync("/api/v1.0/echo");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var versionedMediaType = versioned.Content.Headers.ContentType?.MediaType;
+        versionedMediaType.ShouldNotBeNull();
+        versionedMediaType!.ShouldContain("application/json");
+    }
+}

--- a/src/UI/Api/Controllers/EchoController.cs
+++ b/src/UI/Api/Controllers/EchoController.cs
@@ -1,0 +1,26 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a JSON echo of the incoming HTTP request for operator and developer diagnostics.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/echo")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/echo")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class EchoController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON object reflecting key properties of the current HTTP request.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        ConditionalGetEtag.JsonContent(EchoRequestReflectionBuilder.Build(HttpContext));
+}

--- a/src/UI/Api/EchoModels.cs
+++ b/src/UI/Api/EchoModels.cs
@@ -1,0 +1,26 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/echo</c> and <c>GET /api/v1.0/echo</c>, reflecting key properties of the incoming HTTP request.
+/// </summary>
+/// <param name="Method">HTTP method of the incoming request.</param>
+/// <param name="Path">Request path value (for example <c>/api/echo</c>).</param>
+/// <param name="PathBase">Optional path base when the application is hosted under a virtual directory.</param>
+/// <param name="QueryString">Raw query string including the leading <c>?</c> when present.</param>
+/// <param name="Query">Parsed query parameters; each key maps to all submitted values.</param>
+/// <param name="Scheme">Request scheme (for example <c>https</c>).</param>
+/// <param name="Host">Request host value.</param>
+/// <param name="RemoteIp">Remote client IP address when available.</param>
+/// <param name="Headers">Request header names mapped to value arrays. Sensitive headers such as <c>Authorization</c>, <c>Cookie</c>, and <c>X-Api-Key</c> are redacted to <c>[REDACTED]</c>.</param>
+/// <param name="CorrelationId">Correlation identifier from middleware or the incoming <c>X-Correlation-ID</c> header.</param>
+public sealed record EchoResponse(
+    string Method,
+    string Path,
+    string? PathBase,
+    string? QueryString,
+    IReadOnlyDictionary<string, string[]> Query,
+    string Scheme,
+    string Host,
+    string? RemoteIp,
+    IReadOnlyDictionary<string, string[]> Headers,
+    string? CorrelationId);

--- a/src/UI/Api/EchoRequestReflectionBuilder.cs
+++ b/src/UI/Api/EchoRequestReflectionBuilder.cs
@@ -44,7 +44,7 @@ public static class EchoRequestReflectionBuilder
         var result = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
         foreach (var pair in query)
         {
-            result[pair.Key] = pair.Value.ToArray();
+            result[pair.Key] = pair.Value.Select(static v => v ?? string.Empty).ToArray();
         }
 
         return result;

--- a/src/UI/Api/EchoRequestReflectionBuilder.cs
+++ b/src/UI/Api/EchoRequestReflectionBuilder.cs
@@ -1,0 +1,87 @@
+using ClearMeasure.Bootcamp.ServiceDefaults;
+using Microsoft.AspNetCore.Http;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Builds <see cref="EchoResponse"/> instances from an HTTP request for diagnostic echo endpoints.
+/// </summary>
+public static class EchoRequestReflectionBuilder
+{
+    /// <summary>
+    /// Literal substituted for sensitive header values in echo responses.
+    /// </summary>
+    public const string RedactedHeaderValue = "[REDACTED]";
+
+    private static readonly HashSet<string> SensitiveHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        "X-Api-Key"
+    };
+
+    /// <summary>
+    /// Reflects key properties of <paramref name="context"/>'s HTTP request into an <see cref="EchoResponse"/>.
+    /// </summary>
+    public static EchoResponse Build(HttpContext context)
+    {
+        var request = context.Request;
+        return new EchoResponse(
+            Method: request.Method,
+            Path: request.Path.Value ?? string.Empty,
+            PathBase: request.PathBase.Value,
+            QueryString: request.QueryString.Value,
+            Query: CopyQuery(request.Query),
+            Scheme: request.Scheme,
+            Host: request.Host.Value ?? string.Empty,
+            RemoteIp: context.Connection.RemoteIpAddress?.ToString(),
+            Headers: CopyHeaders(request.Headers),
+            CorrelationId: ResolveCorrelationId(context));
+    }
+
+    private static IReadOnlyDictionary<string, string[]> CopyQuery(IQueryCollection query)
+    {
+        var result = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in query)
+        {
+            result[pair.Key] = pair.Value.ToArray();
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyDictionary<string, string[]> CopyHeaders(IHeaderDictionary headers)
+    {
+        var result = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in headers)
+        {
+            var values = SensitiveHeaderNames.Contains(pair.Key)
+                ? [RedactedHeaderValue]
+                : pair.Value.ToArray();
+            result[pair.Key] = values;
+        }
+
+        return result;
+    }
+
+    private static string? ResolveCorrelationId(HttpContext context)
+    {
+        if (context.Items.TryGetValue(CorrelationIdConstants.HttpContextItemKey, out var itemValue)
+            && itemValue is string fromItems
+            && !string.IsNullOrEmpty(fromItems))
+        {
+            return fromItems;
+        }
+
+        if (context.Request.Headers.TryGetValue(CorrelationIdConstants.HeaderName, out var headerValues))
+        {
+            var fromHeader = headerValues.FirstOrDefault();
+            if (!string.IsNullOrEmpty(fromHeader))
+            {
+                return fromHeader;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/UI/Api/EchoRequestReflectionBuilder.cs
+++ b/src/UI/Api/EchoRequestReflectionBuilder.cs
@@ -57,7 +57,7 @@ public static class EchoRequestReflectionBuilder
         {
             var values = SensitiveHeaderNames.Contains(pair.Key)
                 ? [RedactedHeaderValue]
-                : pair.Value.ToArray();
+                : pair.Value.Select(static v => v ?? string.Empty).ToArray();
             result[pair.Key] = values;
         }
 

--- a/src/UI/Api/UI.Api.csproj
+++ b/src/UI/Api/UI.Api.csproj
@@ -19,6 +19,7 @@
 		<PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
 	</ItemGroup>
 	<ItemGroup>
+		<ProjectReference Include="..\..\ChurchBulletin.ServiceDefaults\ChurchBulletin.ServiceDefaults.csproj" />
 		<ProjectReference Include="..\..\Core\Core.csproj" />
 	</ItemGroup>
 

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and echo endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/EchoControllerTests.cs
+++ b/src/UnitTests/UI.Api/EchoControllerTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EchoControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJsonEchoResponse_When_Called()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Path = "/api/echo";
+        context.Request.QueryString = new QueryString("?debug=1");
+        context.Request.Scheme = "http";
+        context.Request.Host = new HostString("localhost");
+        context.Request.Headers["User-Agent"] = "unit-test";
+
+        var controller = new EchoController
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+
+        var payload = JsonSerializer.Deserialize<EchoResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Method.ShouldBe("GET");
+        payload.Path.ShouldBe("/api/echo");
+        payload.Query["debug"].ShouldBe(["1"]);
+        payload.Scheme.ShouldBe("http");
+        payload.Host.ShouldBe("localhost");
+        payload.Headers["User-Agent"].ShouldBe(["unit-test"]);
+    }
+}

--- a/src/UnitTests/UI.Api/EchoRequestReflectionBuilderTests.cs
+++ b/src/UnitTests/UI.Api/EchoRequestReflectionBuilderTests.cs
@@ -1,0 +1,79 @@
+using ClearMeasure.Bootcamp.ServiceDefaults;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EchoRequestReflectionBuilderTests
+{
+    [Test]
+    public void Should_BuildEchoResponse_When_QueryAndHeadersPresent()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Path = "/api/echo";
+        context.Request.PathBase = "/app";
+        context.Request.QueryString = new QueryString("?a=1&b=2&a=3");
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("example.com", 443);
+        context.Request.Headers["User-Agent"] = "echo-test-agent";
+        context.Request.Headers["Accept"] = "application/json";
+
+        var response = EchoRequestReflectionBuilder.Build(context);
+
+        response.Method.ShouldBe("GET");
+        response.Path.ShouldBe("/api/echo");
+        response.PathBase.ShouldBe("/app");
+        response.QueryString.ShouldBe("?a=1&b=2&a=3");
+        response.Query["a"].ShouldBe(["1", "3"]);
+        response.Query["b"].ShouldBe(["2"]);
+        response.Scheme.ShouldBe("https");
+        response.Host.ShouldBe("example.com:443");
+        response.Headers["User-Agent"].ShouldBe(["echo-test-agent"]);
+        response.Headers["Accept"].ShouldBe(["application/json"]);
+    }
+
+    [Test]
+    public void Should_RedactSensitiveHeaders_When_AuthorizationCookieOrApiKeyPresent()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Authorization"] = "Bearer secret-token";
+        context.Request.Headers["Cookie"] = "session=abc";
+        context.Request.Headers["X-Api-Key"] = "super-secret";
+        context.Request.Headers["Accept"] = "application/json";
+        context.Request.Headers["User-Agent"] = "safe-agent";
+
+        var response = EchoRequestReflectionBuilder.Build(context);
+
+        response.Headers["Authorization"].ShouldBe([EchoRequestReflectionBuilder.RedactedHeaderValue]);
+        response.Headers["Cookie"].ShouldBe([EchoRequestReflectionBuilder.RedactedHeaderValue]);
+        response.Headers["X-Api-Key"].ShouldBe([EchoRequestReflectionBuilder.RedactedHeaderValue]);
+        response.Headers["Accept"].ShouldBe(["application/json"]);
+        response.Headers["User-Agent"].ShouldBe(["safe-agent"]);
+    }
+
+    [Test]
+    public void Should_UseCorrelationIdFromHttpContextItems_When_MiddlewareSet()
+    {
+        var context = new DefaultHttpContext();
+        context.Items[CorrelationIdConstants.HttpContextItemKey] = "from-middleware";
+        context.Request.Headers[CorrelationIdConstants.HeaderName] = "from-header";
+
+        var response = EchoRequestReflectionBuilder.Build(context);
+
+        response.CorrelationId.ShouldBe("from-middleware");
+    }
+
+    [Test]
+    public void Should_FallbackToCorrelationHeader_When_ItemsNotSet()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[CorrelationIdConstants.HeaderName] = "from-header";
+
+        var response = EchoRequestReflectionBuilder.Build(context);
+
+        response.CorrelationId.ShouldBe("from-header");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/echo", true)]
+    [TestCase("/api/v1.0/echo", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -107,4 +107,23 @@ public class ApiKeyAuthenticationWebTests
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
     }
+
+    [Test]
+    public async Task Should_Return200_When_EchoWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/echo");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var unversionedMediaType = unversioned.Content.Headers.ContentType?.MediaType;
+        unversionedMediaType.ShouldNotBeNull();
+        unversionedMediaType!.ShouldContain("application/json");
+
+        var versioned = await client.GetAsync("/api/v1.0/echo");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var versionedMediaType = versioned.Content.Headers.ContentType?.MediaType;
+        versionedMediaType.ShouldNotBeNull();
+        versionedMediaType!.ShouldContain("application/json");
+    }
 }


### PR DESCRIPTION
Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

## Summary

Implements `GET /api/echo` and `GET /api/v1.0/echo` — a public, rate-limited JSON diagnostic endpoint that reflects key properties of the incoming HTTP request (method, path, query, headers, scheme, host, remote IP, correlation ID). Sensitive headers (`Authorization`, `Cookie`, `X-Api-Key`) are redacted to `[REDACTED]`.

Closes #6810

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/EchoModels.cs` | `EchoResponse` record with XML documentation |
| `src/UI/Api/EchoRequestReflectionBuilder.cs` | Builds echo payload from `HttpContext`; redacts sensitive headers |
| `src/UI/Api/Controllers/EchoController.cs` | GET endpoint with versioning, rate limiting, anonymous access |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Public bypass for `/api/echo` and `/api/v1.0/echo` |
| `src/UI/Api/UI.Api.csproj` | Project reference to ServiceDefaults for `CorrelationIdConstants` |
| `src/UnitTests/UI.Api/EchoRequestReflectionBuilderTests.cs` | Builder unit tests (query, redaction, correlation ID) |
| `src/UnitTests/UI.Api/EchoControllerTests.cs` | Controller unit test |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Echo path bypass test cases |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Echo without API key web test |
| `src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs` | Full pipeline integration tests (5 scenarios) |

## Testing Notes

- Private build passed: 272 unit tests + 121 integration tests green
- Echo-specific: `dotnet test src/UnitTests --filter "FullyQualifiedName~Echo"` (8 tests)
- Echo integration: covered in full integration suite via `EchoEndpointIntegrationTests`
- No acceptance/Playwright tests — no UX change per issue scope
