### PR TITLE
Fix build warnings: pin vulnerable transitive packages

### DIFF
--- a/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj
+++ b/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Pin transitive MessagePack (from Aspire SDK) above 2.5.192 to resolve NU1902/NU1903. -->
+    <PackageReference Include="MessagePack" Version="2.5.302" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\UI\Server\UI.Server.csproj" />
     <ProjectReference Include="..\Worker\Worker.csproj" />
   </ItemGroup>

--- a/src/DataAccess/DataAccess.csproj
+++ b/src/DataAccess/DataAccess.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="NServiceBus.Persistence.Sql.TransactionalSession" Version="8.3.0" />
+    <!-- Pin transitive SQLitePCLRaw above 2.1.11 to resolve NU1903 (GHSA-2m69-gcr7-jv3q). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
 	</ItemGroup>
 

--- a/src/McpServer/McpServer.csproj
+++ b/src/McpServer/McpServer.csproj
@@ -17,6 +17,8 @@
 		<PackageReference Include="MediatR" Version="12.4.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+		<!-- Pin transitive SQLitePCLRaw above 2.1.11 to resolve NU1903 (GHSA-2m69-gcr7-jv3q). -->
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />


### PR DESCRIPTION
## Summary
Resolves all 157 build warnings (build now reports **0 warnings / 0 errors**).

## Changes
- **NU1903 (high):** Pin transitive `SQLitePCLRaw.bundle_e_sqlite3` from 2.1.11 → **2.1.12** (`GHSA-2m69-gcr7-jv3q`) in `DataAccess` and `McpServer`. These are the only projects referencing `EntityFrameworkCore.Sqlite` directly; the pin propagates to the 4 dependent projects (UI.Server, Worker, UnitTests, IntegrationTests) via project references.
- **NU1902/NU1903 (moderate + high, 11 advisories):** Pin transitive `MessagePack` (from the Aspire SDK) from 2.5.192 → **2.5.302** in `ChurchBulletin.AppHost`. Stays within the 2.5.x line to avoid a major-version bump.
- **MSB3061 (139):** File-lock warnings caused by orphaned `testhost`/Playwright `node` processes holding `bin` files during the clean step. An environment artifact, not a code defect — cleared on a clean build. No source change required.

Versions stay in-major to minimize risk. No SDK changes.

## Testing
- `privatebuild.ps1`: **0 warnings, 0 errors**
- Unit tests: 266 passed
- Integration tests: 118 passed
- Acceptance tests (pre-change baseline): 83 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)