### PR TITLE
New API endpoint GET /api/health/detailed for component-level health reporting (#6808)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Server;
 using Shouldly;
 
 namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
@@ -139,5 +140,114 @@ public class DetailedHealthEndpointIntegrationTests
                 || c.Status == ComponentHealthStatus.Degraded
                 || c.Status == ComponentHealthStatus.Unhealthy).ShouldBeTrue();
         }
+    }
+
+    [Test]
+    public async Task Should_Return200AndEquivalentPayload_When_GetDetailedHealth_LegacyAndV1Paths()
+    {
+        var legacy = await _client!.GetAsync("/api/health/detailed");
+        var v1 = await _client.GetAsync("/api/v1.0/health/detailed");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var legacyReport = await legacy.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var v1Report = await v1.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        legacyReport.ShouldNotBeNull();
+        v1Report.ShouldNotBeNull();
+
+        legacyReport!.OverallStatus.ShouldBe(v1Report!.OverallStatus);
+        var legacyNames = legacyReport.Components.Select(c => c.Name).Order().ToList();
+        var v1Names = v1Report.Components.Select(c => c.Name).Order().ToList();
+        legacyNames.ShouldBe(v1Names);
+        foreach (var name in legacyNames)
+        {
+            var legacyStatus = legacyReport.Components.First(c => c.Name == name).Status;
+            var v1Status = v1Report.Components.First(c => c.Name == name).Status;
+            legacyStatus.ShouldBe(v1Status);
+        }
+    }
+
+    [Test]
+    public async Task Should_IncludeApiSupportedVersionsHeader_When_GetDetailedHealthVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/health/detailed");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues("api-supported-versions", out var values).ShouldBeTrue();
+        values.ShouldNotBeNull();
+        string.Join(", ", values!).ShouldContain("1.0");
+    }
+
+    [Test]
+    public async Task Should_ReturnNotSuccess_When_GetDetailedHealth_UnsupportedVersion()
+    {
+        var response = await _client!.GetAsync("/api/v2.0/health/detailed");
+
+        response.IsSuccessStatusCode.ShouldBeFalse();
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.NotFound, HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Return200WithJsonBody_When_OverallStatusUnhealthy()
+    {
+        try
+        {
+            var setResponse = await _client!.GetAsync("/_demo/setneedsreboot/true");
+            setResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            var response = await _client.GetAsync("/api/health/detailed");
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            report.ShouldNotBeNull();
+            report!.OverallStatus.ShouldBe(ComponentHealthStatus.Unhealthy);
+            report.Components.ShouldContain(c =>
+                c.Name == "NeedsReboot" && c.Status == ComponentHealthStatus.Unhealthy);
+        }
+        finally
+        {
+            NeedsRebootHealthCheck.NeedsReboot = false;
+            await _client!.GetAsync("/_demo/setneedsreboot/false");
+        }
+    }
+
+    [Test]
+    public async Task Should_IncludePerComponentSchemaFields_When_DetailedHealthReturned()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var components = doc.RootElement.GetProperty("components");
+        components.GetArrayLength().ShouldBeGreaterThan(0);
+
+        foreach (var element in components.EnumerateArray())
+        {
+            element.GetProperty("name").GetString().ShouldNotBeNullOrWhiteSpace();
+            var status = element.GetProperty("status").GetString();
+            status.ShouldBeOneOf(
+                ComponentHealthStatus.Healthy,
+                ComponentHealthStatus.Degraded,
+                ComponentHealthStatus.Unhealthy);
+            element.GetProperty("durationMs").GetDouble().ShouldBeGreaterThanOrEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Should_OrderComponentsAlphabeticallyByName_When_DetailedHealthReturned()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        var names = report!.Components.Select(c => c.Name).ToList();
+        names.ShouldBe(names.Order(StringComparer.Ordinal).ToList());
     }
 }

--- a/src/UnitTests/Api/ApiRateLimitingWebTests.cs
+++ b/src/UnitTests/Api/ApiRateLimitingWebTests.cs
@@ -161,4 +161,14 @@ public class ApiRateLimitingWebTests
         for (var i = 0; i < 5; i++)
             (await client.GetAsync("/api/time")).StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return429_When_DetailedHealthExceedsRateLimit()
+    {
+        await using var factory = new TunableApiRateLimitWebApplicationFactory(StrictLimitSettings(2));
+        using var client = factory.CreateClient();
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+    }
 }

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -33,6 +33,33 @@ public class ApiKeyAuthenticationWebTests
     }
 
     [Test]
+    public async Task Should_Return401_When_ApiHealthDetailedCalledWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/health/detailed");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ApiHealthDetailedCalledWithValidKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var unversioned = await client.GetAsync("/api/health/detailed");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/health/detailed");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
     public async Task Should_Return401_When_ApiDiagnosticsCalledWithoutKey()
     {
         await using var factory = new ApiKeyProtectedWebApplicationFactory();

--- a/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
+++ b/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
@@ -54,7 +54,8 @@ public class EtagConditionalGetWebTests
     [Test]
     public async Task Should_Return304NotModified_When_DetailedHealthIfNoneMatchMatchesEtag()
     {
-        using var client = _factory!.CreateClient();
+        await using var factory = new FixedDetailedHealthWebApplicationFactory();
+        using var client = factory.CreateClient();
         var first = await client.GetAsync("/api/health/detailed");
         first.StatusCode.ShouldBe(HttpStatusCode.OK);
         var etag = first.Headers.ETag;

--- a/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
+++ b/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
@@ -41,4 +41,29 @@ public class EtagConditionalGetWebTests
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Headers.ETag.ShouldNotBeNull();
     }
+
+    [Test]
+    public async Task Should_IncludeEtagHeader_When_GetDetailedHealth()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+    }
+
+    [Test]
+    public async Task Should_Return304NotModified_When_DetailedHealthIfNoneMatchMatchesEtag()
+    {
+        using var client = _factory!.CreateClient();
+        var first = await client.GetAsync("/api/health/detailed");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var etag = first.Headers.ETag;
+        etag.ShouldNotBeNull();
+
+        using var second = new HttpRequestMessage(HttpMethod.Get, "/api/health/detailed");
+        second.Headers.IfNoneMatch.Add(etag!);
+        var notModified = await client.SendAsync(second);
+        notModified.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
+    }
 }

--- a/src/UnitTests/UI.Server/FixedDetailedHealthWebApplicationFactory.cs
+++ b/src/UnitTests/UI.Server/FixedDetailedHealthWebApplicationFactory.cs
@@ -1,0 +1,63 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+/// <summary>
+/// In-process UI.Server host with a fixed <see cref="IDetailedHealthReportProvider"/> for stable ETag conditional GET tests.
+/// </summary>
+public sealed class FixedDetailedHealthWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    internal static readonly DetailedHealthReport FixedReport = new()
+    {
+        OverallStatus = ComponentHealthStatus.Healthy,
+        CheckedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        Components =
+        [
+            new ComponentHealthEntry
+            {
+                Name = "API",
+                Status = ComponentHealthStatus.Healthy,
+                DurationMs = 1.0
+            }
+        ]
+    };
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", WebApplicationTestingDatabase.SqliteSharedMemoryConnectionString);
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = WebApplicationTestingDatabase.SqliteSharedMemoryConnectionString,
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = ""
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            var descriptors = services.Where(d => d.ServiceType == typeof(IDetailedHealthReportProvider)).ToList();
+            foreach (var descriptor in descriptors)
+                services.Remove(descriptor);
+
+            services.AddSingleton<IDetailedHealthReportProvider>(new StubDetailedHealthReportProvider(FixedReport));
+        });
+    }
+
+    private sealed class StubDetailedHealthReportProvider(DetailedHealthReport report) : IDetailedHealthReportProvider
+    {
+        public Task<DetailedHealthReport> GetReportAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(report);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

## Summary

Adds comprehensive test coverage for the existing `GET /api/health/detailed` endpoint, which returns component-level health status as JSON for operational monitoring. The endpoint implementation (controller, provider, models, DI) was already present; this PR completes the test design checklist from issue #6808.

The detailed health API aggregates registered ASP.NET Core health checks (excluding liveness-only probes) into a machine-oriented payload with `overallStatus`, `checkedAtUtc`, and a `components` array. It supports both legacy (`/api/health/detailed`) and versioned (`/api/v1.0/health/detailed`) routes, ETag conditional GET, API key auth, and rate limiting.

## Files Changed

| File | Description |
|------|-------------|
| `src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs` | Added integration tests for versioning, schema fields, alphabetical ordering, unhealthy status via NeedsReboot, and API version headers |
| `src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs` | Added ETag header and 304 Not Modified tests for detailed health |
| `src/UnitTests/UI.Server/FixedDetailedHealthWebApplicationFactory.cs` | Test factory with deterministic health report for stable ETag assertions |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Added API key auth tests for `/api/health/detailed` (401 without key, 200 with key) |
| `src/UnitTests/Api/ApiRateLimitingWebTests.cs` | Added rate-limit 429 test for detailed health endpoint |

## Testing Notes

- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./PrivateBuild.ps1` — all unit and integration tests pass
- New integration tests exercise HTTP contract, versioning, unhealthy scenario via `/_demo/setneedsreboot/true`, and component schema
- Web-level tests cover ETag conditional GET (with fixed provider), API key protection, and rate limiting

Closes #6808
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-161fbafc-91c4-468d-b9c3-4e5c1372770c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-161fbafc-91c4-468d-b9c3-4e5c1372770c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

