### PR TITLE
New API endpoint GET /api/metrics/summary for application runtime metrics (#6809)

### DIFF
--- a/src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/MetricsSummaryEndpointIntegrationTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class MetricsSummaryEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetMetricsSummaryUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("totalRequestsServed", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("managedMemoryBytes", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("workingSetBytes", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("gcCollectionCounts", out var gc).ShouldBeTrue();
+        gc.TryGetProperty("gen0", out _).ShouldBeTrue();
+        gc.TryGetProperty("gen1", out _).ShouldBeTrue();
+        gc.TryGetProperty("gen2", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetMetricsSummaryVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/metrics/summary");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("uptime", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("totalRequestsServed", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("managedMemoryBytes", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("workingSetBytes", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("gcCollectionCounts", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_ExposeNonNegativeUptime_When_GetMetricsSummary()
+    {
+        var before = DateTime.UtcNow;
+        var response = await _client!.GetAsync("/api/metrics/summary");
+        var after = DateTime.UtcNow;
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Uptime.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        var health = SimpleHealthResponseBuilder.Build(TimeProvider.System);
+        (after - before).ShouldBeLessThan(TimeSpan.FromSeconds(30));
+        payload.Uptime.ShouldBeLessThanOrEqualTo(health.Uptime + TimeSpan.FromSeconds(2));
+        payload.Uptime.ShouldBeGreaterThanOrEqualTo(health.Uptime - TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
+    public async Task Should_ExposeNonNegativeMemoryAndGcCounts_When_GetMetricsSummary()
+    {
+        var response = await _client!.GetAsync("/api/metrics/summary");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.ManagedMemoryBytes.ShouldBeGreaterThanOrEqualTo(0);
+        payload.WorkingSetBytes.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollectionCounts.Gen0.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollectionCounts.Gen1.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollectionCounts.Gen2.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_IncrementTotalRequestsServed_When_TrafficOccurs()
+    {
+        var baselineResponse = await _client!.GetAsync("/api/metrics/summary");
+        baselineResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var baseline = await baselineResponse.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        baseline.ShouldNotBeNull();
+
+        const int additionalRequests = 3;
+        for (var i = 0; i < additionalRequests; i++)
+        {
+            var ping = await _client.GetAsync("/api/ping");
+            ping.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        var afterResponse = await _client.GetAsync("/api/metrics/summary");
+        afterResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var after = await afterResponse.Content.ReadFromJsonAsync<MetricsSummaryResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        after.ShouldNotBeNull();
+        after!.TotalRequestsServed.ShouldBeGreaterThanOrEqualTo(baseline!.TotalRequestsServed + additionalRequests);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabledAndMetricsProtected()
+    {
+        await using var factory = new DiagnosticsApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/metrics/summary");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var unauthVersioned = await client.GetAsync("/api/v1.0/metrics/summary");
+        unauthVersioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var ok = await withKey.GetAsync("/api/metrics/summary");
+        ok.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var okVersioned = await withKey.GetAsync("/api/v1.0/metrics/summary");
+        okVersioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_NotConflictWithExistingDiagnosticsRoutes_When_MetricsRegistered()
+    {
+        var diagnostics = await _client!.GetAsync("/api/diagnostics");
+        diagnostics.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var metrics = await _client.GetAsync("/api/metrics/summary");
+        metrics.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/UI/Api/Controllers/MetricsSummaryController.cs
+++ b/src/UI/Api/Controllers/MetricsSummaryController.cs
@@ -1,0 +1,27 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a JSON runtime metrics snapshot for operators and monitoring integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/metrics/summary")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/metrics/summary")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class MetricsSummaryController(TimeProvider timeProvider, IRequestMetricsCollector collector) : ControllerBase
+{
+    /// <summary>
+    /// Returns uptime, total requests served, memory usage, and GC collection counts.
+    /// </summary>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        var payload = MetricsSummaryResponseBuilder.Build(timeProvider, collector.TotalRequestsServed);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/IRequestMetricsCollector.cs
+++ b/src/UI/Api/IRequestMetricsCollector.cs
@@ -1,0 +1,17 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Tracks total HTTP requests served by the host since process start.
+/// </summary>
+public interface IRequestMetricsCollector
+{
+    /// <summary>
+    /// Records one HTTP request.
+    /// </summary>
+    void RecordRequest();
+
+    /// <summary>
+    /// Total requests recorded since process start.
+    /// </summary>
+    long TotalRequestsServed { get; }
+}

--- a/src/UI/Api/MetricsSummaryModels.cs
+++ b/src/UI/Api/MetricsSummaryModels.cs
@@ -1,0 +1,26 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/metrics/summary</c> and <c>GET /api/v1.0/metrics/summary</c>.
+/// </summary>
+/// <param name="Uptime">Process uptime (same semantics as <see cref="SimpleHealthResponseBuilder"/>).</param>
+/// <param name="TotalRequestsServed">
+/// Total HTTP requests observed by the host since process start (all traffic passing request-metrics middleware, not API-only).
+/// </param>
+/// <param name="ManagedMemoryBytes">Managed heap size from <see cref="GC.GetTotalMemory(bool)"/> without forcing collection.</param>
+/// <param name="WorkingSetBytes">Process working set from <see cref="System.Diagnostics.Process.WorkingSet64"/>.</param>
+/// <param name="GcCollectionCounts">GC collection counts per generation.</param>
+public sealed record MetricsSummaryResponse(
+    TimeSpan Uptime,
+    long TotalRequestsServed,
+    long ManagedMemoryBytes,
+    long WorkingSetBytes,
+    GcCollectionCounts GcCollectionCounts);
+
+/// <summary>
+/// GC collection counts for generations 0, 1, and 2.
+/// </summary>
+/// <param name="Gen0">Collections for generation 0.</param>
+/// <param name="Gen1">Collections for generation 1.</param>
+/// <param name="Gen2">Collections for generation 2.</param>
+public sealed record GcCollectionCounts(int Gen0, int Gen1, int Gen2);

--- a/src/UI/Api/MetricsSummaryResponseBuilder.cs
+++ b/src/UI/Api/MetricsSummaryResponseBuilder.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Builds <see cref="MetricsSummaryResponse"/> for <c>GET /api/metrics/summary</c>.
+/// </summary>
+public static class MetricsSummaryResponseBuilder
+{
+    /// <summary>
+    /// Creates a runtime metrics snapshot using the supplied clock and request counter value.
+    /// </summary>
+    /// <param name="timeProvider">Clock for uptime calculation.</param>
+    /// <param name="totalRequestsServed">Total requests served (injected for deterministic tests).</param>
+    public static MetricsSummaryResponse Build(TimeProvider timeProvider, long totalRequestsServed)
+    {
+        var uptime = SimpleHealthResponseBuilder.Build(timeProvider).Uptime;
+        var managedMemoryBytes = GC.GetTotalMemory(false);
+        var workingSetBytes = Process.GetCurrentProcess().WorkingSet64;
+        var gcCollectionCounts = new GcCollectionCounts(
+            GC.CollectionCount(0),
+            GC.CollectionCount(1),
+            GC.CollectionCount(2));
+
+        return new MetricsSummaryResponse(
+            uptime,
+            totalRequestsServed,
+            managedMemoryBytes,
+            workingSetBytes,
+            gcCollectionCounts);
+    }
+}

--- a/src/UI/Server/Middleware/RequestMetricsMiddleware.cs
+++ b/src/UI/Server/Middleware/RequestMetricsMiddleware.cs
@@ -1,0 +1,25 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Http;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Middleware;
+
+/// <summary>
+/// Increments <see cref="IRequestMetricsCollector"/> once per HTTP request that reaches the middleware.
+/// </summary>
+public sealed class RequestMetricsMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IRequestMetricsCollector _collector;
+
+    public RequestMetricsMiddleware(RequestDelegate next, IRequestMetricsCollector collector)
+    {
+        _next = next;
+        _collector = collector;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        _collector.RecordRequest();
+        await _next(context);
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddApiVersioning(options =>
 builder.Services.AddRazorPages();
 builder.Host.UseLamar(registry => { registry.IncludeRegistry<UiServiceRegistry>(); });
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<IRequestMetricsCollector, RequestMetricsCollector>();
 builder.Services.AddScoped<IDistributedBus, DistributedBus>();
 builder.Services.AddMemoryCache();
 builder.Services.Configure<IdempotencyOptions>(
@@ -161,6 +162,8 @@ app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+app.UseMiddleware<RequestMetricsMiddleware>();
 
 app.UseWhen(
     context => ApiRateLimitingExtensions.ShouldApplyToPath(context.Request.Path),

--- a/src/UI/Server/RequestMetricsCollector.cs
+++ b/src/UI/Server/RequestMetricsCollector.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using ClearMeasure.Bootcamp.UI.Api;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Thread-safe singleton request counter for runtime metrics.
+/// </summary>
+public sealed class RequestMetricsCollector : IRequestMetricsCollector
+{
+    private long _totalRequestsServed;
+
+    /// <inheritdoc />
+    public void RecordRequest() => Interlocked.Increment(ref _totalRequestsServed);
+
+    /// <inheritdoc />
+    public long TotalRequestsServed => Interlocked.Read(ref _totalRequestsServed);
+}

--- a/src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs
+++ b/src/UnitTests/UI.Api/MetricsSummaryControllerTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class MetricsSummaryControllerTests
+{
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class StubRequestMetricsCollector(long totalRequestsServed) : IRequestMetricsCollector
+    {
+        public long TotalRequestsServed { get; } = totalRequestsServed;
+
+        public void RecordRequest()
+        {
+        }
+    }
+
+    [Test]
+    public void Get_Should_ReturnJson_WithUptimeRequestsMemoryAndGc_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+        var collector = new StubRequestMetricsCollector(17);
+        var controller = new MetricsSummaryController(clock, collector)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<MetricsSummaryResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Uptime.ShouldBe(SimpleHealthResponseBuilder.Build(clock).Uptime);
+        payload.TotalRequestsServed.ShouldBe(17);
+        payload.ManagedMemoryBytes.ShouldBeGreaterThanOrEqualTo(0);
+        payload.WorkingSetBytes.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollectionCounts.Gen0.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollectionCounts.Gen1.ShouldBeGreaterThanOrEqualTo(0);
+        payload.GcCollectionCounts.Gen2.ShouldBeGreaterThanOrEqualTo(0);
+    }
+}

--- a/src/UnitTests/UI.Api/MetricsSummaryResponseBuilderTests.cs
+++ b/src/UnitTests/UI.Api/MetricsSummaryResponseBuilderTests.cs
@@ -1,0 +1,56 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class MetricsSummaryResponseBuilderTests
+{
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    [Test]
+    public void Build_Should_ReuseUptimeSemantics_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+
+        var response = MetricsSummaryResponseBuilder.Build(clock, 0);
+
+        response.Uptime.ShouldBe(SimpleHealthResponseBuilder.Build(clock).Uptime);
+    }
+
+    [Test]
+    public void Build_Should_ExposeGcCollectionCounts_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+
+        var response = MetricsSummaryResponseBuilder.Build(clock, 0);
+
+        response.GcCollectionCounts.Gen0.ShouldBeGreaterThanOrEqualTo(0);
+        response.GcCollectionCounts.Gen1.ShouldBeGreaterThanOrEqualTo(0);
+        response.GcCollectionCounts.Gen2.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public void Build_Should_ExposeMemoryValues_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+
+        var response = MetricsSummaryResponseBuilder.Build(clock, 0);
+
+        response.ManagedMemoryBytes.ShouldBeGreaterThanOrEqualTo(0);
+        response.WorkingSetBytes.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public void Build_Should_PassThroughTotalRequestsServed_When_Called()
+    {
+        var clock = new FixedUtcTimeProvider(new DateTimeOffset(2026, 4, 10, 15, 0, 0, TimeSpan.Zero));
+
+        var response = MetricsSummaryResponseBuilder.Build(clock, 42);
+
+        response.TotalRequestsServed.ShouldBe(42);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -10,6 +10,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/health", false)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
+    [TestCase("/api/metrics/summary", false)]
+    [TestCase("/api/v1.0/metrics/summary", false)]
     [TestCase("/api/version", true)]
     [TestCase("/api/v1.0/version", true)]
     [TestCase("/api/time", true)]

--- a/src/UnitTests/UI.Server/RequestMetricsCollectorTests.cs
+++ b/src/UnitTests/UI.Server/RequestMetricsCollectorTests.cs
@@ -1,0 +1,30 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class RequestMetricsCollectorTests
+{
+    [Test]
+    public void RecordRequest_Should_IncrementTotalRequestsServed_When_Called()
+    {
+        var collector = new RequestMetricsCollector();
+
+        collector.RecordRequest();
+        collector.RecordRequest();
+
+        collector.TotalRequestsServed.ShouldBe(2);
+    }
+
+    [Test]
+    public void RecordRequest_Should_IncrementTotalRequestsServed_When_CalledConcurrently()
+    {
+        var collector = new RequestMetricsCollector();
+        const int iterations = 1000;
+
+        Parallel.For(0, iterations, _ => collector.RecordRequest());
+
+        collector.TotalRequestsServed.ShouldBe(iterations);
+    }
+}

--- a/src/UnitTests/UI.Server/RequestMetricsMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/RequestMetricsMiddlewareTests.cs
@@ -1,0 +1,31 @@
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Server.Middleware;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class RequestMetricsMiddlewareTests
+{
+    private sealed class StubRequestMetricsCollector : IRequestMetricsCollector
+    {
+        public int RecordRequestCallCount { get; private set; }
+
+        public long TotalRequestsServed => RecordRequestCallCount;
+
+        public void RecordRequest() => RecordRequestCallCount++;
+    }
+
+    [Test]
+    public async Task InvokeAsync_Should_CallRecordRequestOnce_When_RequestPassesThrough()
+    {
+        var collector = new StubRequestMetricsCollector();
+        var middleware = new RequestMetricsMiddleware(_ => Task.CompletedTask, collector);
+        var context = new DefaultHttpContext();
+
+        await middleware.InvokeAsync(context);
+
+        collector.RecordRequestCallCount.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new machine-oriented JSON endpoint at  (and versioned ) that returns a runtime metrics snapshot for operators and monitoring tools: process uptime, total HTTP requests served, managed memory, working set, and GC collection counts.

## Changes

| File | Description |
|------|-------------|
|  | Response DTOs (, ) |
|  | Builds snapshot from  and request counter |
|  | Abstraction for host-wide request counting |
|  | Thread-safe singleton counter () |
|  | Records one request per HTTP call |
|  | Dual-route controller with rate limiting |
|  | Registers collector and middleware after routing |
|  | Builder unit tests |
|  | Controller unit tests |
|  | Collector concurrency tests |
|  | Middleware unit tests |
|  | Metrics paths require API key |
|  | End-to-end contract, counting, API key tests |

## Testing

- /workspace/src/DataAccess/DataAccess.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q [/workspace/src/ChurchBulletin.sln]
/workspace/src/AcceptanceTests/AcceptanceTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q [/workspace/src/ChurchBulletin.sln]
/workspace/src/Worker/Worker.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-2f33-pr97-265q [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-2x83-8g95-xh59 [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-cj9g-3mj2-g8vv [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-cxmj-83gh-fp49 [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1903: Package 'MessagePack' 2.5.192 has a known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-q2h6-ghwm-5qm8 [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-qhmf-xw27-6rqr [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-v72x-2h86-7f8m [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1903: Package 'MessagePack' 2.5.192 has a known high severity vulnerability, https://github.com/advisories/GHSA-vh6j-jc39-fggf [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-w567-gjr2-hm5j [/workspace/src/ChurchBulletin.sln]
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-wfr3-xj75-pfwh [/workspace/src/ChurchBulletin.sln]
/workspace/src/UI/Server/UI.Server.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q [/workspace/src/ChurchBulletin.sln]
/workspace/src/McpServer/McpServer.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q [/workspace/src/ChurchBulletin.sln]
/workspace/src/UnitTests/UnitTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q [/workspace/src/ChurchBulletin.sln]
/workspace/src/IntegrationTests/IntegrationTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q [/workspace/src/ChurchBulletin.sln]
/workspace/src/IntegrationTests/IntegrationTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/UnitTests/UnitTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/DataAccess/DataAccess.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/UI/Server/UI.Server.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-2f33-pr97-265q
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-2x83-8g95-xh59
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-cj9g-3mj2-g8vv
/workspace/src/AcceptanceTests/AcceptanceTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-cxmj-83gh-fp49
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1903: Package 'MessagePack' 2.5.192 has a known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-q2h6-ghwm-5qm8
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-qhmf-xw27-6rqr
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-v72x-2h86-7f8m
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1903: Package 'MessagePack' 2.5.192 has a known high severity vulnerability, https://github.com/advisories/GHSA-vh6j-jc39-fggf
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-w567-gjr2-hm5j
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-wfr3-xj75-pfwh
/workspace/src/McpServer/McpServer.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q

Build succeeded.

/workspace/src/IntegrationTests/IntegrationTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/UnitTests/UnitTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/DataAccess/DataAccess.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/UI/Server/UI.Server.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-2f33-pr97-265q
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-2x83-8g95-xh59
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-cj9g-3mj2-g8vv
/workspace/src/AcceptanceTests/AcceptanceTests.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-cxmj-83gh-fp49
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1903: Package 'MessagePack' 2.5.192 has a known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-q2h6-ghwm-5qm8
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-qhmf-xw27-6rqr
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-v72x-2h86-7f8m
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1903: Package 'MessagePack' 2.5.192 has a known high severity vulnerability, https://github.com/advisories/GHSA-vh6j-jc39-fggf
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-w567-gjr2-hm5j
/workspace/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj : warning NU1902: Package 'MessagePack' 2.5.192 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-wfr3-xj75-pfwh
/workspace/src/McpServer/McpServer.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
    17 Warning(s)
    0 Error(s)

Time Elapsed 00:00:06.70
Test run for /workspace/src/UnitTests/bin/Release/net10.0/ClearMeasure.Bootcamp.UnitTests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.
Results File: /workspace/build/test/UnitTests/_cursor_2026-07-12_16_00_44_net10.0.trx

Passed!  - Failed:     0, Passed:   274, Skipped:     0, Total:   274, Duration: 20 s - ClearMeasure.Bootcamp.UnitTests.dll (net10.0)

Attachments:
  /workspace/build/test/UnitTests/93c7be45-b60e-4905-8743-91fb80c0e626/coverage.cobertura.xml
ec724a0309ea169b87890ed3f55c25e5bdabcd02b4ceb0627bd105c7c69c97de
[2026-07-12 16:01:12] [WARNING] Still waiting for SQL Server... Error: A connection was successfully established with the server, but then an error occurred during the pre-login handshake. (provider: TCP Provider, error: 0 - Success)
Executing Database Server script '001-first-script.sql'
Executing Database Server script '003-WorkOrderAndEmployeeTables.sql'
Executing Database Server script '004_RenameConstraintsToGoodNames.sql'
Executing Database Server script '005_AddedWorkOrderNumber.sql'
Executing Database Server script '006_MakeAssigneeNullable.sql'
Executing Database Server script '007_ChangeStatusToChar.sql'
Executing Database Server script '008_AddSomeEmployeeRecords.sql'
Executing Database Server script '009_AddAuditEntry.sql'
Executing Database Server script '010_AddRole.sql'
Executing Database Server script '011_EmployeeRolesTable.sql'
Executing Database Server script '012_ManagerSecretary.sql'
Executing Database Server script '013_SecretaryColumn.sql'
Executing Database Server script '014_MergingEmployees.sql'
Executing Database Server script '015_RemovedAuditEntriesSecretaryManager.sql'
Executing Database Server script '016_AddRoomNumberToWorkOrder.sql'
Executing Database Server script '017_AddAuditEntryTable.sql'
Executing Database Server script '017_AddCreatedDateAndCompletedDateToWorkOrder.sql'
Executing Database Server script '018_AddAssignedDateToWorkOrder.sql'
Executing Database Server script '019_ChangeRoomNumberFromIntToString.sql'
Executing Database Server script '020_DropAuditEntry.sql'
Executing Database Server script '021_ExtendWorkOrderNumberLength.sql'
Executing Database Server script '022_CreateNServiceBusSchema.sql'
Executing Database Server script '023_MigrateCancelledWorkOrders.sql'
Executing Database Server script '024_ExtendWorkOrderTitleLength.sql'
Executing Database Server script '025_AddWorkOrderAttachmentTable.sql'
Executing Database Server script '026_AddPreferredLanguageToEmployee.sql'
Executing Database Server script '027_UpdateWorkOrderDFTDRT.sql'
Test run for /workspace/src/IntegrationTests/bin/Release/net10.0/ClearMeasure.Bootcamp.IntegrationTests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.
Results File: /workspace/build/test/IntegrationTests/_cursor_2026-07-12_16_01_24_net10.0.trx

Passed!  - Failed:     0, Passed:   123, Skipped:     0, Total:   123, Duration: 57 s - ClearMeasure.Bootcamp.IntegrationTests.dll (net10.0)

Attachments:
  /workspace/build/test/IntegrationTests/b7c2be52-a10b-47cb-b6c6-699d0f8cbfad/coverage.cobertura.xml
[2026-07-12 16:02:22] [INFO] BUILD SUCCEEDED - Build time: 00:01:51.7861142 — passed (274 unit tests, 123 integration tests)
- Unit tests cover builder, controller, collector concurrency, middleware invocation, and API key path validation
- Integration tests cover unversioned/versioned routes, uptime/memory/GC non-negativity, request counter increment, API key enforcement, and route coexistence with 

Closes #6809