### PR TITLE
Add codebase-cartography-audit skill

### DIFF
--- a/.claude/skills/codebase-cartography-audit/PROMPT.md
+++ b/.claude/skills/codebase-cartography-audit/PROMPT.md
@@ -1,0 +1,143 @@
+# Portable Cartography-Audit Prompt (standalone)
+
+Paste into any capable coding-agent session when you can't load the skill. It
+compresses the full pipeline: map → measure → analyze → diagram → assemble.
+
+---
+
+You are performing a **full cartographic audit** of a codebase I inherited
+(possibly AI-generated). Produce a **self-contained report directory** with
+embedded, rendered architecture diagrams and measured metrics. Do not mutate the
+target repo; install tools globally or as standalone binaries; exclude
+build/vendor output (`bin`,`obj`,`node_modules`,`dist`,`.git`) from every metric.
+
+**Output-fidelity rules (do not skip — these are the usual failure modes):**
+(a) Emit **full tables**, not prose summaries — the function-point count MUST show
+the IFPUG function-type table (count × weight = FP), all 14 GSCs with a
+justification each + the VAF math, per-category backfiring tables, and a
+subtotals+total table; never collapse to "EI59 EO25 … VAF 1.21". (b) **Reconcile
+every subtotal**: Σ(components) must equal each category subtotal and the grand
+total; a subtotal bigger than the listed rows means phantom LOC — find/attribute or
+exclude it, print the check. (c) **Exclude non-authored code** (vendored, minified,
+generated, seed/config dumps) from LOC; flag any file/dir >~2k LOC. (d) Count
+**ILF/EIF as aggregate roots/logical files, not per-table**; rate GSCs
+conservatively (default 2–3) and show them. (e) **Never sum System + DevOps/Test at
+the full-lifecycle rate** (double-counts tests) — headline is System-only.
+(f) **Actually open/Read each rendered PNG** before claiming it passed.
+
+Run this ordered pipeline:
+
+1. **Scope & inventory.** Detect languages/stack, solution layout, entry points,
+   module list, file/LOC size. Create one self-contained directory
+   `codebase-audit-report/` containing `README.md`, `images/`, `diagrams/`, and
+   `metrics/` (all four inside it, so relative links resolve).
+
+2. **Architecture map.** Reconstruct layers and dependency direction from project
+   references and imports. Do all dependencies point inward to a framework-free
+   domain core (Onion/Clean)? Where are the violations and cycles?
+
+3. **Measure (real tools, recorded commands).** Acquire and run: **scc** for LOC
+   per file/language (`scc --by-file --format json`); a per-language lint tool
+   (C#: Roslynator; JS/TS: ESLint; Python: ruff; Java: pmd/checkstyle; Go:
+   staticcheck); a duplication tool (jscpd/pmd-cpd). Save raw output to
+   `metrics/`. Write the analysis helpers as **single-file C# scripts** (`.csx`,
+   run with `dotnet-script` — NOT Python, NOT PowerShell): one that rolls up
+   per-component LOC + class/object count + genuine McCabe cyclomatic complexity
+   (strip comments/strings; `CC = max(methods,1)+decisionPoints`; do not count
+   nullable-type `?`) + **average CC per class** + density, and one for function
+   points (3b). **Get test counts from the runner** (`dotnet test --list-tests` /
+   `pytest --collect-only`), never by grepping `[Test]` attributes. Every
+   objective number must come from a tool, not inference. Cite versions + commands.
+   **Run scc over the WHOLE repo** (not just `src/`) and classify every file into
+   **two categories — System** (product runtime) vs **DevOps/Test** (all test
+   suites + build/deploy scripts + migration/tooling projects). Report a
+   **subtotal per category plus a grand total** for LOC, classes, and CC, and the
+   System/DevOps-Test LOC split %.
+
+3b. **Function points (two methods, reconciled).** In a `.csx` script:
+   (A) **IFPUG** — derive EI (command handlers), EQ (queries), EO (reports/
+   exports), ILF (app-owned aggregates), EIF (external data sources) counts from
+   the code (document each basis); weight at average (EI 4 / EO 5 / EQ 4 / ILF 10
+   / EIF 7); UFP → VAF (`0.65 + 0.01·ΣGSC` over the 14 GSCs) → AFP — this is the
+   **System** FP (delivered functionality).
+   (B) **Capers Jones backfiring** — LOC ÷ Jones LOC/FP ratios (C#≈54, JS≈47,
+   markup≈40, SQL≈13–21; note scc counts physical LOC ~1.2–1.5× logical, so state
+   the adjustment) per category: System LOC (cross-checks IFPUG) and DevOps/Test
+   LOC (its primary **equivalent FP**). Reconcile the System count (% divergence,
+   ±30%), then report **System FP + DevOps/Test FP + Total**.
+
+3c. **Economic valuation (effort + cost + schedule) across MULTIPLE bands.** In a
+   `.csx` script: (1) **Effort** = FP ÷ FP-per-man-day for a band of
+   **0.32 / 0.5 / 1 / 2 / 3 FP/day** (include the 0.32 Jones-baseline row so the
+   headline is readable; → man-months at ~22 days); cite Capers Jones
+   (full-lifecycle ~7 FP/staff-month ≈ 0.32 FP/day — "Software Economics and
+   Function Point Metrics", IFPUG 2017) and Steve McConnell ("Software Estimation")
+   for the 10× productivity spread (NOT a 1 FP/day figure). Show the LOC/man-day
+   equivalent. (2) **Cost** = effort × fully-loaded day rate (median base × burden
+   1.5–1.75× ÷ 260); look up CURRENT medians (web search) from PayScale,
+   Salary.com, US BLS (+ note aggregators) and cite each; give a **cost row per
+   band split System / DevOps-Test / Total** (Module 11.0 FP subtotals) — except
+   the 0.32 full-lifecycle row, where DevOps/Test and Total are "n/a (in System)"
+   (the Total column is a coding-centric figure only; never sum System + DevOps at
+   the lifecycle rate — it double-counts test-writing). Headline = System
+   full-lifecycle figure alone. Replacement cost, not market value. (3) **Schedule check** = calendar months ≈ FP^exponent (0.32 small →
+   0.45 large) and implied team size; flag if implausible.
+
+4. **Defects & smells.** Following the highest LOC×complexity components first,
+   audit: SOLID (SRP/OCP/LSP/ISP/DIP); Onion/Clean dependency-direction & leaked
+   infrastructure; Fowler smells (long method/large class/primitive obsession/
+   data clumps/duplication/dead code/feature envy/shotgun surgery); enterprise/
+   domain (anemic model, transaction-script creep, repository/UoW, value
+   objects); AI anti-patterns (magic strings/numbers, hardcoded secrets [Critical],
+   swallowed catches, sync-over-async, dead code). Every finding: `file:line`,
+   principle, why-it-hurts, named refactoring, effort/risk (S/M/L). Rank by
+   severity × spread. Severity: **Critical** (bug/security/data-loss), **High**
+   (blocks change / spreads widely), **Medium** (localized), **Low** (cosmetic).
+
+5. **Testing.** **Discover every test suite** (all test projects/assemblies by
+   framework marker — there may be dozens — splitting mixed projects by namespace/
+   fixture), **count each with the runner** (`--list-tests`/`--collect-only`, not
+   attribute grepping), and **classify each as unit / integration /
+   acceptance(full-system) by evidence** (package refs, usings, base classes, not
+   folder name; flag names that contradict their signal). Emit a suite matrix
+   (suite, project, framework, count, layer, signal), roll up by layer, and report
+   the pyramid shape (flag ice-cream-cone/hourglass); is the risky logic covered;
+   boundary tests at each DB/queue/HTTP/third-party seam; any full-system test
+   that starts the app and drives the UI with externals stubbed; flakiness
+   sources. Thin coverage ⇒ backlog leads with characterization tests.
+
+6. **Diagrams (PlantUML → PNG, inspected).** Author under `diagrams/` five views:
+   (1) **logical** C4 component, (2) **runtime** container/dynamic, (3)
+   **dependencies** build-time graph with arrow direction + cycles, (4)
+   **testing** suites-by-layer showing the pyramid, (5) **build/devops/deploy**
+   source→CI→artifacts→environments. Plus a **logical-annotated** view whose
+   boxes carry LOC and cyclomatic complexity from step 3. Use the **C4-PlantUML**
+   template library by default (`!include <C4/…>` — renders offline via Graphviz);
+   fall back to plain PlantUML only if the bundled stdlib is missing. **ASCII
+   labels only** (no em-dashes/arrows — they mojibake). Show the **System vs
+   DevOps/Test** split as separate `System_Boundary`s with subtotal labels in the
+   logical, dependency, testing, and deploy views. Render into the report's images
+   dir. **Then open/read each rendered PNG and verify legibility** — no clipping,
+   no overlap, correct arrow direction, annotations readable, sane aspect ratio.
+   Fix the source and re-render any that fail. Confirm each image was inspected.
+
+7. **Assemble `codebase-audit-report/README.md`** (self-contained dir holding
+   `README.md`, `images/`, `diagrams/`, `metrics/`): how-to-reproduce
+   (tools+versions+commands); executive summary (3–5 systemic problems + single
+   highest-leverage fix); the embedded diagram PNGs (`![](images/xx.png)`) each
+   with a reading; inventory & metrics tables — **each of LOC, function points, and
+   cost shown as System / DevOps-Test / Total** — plus per-component rollup
+   (with class count & avg CC/class), top-10 complex files, lint summary,
+   duplication clones; prioritized findings grouped and sorted by severity ×
+   spread; testing assessment (the suite matrix); and a sequenced refactoring
+   backlog flagging where characterization tests must come first.
+
+**Self-check before delivering** (any missing item = not done): the 5-row IFPUG
+table; the 14-row GSC table + VAF math; per-category backfiring tables; the printed
+`Σ(components)==subtotal` reconciliation + an Excluded (non-authored) bucket; the
+per-band cost table with 0.32-row cells marked "n/a (in System)"; System/DevOps-
+Test/Total for LOC, FP, and cost; and a legibility verdict for each of the 6 PNGs
+you actually opened.
+
+Deliver the path to the finished report directory and a short summary of the
+worst findings.

--- a/.claude/skills/codebase-cartography-audit/SKILL.md
+++ b/.claude/skills/codebase-cartography-audit/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: codebase-cartography-audit
+description: >-
+  Full cartographic audit of an inherited or AI-generated codebase. Produces a
+  self-contained report directory with: a complete inventory split into System vs
+  DevOps/Test code (with LOC/function-point/cost subtotals + total); five
+  C4-PlantUML views (logical, runtime, dependencies, testing, build/devops/deploy)
+  plus a metrics-annotated logical view, rendered to PNG and visually inspected
+  for legibility; a maintainability-defect
+  and code-smell analysis grounded in SOLID, Onion & Clean Architecture, Fowler
+  smells, enterprise/persistence patterns and the testing pyramid; tool-measured
+  metrics (lines of code, cyclomatic complexity, linting/duplication, and a
+  Function Point count via IFPUG cross-checked with Capers Jones backfiring, plus
+  an economic valuation that turns function points into effort in staff-months and
+  a build-cost / replacement-investment dollar range using Capers Jones
+  productivity rates and current median engineer salaries)
+  gathered by downloading and running the right CLI tools for the detected stack,
+  with all analysis helpers written as single-file C# scripts (no Python/PowerShell);
+  a logical diagram annotated with LOC and cyclomatic complexity in each box; and a README
+  with the rendered diagram PNGs embedded. Use when onboarding to unfamiliar
+  code, reviewing an AI-coded app, or planning a refactor and you want both a
+  defensible principle-linked defect backlog AND measured, diagrammed evidence.
+---
+
+# Codebase Cartography Audit
+
+A superset of `inherited-code-audit`. It keeps that skill's evidence-backed,
+principle-linked defect catalogue and adds three things: **measured metrics**
+(LOC, cyclomatic complexity, lint, duplication — from real tools), **five C4
+architecture diagrams** rendered to inspected PNGs, and a **single self-contained
+report directory** with the diagrams embedded in a README.
+
+Deliverable: a new directory (default `./codebase-audit-report/`) containing
+`README.md` (the report, with embedded diagram PNGs), `images/` (rendered PNGs),
+`diagrams/` (PlantUML sources), and `metrics/` (raw tool output). Every claim
+cites `file:line` or a reproducible command.
+
+## When to use this
+
+- You inherited a codebase (especially AI-generated) and want the full picture:
+  map + measured health + prioritized defect backlog in one artifact.
+- You are planning a refactor and need diagrams, hotspot metrics, and a
+  principle-linked backlog to justify sequencing.
+- You want a shareable onboarding document for a system you're taking over.
+
+## The inspection catalogue
+
+Modules 1–8 are the maintainability/architecture lenses (identical in spirit to
+`inherited-code-audit`). Modules 9–10 add the measured and diagrammed scope.
+
+| # | Module | File | Focus |
+|---|--------|------|-------|
+| 1 | SOLID (SRP, OCP, LSP, ISP, DIP) | `references/01-solid.md` | Martin |
+| 2 | Onion Architecture | `references/02-onion-architecture.md` | Palermo |
+| 3 | Clean Architecture & component rules | `references/03-clean-architecture.md` | Martin |
+| 4 | Fowler code smells | `references/04-code-smells.md` | Fowler / Beck |
+| 5 | Enterprise & domain patterns | `references/05-enterprise-patterns.md` | Fowler, Evans |
+| 6 | Persistence, IoC & low-ceremony | `references/06-jeremy-miller.md` | Miller |
+| 7 | AI-code anti-patterns | `references/07-ai-antipatterns.md` | (composite) |
+| 8 | Testing & the automation pyramid | `references/08-testing.md` | Palermo, Martin, Cohn |
+| 9 | Inventory, metrics & linting (tools) | `references/09-inventory-and-metrics.md` | measured |
+| 10 | C4 diagrams (PlantUML) + rendering | `references/10-c4-plantuml-diagrams.md` | diagrammed |
+| 11 | Function points (IFPUG + Jones backfiring) | `references/11-function-points.md` | sized |
+| 12 | Economic valuation (effort, cost, replacement value) | `references/12-economic-valuation.md` | priced |
+
+## How to run the audit (ordered pipeline)
+
+Do these in order; later stages consume earlier outputs. Fan the read-only
+investigation stages out to parallel subagents where the codebase is large.
+
+1. **Scope & inventory.** Detect languages/stack, solution layout, entry points,
+   project/module list, and size (file & LOC counts). Note build output and
+   vendored dirs to exclude from everything. Create the **self-contained** report
+   directory skeleton — `codebase-audit-report/` holding `README.md`, `images/`,
+   `diagrams/`, and `metrics/` (all four inside the one directory, so the report
+   is portable and its relative links resolve).
+
+2. **Map the architecture (Modules 2 & 3).** Reconstruct layers and the
+   dependency direction from project references and imports. This frames the
+   diagrams and the defect hunt. Identify the domain core, application layer,
+   infrastructure, UI, and any dependency-direction violations.
+
+3. **Measure (Modules 9 & 11).** Acquire and run the right tools for the detected
+   stack (scc for LOC always; plus a per-language lint/duplication tool). Save raw
+   output to `metrics/`. Write the metric rollup and the function-point analysis
+   as **single-file C# scripts** (`.csx`, run with `dotnet-script` — no Python,
+   no PowerShell for analysis logic). Produce the per-component LOC + McCabe
+   cyclomatic-complexity + density rollup, and the two-method Function Point
+   estimate (IFPUG count reconciled against Capers Jones backfiring, Module 11),
+   and the economic valuation that turns FP into effort and a build-cost /
+   replacement-investment dollar range across **multiple productivity bands**
+   (0.32–3.0 FP/man-day per Capers Jones & Steve McConnell), using median engineer
+   salaries × burden (look salaries up live and cite), plus a schedule sanity
+   check (Module 12). Also count classes and **average CC per class**, and get
+   **test counts from the test runner** (`--list-tests`), not by hand.
+   Classify all code into **two categories — System vs DevOps/Test** (tests +
+   build/deploy scripts + tooling; run scc over the whole repo) and report a
+   **subtotal for each plus a total** for LOC, function points, and cost
+   (Modules 9.3b, 11.0, 12). For **cost**, the per-band Total column is
+   coding-centric bands only — at the 0.32 full-lifecycle row the DevOps/Test and
+   Total cells are "n/a (in System)" (never sum them; Module 12.2). Productivity
+   bands span **0.32–3.0 FP/man-day** (incl. the Jones 0.32 baseline).
+
+4. **Analyze defects & smells (Modules 1, 4, 5, 6, 7).** Follow the risk — the
+   high-LOC/high-complexity components from step 3 first. Sweep the cheap
+   high-signal AI defects (magic strings, duplication, hardcoded config, god
+   classes), then the principle checks. Every finding: `file:line`, principle,
+   why-it-hurts, named fix, effort/risk. **Report each defect once** under its
+   most-specific principle and cross-reference the others (god class, switch-on-
+   type, dead code, DIP/IoC, anemic domain recur across Modules 1/4/5/6/7 — do not
+   emit the same file:line three times under different names).
+
+5. **Assess the safety net (Module 8).** **Discover every test suite** (there may
+   be dozens), count each with the runner, and **classify each as unit /
+   integration / acceptance(full-system) by evidence, not folder name** — emit a
+   suite matrix and roll it up to the pyramid shape. Determine whether the risky
+   logic is covered. Thin coverage ⇒ the backlog leads with characterization tests.
+
+6. **Diagram (Module 10).** Author the five views plus the metrics-annotated
+   logical view using the **C4-PlantUML template library** (`<C4/…>`, renders
+   offline via Graphviz), each showing the **System vs DevOps/Test** split via
+   separate `System_Boundary`s with subtotal labels. ASCII labels only (no
+   em-dashes/arrows — they mojibake). Render to PNG. **Read each rendered PNG and
+   verify legibility**; fix source and re-render any that fail. Record that each
+   was visually inspected.
+
+7. **Assemble the report.** Write `codebase-audit-report/README.md` embedding the
+   verified PNGs (`![](images/xx.png)`), followed by the executive summary,
+   architecture map, metrics tables, prioritized findings, and the sequenced
+   refactoring backlog. **Before delivering, run this self-check** — any missing
+   item means the audit is not done: (i) the 5-row IFPUG function-type table;
+   (ii) the 14-row GSC table + VAF math; (iii) per-category backfiring tables;
+   (iv) the printed `Σ(components)==subtotal` reconciliation lines and an Excluded
+   (non-authored) bucket; (v) the per-band cost table with the 0.32-row cells
+   marked "n/a (in System)"; (vi) System/DevOps-Test/Total for LOC, FP, and cost;
+   (vii) a legibility verdict for each of the 6 PNGs you actually opened.
+
+## Finding format (required for every defect)
+
+```
+### [SEVERITY] <short title>
+- **Principle:** <e.g. DIP — Dependency Inversion (Module 1)>
+- **Location:** path/to/File.cs:120-148  (+ other sites if duplicated)
+- **Evidence:** <the concrete smell — quote the code or describe precisely>
+- **Why it hurts:** <maintainability/bug-surface/duplication cost>
+- **Fix:** <the specific refactoring move, named where possible>
+- **Effort / Risk:** <S/M/L, and whether tests exist to make it safe>
+```
+
+Severity: **Critical** (bug/security/data-loss), **High** (blocks change /
+spreads widely), **Medium** (localized), **Low** (cosmetic).
+
+## Report structure (`codebase-audit-report/README.md`)
+
+1. **Title + how-to-reproduce** — tools used (name+version) and the commands, so
+   every metric and diagram can be regenerated.
+2. **Executive summary** — overall health, 3–5 systemic problems, single
+   highest-leverage fix.
+3. **Architecture diagrams** — the five embedded PNGs + the annotated logical
+   PNG, each with a one-paragraph reading.
+4. **Inventory & metrics** — language breakdown, per-component LOC/complexity/
+   density rollup (with class count & avg CC/class), top-10 most-complex files,
+   lint summary, duplication clones, the Function Point sizing, and the economic
+   valuation. **Present LOC, function points, and cost each as System /
+   DevOps-Test / Total** (Modules 9.3b, 11.0, 12) — for cost, the Total is
+   coding-centric only and the 0.32 full-lifecycle row's DevOps/Test + Total cells
+   are "n/a (in System)".
+5. **Prioritized findings** — grouped by module, sorted by severity × spread.
+6. **Testing assessment** — pyramid shape, coverage gaps, refactor-safety verdict.
+7. **Refactoring backlog** — sequenced, "characterize with tests first" flagged
+   wherever coverage is thin.
+
+## Output fidelity rules (avoid these common LLM failure modes)
+
+These are the mistakes that most often make an otherwise-good audit wrong. Treat
+each as mandatory:
+
+1. **Emit FULL tables, never prose summaries, for quantitative sections.** The
+   function-point count in particular MUST be full tables — the IFPUG
+   function-type table (count × weight = FP), the 14-row GSC table with a
+   justification per rating and the VAF computation, per-category backfiring
+   tables, and the subtotals+total table. Collapsing to "EI59 EO25 … VAF 1.21" is
+   a defect. Same for the LOC rollup, cost bands, and suite matrix.
+2. **Reconcile every subtotal with its parts.** Σ(component line items) must equal
+   each category subtotal and the grand total. A subtotal larger than the visible
+   rows (phantom LOC from a whole-repo walk) is a bug — find and attribute or
+   exclude it. Print the reconciliation check. Unattributed LOC silently inflates
+   FP and cost.
+3. **Exclude non-authored code** (vendored, minified, generated, seed/config
+   dumps) from the LOC tally, or bucket it separately — never fold it into System
+   or DevOps/Test. Flag any single file/dir >~2k LOC and confirm it's real source.
+4. **Count data functions (ILF/EIF) as logical files / aggregate roots, not
+   per-table**; rate GSCs conservatively and show them. These are the two biggest
+   IFPUG divergence sources between analysts (see Module 11.0-pre).
+5. **Do not present a full-lifecycle Total that sums System + DevOps/Test** — that
+   double-counts test-writing. Headline = System full-lifecycle alone.
+6. **Actually inspect each rendered PNG** (Read the image) before claiming it
+   passed — don't assert a legibility verdict you didn't check.
+7. **Every objective number traces to a tool command**; qualitative findings each
+   cite `file:line`. When a hand-count (IFPUG) and a mechanical count (backfiring)
+   disagree, the mechanical one is the sanity bound.
+
+## Guiding stance
+
+- **Evidence over opinion.** Every defect cites code; every number cites a
+  command. No principle name without a concrete instance.
+- **Objective counts come from tools, never inference.** LOC, classes, complexity,
+  test counts, lint, function points, and cost are each produced by a command or a
+  committed `.csx` and captured in `metrics/`. Never eyeball-and-assert a count;
+  in particular, count tests with the runner (`--list-tests`), not by grepping
+  `[Test]` attributes. Only qualitative findings are analyst-authored.
+- **Measure, then follow the risk.** The highest LOC × complexity component,
+  touched by every feature, outranks a tidy leaf class.
+- **Diagrams must be readable.** A rendered PNG that is clipped, overlapping, or
+  mislabelled is a defect to fix, not ship. Inspect every image.
+- **Refactor behind tests.** Where the net is thin, the first backlog item is
+  characterization tests.
+- **Prefer removing over adding.** The best outcome is less code: dedup, delete
+  dead paths, collapse needless abstraction.
+- **Never mutate the target repo** to gather metrics; install tools globally / as
+  standalone binaries and exclude build/vendor output.
+- **Analysis helpers are single-file C# (`.csx` via `dotnet-script`).** Not
+  Python, not PowerShell — C# handles the multi-variable rollup and function-point
+  math cleanly and keeps the toolchain on .NET. PowerShell may be used only for
+  build/orchestration glue, never for the metric/FP computation.
+
+See `PROMPT.md` for a portable single-paste version of this whole pipeline.

--- a/.claude/skills/codebase-cartography-audit/references/01-solid.md
+++ b/.claude/skills/codebase-cartography-audit/references/01-solid.md
@@ -1,0 +1,155 @@
+# Module 1 — SOLID Principles
+
+Five class-design principles collected and popularized by **Robert C. Martin
+("Uncle Bob")**. They are the load-bearing rules for object-oriented
+maintainability. AI-generated code frequently satisfies none of them because it
+optimizes for "works on the happy path," not for change.
+
+---
+
+## 1.1 SRP — Single Responsibility Principle
+
+> "A module should have one, and only one, reason to change." — R.C. Martin.
+> Reframed: a module should be responsible to one **actor** (one source of
+> change requests).
+
+**Symptoms**
+- A class that mixes policy (business rules) with detail (I/O, formatting, SQL).
+- Methods that would change for unrelated reasons (a `User` class that validates,
+  persists, and renders HTML).
+- "Manager", "Helper", "Utils", "Service" classes that accrete unrelated methods.
+- A class that imports both `System.Data.SqlClient` and a UI/serialization
+  namespace.
+
+**Detection heuristics**
+- Count the distinct reasons-to-change: persistence, validation, formatting,
+  orchestration, external calls. >1 in one class = candidate.
+- High method count + low cohesion (methods use disjoint field subsets — LCOM, Lack of Cohesion of Methods).
+- Class name is a vague noun ("Handler", "Processor").
+
+**Inspection prompt**
+> Examine each class in {scope}. For each, list the distinct *reasons it would
+> change* (business rule, persistence, presentation, external integration,
+> orchestration). Flag any class with more than one. Quote the methods/fields
+> that belong to each responsibility and propose how to split them (Extract
+> Class / Extract Service).
+
+**Remediation:** Extract Class, Extract Method, move I/O to the edges, separate
+policy from mechanism.
+
+---
+
+## 1.2 OCP — Open/Closed Principle
+
+> "Software entities should be open for extension, but closed for modification."
+> — Bertrand Meyer, popularized by Martin.
+
+Adding a behavior should mean adding code, not editing existing tested code.
+
+**Symptoms**
+- Growing `switch`/`if-else` chains on a type code or enum that must be edited
+  for every new variant.
+- `if (type == "pdf") … else if (type == "csv") …` sprinkled in multiple places.
+- Feature flags bolted into core logic instead of injected strategies.
+
+**Detection heuristics**
+- Find enums/`type` strings switched on in more than one location — each is an
+  OCP hotspot and a duplication risk.
+- Search for repeated `switch`/`case` over the same discriminator.
+
+**Inspection prompt**
+> Find every `switch`/`if-else` chain that branches on a type discriminator
+> (enum, string kind, class name). For each, identify whether adding a new case
+> requires editing existing code in multiple places. Recommend a polymorphic
+> replacement (Strategy, Replace Conditional with Polymorphism, or a registry/
+> factory).
+
+**Remediation:** Strategy pattern, polymorphism, Replace Conditional with
+Polymorphism, plugin/registry.
+
+---
+
+## 1.3 LSP — Liskov Substitution Principle
+
+> Subtypes must be substitutable for their base types without breaking callers.
+> — Barbara Liskov.
+
+**Symptoms**
+- Overrides that throw `NotImplementedException`/`NotSupportedException`.
+- Subclasses that tighten preconditions or weaken postconditions.
+- Callers that type-check (`if (x is SpecialType)`) to work around a subtype.
+- The classic `Square : Rectangle` / `ReadOnlyList : List` breakage.
+
+**Detection heuristics**
+- Grep for `NotImplementedException`, `NotSupportedException` in overrides.
+- Find `is`/`as`/`GetType()` checks in code that consumes a base type.
+
+**Inspection prompt**
+> Inspect inheritance hierarchies in {scope}. Flag any override that throws
+> "not supported", narrows accepted inputs, or changes expected behavior such
+> that a caller written against the base type could break. Flag caller-side type
+> checks that betray a broken substitution. Recommend composition or interface
+> segregation instead.
+
+**Remediation:** favor composition over inheritance; segregate interfaces so no
+implementer is forced to fake a member.
+
+---
+
+## 1.4 ISP — Interface Segregation Principle
+
+> No client should be forced to depend on methods it does not use. Prefer many
+> small, role-specific interfaces over one fat interface.
+
+**Symptoms**
+- "God interfaces" with 10+ members; implementers stub half of them.
+- Consumers that use only one method of a large injected interface.
+- `IRepository` with 20 methods where each caller needs one or two.
+
+**Detection heuristics**
+- Interfaces with many members; check how many each implementer/consumer
+  actually uses.
+
+**Inspection prompt**
+> List interfaces with more than ~4 members. For each, determine which members
+> each implementer actually implements meaningfully and which each consumer
+> actually calls. Flag fat interfaces and propose role-based splits.
+
+**Remediation:** split into role interfaces; consumers depend only on what they
+call.
+
+---
+
+## 1.5 DIP — Dependency Inversion Principle
+
+> High-level modules should not depend on low-level modules; both depend on
+> abstractions. Abstractions should not depend on details; details depend on
+> abstractions.
+
+This is the principle that *enables* Onion/Clean Architecture (Module 2/3).
+
+**Symptoms**
+- Business logic that `new`s up a `SqlConnection`, `HttpClient`, `File`, or
+  `DateTime.Now` directly.
+- Domain classes referencing infrastructure namespaces.
+- No interfaces at module boundaries; concrete dependencies everywhere.
+- Static/global singletons reached into from core logic.
+
+**Detection heuristics**
+- In core/domain code, grep for `new` of infrastructure types, `DateTime.Now`,
+  `Console`, `File.`, direct DB/HTTP client construction, static service
+  locators.
+- Check whether the composition happens at a single root (Main/Startup) or is
+  scattered.
+
+**Inspection prompt**
+> In the core/business layer of {scope}, find every direct dependency on a
+> concrete low-level detail: database clients, HTTP clients, file system, system
+> clock (`DateTime.Now`), environment/config access, static singletons. For each,
+> confirm whether an abstraction (interface) sits between the policy and the
+> detail, and whether the concrete is supplied via constructor injection from a
+> composition root. Flag every inward dependency on a detail and propose the
+> interface + injection.
+
+**Remediation:** define interfaces owned by the core; inject concretes from a
+composition root; wrap the clock, config, and I/O.

--- a/.claude/skills/codebase-cartography-audit/references/02-onion-architecture.md
+++ b/.claude/skills/codebase-cartography-audit/references/02-onion-architecture.md
@@ -1,0 +1,79 @@
+# Module 2 — Onion Architecture
+
+Coined by **Jeffrey Palermo** (2008, "The Onion Architecture" series). A layered
+model where **all dependencies point inward toward a domain core** that knows
+nothing of infrastructure. Concentric rings:
+
+```
+        ┌─────────────────────────────────────────┐
+        │  Infrastructure / UI / Tests (outer)      │
+        │   ┌───────────────────────────────────┐   │
+        │   │  Application Services              │   │
+        │   │   ┌───────────────────────────┐    │   │
+        │   │   │  Domain Services           │    │   │
+        │   │   │   ┌───────────────────┐    │    │   │
+        │   │   │   │  Domain Model     │    │    │   │
+        │   │   │   │  (entities, core) │    │    │   │
+        │   │   │   └───────────────────┘    │    │   │
+        │   │   └───────────────────────────┘    │   │
+        │   └───────────────────────────────────┘   │
+        └───────────────────────────────────────────┘
+     Dependencies point INWARD only. Interfaces live in the core;
+     implementations live on the outer edge.
+```
+
+**Core tenets (Palermo)**
+1. The application is built around an **independent object model** (the domain).
+2. **Inner layers define interfaces; outer layers implement them.** The domain
+   declares `IRepository`, `IEmailSender`, `IClock`; Infrastructure implements.
+3. **All coupling is toward the center.** Nothing in the core references
+   Infrastructure, the database, the UI, or a framework.
+4. The **database is an infrastructure detail** at the outermost ring, plugged
+   in — not the center of the application (a rejection of data-centric,
+   database-first design).
+5. Externals (UI, persistence, messaging, third parties) are all peers on the
+   outer edge and are swappable.
+
+**Symptoms of violation**
+- The domain project references EF/ORM, `System.Data`, a web framework, or a
+  specific database package.
+- Entities carry ORM attributes, `[Table]`/`[Column]`, or serialization
+  attributes as their primary shape.
+- Business rules living in controllers, page code-behind, or stored procedures.
+- No separate domain project at all — everything in one assembly, or a
+  "layering" that is really just folders with no enforced dependency direction.
+- Repository/service *interfaces* defined in the Infrastructure project rather
+  than in the core.
+- Data model (rows/DTOs) used as the domain model (see Anemic Domain, Module 5).
+
+**Detection heuristics**
+- Inspect project/assembly references (`.csproj`, module import graph). Draw the
+  dependency arrows. Any arrow from an inner layer to an outer one is a
+  violation.
+- Grep the domain project for infrastructure/framework namespaces.
+- Locate where interfaces are declared vs implemented — interfaces belong inside.
+
+**Inspection prompt**
+> Reconstruct the layer/dependency graph for {scope} from project references and
+> import statements. Identify the domain core (entities + domain interfaces),
+> application services, and infrastructure. Verify that **every dependency
+> points inward**: no inner layer may reference an outer one, and no domain code
+> may reference a database, ORM, web framework, or external SDK. Report each
+> inward-pointing interface that is instead declared in an outer layer, each
+> framework/persistence reference that has leaked into the core, and each
+> business rule that lives in a controller/UI/stored procedure. Produce an ASCII
+> dependency diagram and a numbered list of arrow violations.
+
+**Remediation**
+- Extract a dependency-free domain project; move entities and domain interfaces
+  into it.
+- Move persistence/HTTP/file implementations to an Infrastructure project that
+  references the core (not vice versa).
+- Introduce a composition root (Startup/Program) that wires implementations to
+  the core's interfaces (ties to DIP, Module 1.5, and IoC, Module 6).
+- Push business logic out of controllers into application/domain services.
+
+**Relationship to Clean Architecture (Module 3):** same dependency rule, same
+"database/UI are details" stance, expressed with different ring names. Uncle
+Bob's Clean Architecture (2012+) generalizes Onion, Hexagonal (Ports &
+Adapters, Cockburn), and DCI.

--- a/.claude/skills/codebase-cartography-audit/references/03-clean-architecture.md
+++ b/.claude/skills/codebase-cartography-audit/references/03-clean-architecture.md
@@ -1,0 +1,62 @@
+# Module 3 — Clean Architecture & Component Rules
+
+**Robert C. Martin**, *Clean Architecture* (2017). Adds two things beyond Onion:
+the **Dependency Rule** stated crisply, and a set of **component-level**
+principles for organizing code into deployable/releasable units.
+
+## 3.1 The Dependency Rule
+
+> Source-code dependencies must point only **inward**, toward higher-level
+> policy. Nothing in an inner circle can name anything in an outer circle.
+
+Rings (outer→inner): Frameworks & Drivers → Interface Adapters
+(controllers, presenters, gateways) → Use Cases (application-specific business
+rules) → Entities (enterprise-wide business rules). Data crossing a boundary
+inward is a simple structure the inner layer owns — never an entity/row/framework
+object passed outward-in.
+
+## 3.2 Screaming Architecture
+
+> The top-level structure should "scream" the **domain** (Billing, Ordering,
+> Underwriting), not the framework (Controllers, Models, Views).
+
+**Symptom:** the folder tree tells you it's an MVC/React app but not what the
+business does. AI scaffolds are almost always framework-screaming.
+
+## 3.3 Component Cohesion (which classes belong together)
+
+- **REP — Reuse/Release Equivalence:** the unit of reuse is the unit of release;
+  a component should be independently versionable.
+- **CCP — Common Closure:** classes that change together (for the same reason)
+  belong in the same component. (Component-level SRP.)
+- **CRP — Common Reuse:** classes used together belong together; don't force
+  consumers to depend on things they don't use. (Component-level ISP.)
+
+## 3.4 Component Coupling (relationships between components)
+
+- **ADP — Acyclic Dependencies Principle:** no cycles in the component
+  dependency graph. Cycles make independent build/test/release impossible.
+- **SDP — Stable Dependencies Principle:** depend in the direction of stability;
+  volatile components should depend on stable ones, not the reverse.
+- **SAP — Stable Abstractions Principle:** a stable component should be abstract
+  (interfaces) so it can be extended without modification. Stable + concrete =
+  the "zone of pain."
+
+**Detection heuristics**
+- Build the component/assembly dependency graph; run a cycle check (ADP).
+- Look for a stable core that is concrete rather than abstract (SAP violation).
+- Check whether things that change together are scattered across components
+  (CCP violation) — a single feature change touching many projects is the tell.
+
+**Inspection prompt**
+> For {scope}: (1) State whether the top-level structure screams the domain or
+> the framework. (2) Build the component dependency graph and detect any cycles
+> (ADP). (3) Identify the most stable (most-depended-upon) components and check
+> whether they are abstract (SAP) or concrete "zone of pain". (4) Find features
+> whose changes force edits across many components (CCP violation) and DTOs/
+> entities crossing boundaries in the wrong direction (Dependency Rule). Report
+> violations with the dependency arrows and a proposed re-grouping.
+
+**Remediation:** re-group by feature/domain; break cycles with Dependency
+Inversion (introduce an interface owned by the stable side); extract abstract
+interface packages for stable cores; align folders to business capabilities.

--- a/.claude/skills/codebase-cartography-audit/references/04-code-smells.md
+++ b/.claude/skills/codebase-cartography-audit/references/04-code-smells.md
@@ -1,0 +1,77 @@
+# Module 4 — Code Smells (Fowler / Beck)
+
+From **Martin Fowler**, *Refactoring: Improving the Design of Existing Code*
+(smells catalogue co-created with **Kent Beck**). A "smell" is a surface
+indication that usually corresponds to a deeper problem. Each pairs with named
+refactorings. AI-generated code is dense with the duplication and bloat smells.
+
+The smells are Fowler/Beck's; the five-group taxonomy below follows **Mäntylä's**
+widely used classification (popularized by refactoring.guru), not the book's flat
+list. The *Refactoring* 2nd ed. (2018) also adds **Global Data** and **Mutable
+Data** (both high-signal in AI-generated code) and renames Switch Statements →
+**Repeated Switches** and Inappropriate Intimacy → **Insider Trading**.
+
+## The catalogue (grouped)
+
+### Bloaters
+- **Long Method** — do one thing; if you must comment sections, extract them.
+  *Fix:* Extract Method, Replace Temp with Query, Decompose Conditional.
+- **Large Class / God Class** — too many fields/methods/responsibilities.
+  *Fix:* Extract Class, Extract Subclass, Extract Interface.
+- **Primitive Obsession** — strings/ints for money, dates, ids, ranges.
+  *Fix:* Replace Primitive with Object, introduce Value Objects.
+- **Long Parameter List** — *Fix:* Introduce Parameter Object, Preserve Whole
+  Object.
+- **Data Clumps** — the same 3-4 fields travel together everywhere.
+  *Fix:* Extract Class / Parameter Object.
+
+### Object-orientation abusers
+- **Switch Statements** on type codes — see OCP (Module 1.2). *Fix:* Replace
+  Conditional with Polymorphism.
+- **Refused Bequest** — subclass ignores inherited members — see LSP (1.3).
+- **Temporary Field** — field only set in certain cases.
+- **Alternative Classes with Different Interfaces** — same job, different names.
+
+### Change preventers
+- **Divergent Change** — one class changed for many different reasons (SRP).
+- **Shotgun Surgery** — one change forces edits across many classes (CCP).
+- **Parallel Inheritance Hierarchies.**
+
+### Dispensables
+- **Duplicated Code** — the #1 target. *Fix:* Extract Method/Function, Pull Up
+  Method, Form Template Method, extract shared module.
+- **Dead Code** — unreachable/unused. *Fix:* delete it.
+- **Speculative Generality** — abstraction "for the future" nobody uses.
+  *Fix:* Collapse Hierarchy, Inline Class, Remove Parameter.
+- **Comments compensating for bad code** — *Fix:* make the code self-explaining.
+- **Lazy Class** — not pulling its weight. *Fix:* Inline Class.
+
+### Couplers
+- **Feature Envy** — a method more interested in another class's data than its
+  own. *Fix:* Move Method/Field.
+- **Inappropriate Intimacy** — classes reaching into each other's internals.
+- **Message Chains** — `a.getB().getC().getD()`. *Fix:* Hide Delegate.
+- **Middle Man** — a class that only delegates. *Fix:* Remove Middle Man.
+
+**Detection heuristics**
+- Method/class length and cyclomatic complexity thresholds.
+- Token-level duplication scan (copy-paste blocks).
+- Repeated field groups (data clumps).
+- Message chains: 3+ chained member accesses across distinct objects, e.g. regex
+  `\.\w+\(\)\.\w+\(\)\.\w+` or `a.getB().getC().getD()`.
+- Global/mutable shared state: `public static` mutable fields, singletons holding
+  data, `static` collections written at runtime.
+
+**Inspection prompt**
+> Scan {scope} for Fowler code smells. Report the worst instances in each
+> category: Bloaters (long methods >~30 lines, classes with many
+> responsibilities, primitive obsession for money/date/id, long parameter
+> lists, data clumps); Dispensables (duplicated blocks — quote both sites, dead
+> code, speculative abstractions, lazy classes); Couplers (feature envy, message
+> chains, inappropriate intimacy); Change preventers (divergent change / shotgun
+> surgery). For each, cite file:line, name the smell, and name the specific
+> refactoring that resolves it. Rank by how widely the smell is duplicated.
+
+**Remediation stance:** refactor in small behavior-preserving steps *behind
+tests*. Duplication and dead code are the highest-value, lowest-risk wins —
+attack them first.

--- a/.claude/skills/codebase-cartography-audit/references/05-enterprise-patterns.md
+++ b/.claude/skills/codebase-cartography-audit/references/05-enterprise-patterns.md
@@ -1,0 +1,86 @@
+# Module 5 — Enterprise & Domain Patterns
+
+From **Martin Fowler**, *Patterns of Enterprise Application Architecture* (PoEAA)
+and **Eric Evans**, *Domain-Driven Design*. These describe how domain logic and
+persistence should be organized — the layer where inherited/AI code most often
+degenerates into procedural spaghetti or an anemic shell around a database.
+
+## 5.1 Domain Model vs Transaction Script
+
+- **Transaction Script** — organizes logic as a procedure per request. Fine for
+  simple apps; collapses under growing business complexity (duplication,
+  no reuse of rules).
+- **Domain Model** — an object model where behavior and data live together.
+  Preferred as complexity grows.
+- **Smell:** a "Service" layer holding all logic while entities are bags of
+  getters/setters = Transaction Script masquerading as OO.
+
+## 5.2 Anemic Domain Model (Fowler — an anti-pattern)
+
+> Objects that carry data but no behavior, with all logic in separate service
+> classes. It has the *cost* of a domain model (mapping, object graph) with none
+> of the *benefit* (encapsulated behavior). Fowler explicitly calls it an
+> anti-pattern.
+
+**Symptoms:** entities are all public get/set with zero invariants; validation
+and rules live in `XxxService`/`XxxManager`; no method on the entity enforces
+its own consistency. **This is the single most common shape of AI-generated
+"domain" code.**
+
+**Fix:** move behavior onto the entities; make invalid states unrepresentable;
+use value objects; keep services thin (orchestration only).
+
+## 5.3 Repository & Unit of Work
+
+- **Repository** — a collection-like abstraction over persistence; the domain
+  talks to `IRepository`, not to SQL/ORM. Interface belongs in the core
+  (ties to Onion, Module 2).
+- **Unit of Work** — tracks changes and commits them atomically.
+- **Smells:** repositories that leak `IQueryable`/ORM types to callers; a
+  "repository" that is just a thin passthrough with a method per query (a
+  generic `IRepository<T>` that adds nothing); business logic inside repository
+  methods; direct DB access bypassing the repository in some places.
+
+## 5.4 Service Layer / Application Services
+
+- Thin boundary defining the app's operations; orchestrates domain objects and
+  transactions. **Smell:** "fat services" that contain the business rules that
+  belong on the domain (see 5.2).
+
+## 5.5 Value Objects & Domain Primitives
+
+- Wrap primitives that have rules (Money, EmailAddress, DateRange, Quantity).
+  Counters Primitive Obsession (Module 4). Immutable, equality by value,
+  self-validating.
+
+**Detection heuristics**
+- Ratio of behavior to data on "entities" (methods vs. plain properties).
+- Location of validation/business rules (entity vs. service).
+- Repository interfaces returning ORM/`IQueryable` types.
+- Money/dates/ids passed as raw `decimal`/`string`/`DateTime`.
+
+**Inspection prompt**
+> Assess the domain layer of {scope}. (1) Classify it as Domain Model or
+> Transaction Script, and specifically flag Anemic Domain Model: quote entities
+> that are pure get/set and show where their business rules actually live.
+> (2) Check the persistence abstraction: are Repository/Unit-of-Work present, do
+> their interfaces live in the core, and do they leak ORM/`IQueryable` types?
+> (3) Find Primitive Obsession — money, dates, ids, emails handled as raw
+> primitives — and propose Value Objects. For each finding cite file:line and
+> give the pattern-named remediation.
+
+## Aggregates & consistency boundaries (Evans)
+
+- **Aggregate / aggregate root (Evans, DDD):** a cluster of entities/value objects
+  treated as one consistency unit, mutated only through its root, which enforces
+  the invariants. **Symptom of absence:** entities mutated from anywhere (handlers,
+  UI, mappers) with no root guarding invariants — the structural cause of the
+  Anemic Domain smell above. Related: Ubiquitous Language (code names match the
+  domain) and Bounded Contexts (a model is valid within one context, not global).
+- **Detection:** child entities created/edited without going through a root;
+  invariants (totals, state transitions, membership rules) enforced in services
+  instead of the aggregate; one giant shared model spanning unrelated concerns.
+
+**Remediation:** relocate rules onto entities and aggregate roots; introduce value
+objects; define repository interfaces in the domain (one per aggregate root) and
+keep them collection-like; keep services orchestration-only.

--- a/.claude/skills/codebase-cartography-audit/references/06-jeremy-miller.md
+++ b/.claude/skills/codebase-cartography-audit/references/06-jeremy-miller.md
@@ -1,0 +1,80 @@
+# Module 6 — Persistence Ignorance, IoC & Low-Ceremony Design (Jeremy D. Miller)
+
+**Jeremy D. Miller** — creator of StructureMap (the first mature .NET IoC
+container), Lamar, Marten, and Wolverine; long-running "Patterns in Practice"
+(MSDN) and "The Shade Tree Developer" writings. His throughline: **push
+infrastructure to the edges, keep the core persistence-ignorant, compose the
+system explicitly, and relentlessly cut ceremony.**
+
+## 6.1 Inversion of Control / Dependency Injection done right
+
+- Dependencies are **injected** (constructor) and wired at a single
+  **composition root** — not resolved via a static Service Locator scattered
+  through the code (Service Locator is a widely-recognized anti-pattern when used
+  as a global reach-through — see Mark Seemann, *Dependency Injection in .NET*).
+- **Smells:** `container.GetInstance<T>()` / `ServiceLocator.Current` sprinkled
+  in business code; `new`-ing dependencies inside methods; static singletons;
+  no single place where wiring happens; over-registration of things that are
+  never varied.
+
+**Inspection prompt**
+> Find every place a dependency is obtained other than via constructor
+> injection: static service locators, container `Resolve/GetInstance` calls in
+> business code, `new` of a collaborator with behavior, static/global
+> singletons. Confirm whether wiring is centralized in one composition root.
+> Report each service-locator reach-through and propose constructor injection.
+
+## 6.2 Persistence Ignorance (POCO domain)
+
+- The domain model should be plain objects unaware of how they are stored — no
+  base class from the ORM, no persistence attributes driving the model's shape,
+  no `Save()` on entities. (Miller's Marten deliberately stores POCOs as
+  documents to preserve this.)
+- **Smells:** entities inheriting an ORM base type; `[Table]`/`[Key]`/`[Column]`
+  as the *primary* definition of the model; active-record `entity.Save()`;
+  lazy-loading proxies leaking into domain logic.
+
+**Inspection prompt**
+> Determine whether the domain model is persistence-ignorant: are entities plain
+> objects, or do they inherit ORM base classes / carry persistence attributes /
+> expose `Save()`/`Load()` themselves? Quote offending types and propose a POCO
+> model with mapping pushed to the infrastructure edge.
+
+## 6.3 Low Ceremony / minimal abstraction
+
+- Prefer the simplest thing that works; avoid layers of indirection that add no
+  behavior. Miller is a critic of "enterprisey" ceremony — needless interfaces
+  with one implementation, deep inheritance, and abstraction that exists only to
+  satisfy dogma.
+- **Smells:** an interface per class with exactly one implementation and no test
+  or substitution need; anemic pass-through layers; heavy generic base classes;
+  configuration ceremony that dwarfs the logic.
+- **Balance note:** this is in tension with "always program to an interface."
+  The rule is *abstract at real seams* (I/O, external systems, things you swap
+  or fake in tests) — not everywhere reflexively.
+
+**Inspection prompt**
+> Find ceremony that adds indirection without behavior: interfaces with a single
+> implementation that is never faked in tests or swapped, pass-through wrapper
+> classes, and deep base-class hierarchies. Distinguish genuine seams (I/O,
+> externals — keep them) from dogmatic abstraction (collapse it). Recommend
+> inlining/collapsing where the abstraction earns nothing.
+
+## 6.4 Command/Query Separation (CQS)
+
+CQS is **Bertrand Meyer's** principle (*Object-Oriented Software Construction*),
+championed in .NET practice by Miller and by Fowler.
+
+- A method either **does** something (command, returns void, has side effects)
+  or **answers** something (query, returns data, no side effects) — not both.
+- **Smells:** `GetOrCreateX()`, queries that mutate state, properties with side
+  effects, methods returning a value *and* writing to the DB.
+
+**Inspection prompt**
+> Find methods that both return data and cause side effects (mutation, I/O),
+> and query-named methods/properties that mutate. Report each CQS violation and
+> propose splitting into a command and a query.
+
+**Remediation stance (all of Module 6):** one composition root; POCO domain with
+mapping at the edge; interfaces only at real seams; commands and queries kept
+separate; delete ceremony that buys nothing.

--- a/.claude/skills/codebase-cartography-audit/references/07-ai-antipatterns.md
+++ b/.claude/skills/codebase-cartography-audit/references/07-ai-antipatterns.md
@@ -1,0 +1,109 @@
+# Module 7 — AI-Code Anti-Patterns
+
+Composite module targeting the defects that Large-Language-Model code
+generators reliably emit. These are high-signal and cheap to detect — run this
+module early. They map back to the named principles but deserve their own sweep
+because they cluster in generated code.
+
+## 7.1 Magic strings & magic numbers
+- Literal strings/numbers embedded in logic: status values, config keys, routes,
+  SQL, error codes, thresholds, dictionary keys.
+- **Why it hurts:** no single source of truth, typo bugs the compiler can't
+  catch, duplication across files, impossible to grep confidently.
+- **Fix:** constants, enums, typed options, resource files, named config.
+- **Prompt:** *Find string and numeric literals used as identifiers, keys,
+  statuses, thresholds, routes, or config in logic (exclude genuine one-off UI
+  text and test data). Group duplicated literals across files. Propose
+  constants/enums/typed config for each cluster.*
+
+## 7.2 Duplication (DRY violations)
+- LLMs re-emit near-identical blocks rather than reusing. Copy-pasted methods,
+  parallel validation, repeated mapping/DTO code, duplicated error handling.
+- **Fix:** Extract Method/Class/module; shared helpers; template method.
+- **Prompt:** *Detect duplicated and near-duplicated code blocks across {scope}.
+  Quote each cluster with all sites, estimate the divergence, and propose the
+  single extraction that collapses it. Rank by number of copies.*
+
+## 7.3 God classes / god functions
+- One class or function that orchestrates everything (SRP, Module 1.1; Large
+  Class, Module 4). Common in AI "just make it work" output.
+- **Prompt:** *Identify the largest classes/functions by responsibility count,
+  length, and fan-in. For each, enumerate the distinct responsibilities and
+  propose the split.*
+
+## 7.4 Hardcoded configuration & secrets
+- Connection strings, API keys, URLs, credentials, feature toggles baked into
+  source. **Secrets in source = Critical severity.**
+- **Fix:** configuration providers, environment, secret stores; never in repo.
+- **Prompt:** *Scan for hardcoded connection strings, API keys, passwords,
+  tokens, base URLs, file paths, and environment-specific values. Flag any
+  credential/secret as Critical. Propose externalized configuration.*
+
+## 7.5 Inconsistent naming & structure
+- Mixed conventions, same concept named 3 ways, folder layout that doesn't match
+  the domain (Screaming Architecture, Module 3.2).
+- **Prompt:** *Catalogue naming inconsistencies for the same concept and
+  convention drift (casing, prefixes, layer suffixes). Propose a consistent
+  vocabulary.*
+
+## 7.6 Poor / swallowed error handling
+- `catch (Exception) { }` empty catches; catching and rethrowing without
+  context; returning null on error; logging then swallowing; no fail-fast.
+- **Fix:** guard clauses, fail fast, meaningful exceptions, don't swallow.
+- **Prompt:** *Find empty catch blocks, catch-all swallowing, null-on-error
+  returns, and missing guard clauses/input validation at boundaries. Flag data-
+  loss/silent-failure risks and propose fail-fast handling.*
+
+## 7.7 Deep nesting & missing guard clauses
+- Arrow code (nested ifs), no early returns, complex boolean conditions.
+- **Fix:** guard clauses / early return, Decompose Conditional, invert.
+- **Prompt:** *Find methods with nesting depth >3 or complex compound
+  conditionals. Propose guard clauses and conditional decomposition.*
+
+## 7.8 Async / resource misuse
+- `async void`, missing `await`, sync-over-async (`.Result`/`.Wait()`),
+  undisposed `IDisposable`, DB connections/HTTP clients not pooled.
+- **Prompt:** *Find async/resource hazards: async void, unawaited tasks, sync-
+  over-async blocking, undisposed disposables, per-call HttpClient/connection
+  creation. Flag deadlock and leak risks.*
+
+## 7.9 Security surface (quick pass)
+- SQL built by string concatenation (injection), unvalidated input, missing
+  authz checks, secrets in logs, overly broad CORS. Escalate anything real to
+  the dedicated `/security-review` skill.
+- **Prompt:** *Scan for injection (string-concatenated SQL/commands),
+  unvalidated external input reaching sensitive sinks, missing authorization on
+  endpoints, and secrets written to logs. List with severity; recommend running
+  a full security review on hits.*
+
+## 7.10 Dead code & speculative generality
+- Unused methods/classes/params, commented-out blocks, unreached branches,
+  abstractions with a single caller "for the future."
+- **Prompt:** *Find unused/unreachable code, commented-out blocks, and
+  unused-parameters, plus abstractions with exactly one use. Recommend deletion.*
+
+## 7.11 Hallucinated / phantom dependencies (LLM-specific)
+- Imports of non-existent APIs, wrong overloads, or packages that don't exist /
+  aren't referenced (a supply-chain "slopsquatting" risk if later `add`ed blindly).
+- **Prompt:** *Verify every imported package/module resolves to a real, referenced
+  dependency and every called API member exists. Flag phantom imports, unused
+  package references, and calls to members not present in the referenced version.*
+
+## 7.12 Reinvented framework/stdlib functionality (LLM-specific)
+- Hand-rolled JSON parsing, date math, retry/backoff, string casing, DI, or
+  collection helpers that duplicate the framework/BCL.
+- **Prompt:** *Find hand-written implementations of things the framework/stdlib
+  already provides (serialization, date/time, retry, hashing, LINQ-able helpers).
+  Recommend the built-in.*
+
+## 7.13 Placeholder stubs & narrating comments (LLM-specific)
+- Shipped `// TODO: implement`, `throw new NotImplementedException()` on live
+  paths, lorem-ipsum/sample defaults, and line-by-line comments that restate the
+  code instead of explaining *why*.
+- **Prompt:** *Find NotImplemented/TODO stubs on non-test code paths, placeholder/
+  sample values shipped as defaults, and comment blocks that merely narrate the
+  next line. Flag stubs as correctness risks; recommend deleting narration.*
+
+**Stance:** deleting duplication, dead code, and magic literals typically
+removes more bug surface per hour than any other activity — and it is low-risk.
+Do it behind whatever tests exist; if none exist, see Module 8 first.

--- a/.claude/skills/codebase-cartography-audit/references/08-testing.md
+++ b/.claude/skills/codebase-cartography-audit/references/08-testing.md
@@ -1,0 +1,127 @@
+# Module 8 — Testing & the Automation Pyramid
+
+Advocated across these authorities: **Mike Cohn** (originator of the *Test
+Automation Pyramid*, *Succeeding with Agile*, 2009 — fast, numerous unit tests at
+the base; fewer service/integration tests; a thin cap of slow UI tests),
+**Robert C. Martin** (TDD, the "three laws," tests as a first-class part of Clean
+Architecture), **Jeffrey Palermo** (popularized the pyramid in .NET/Onion
+practice), **Martin Fowler** (test-pyramid write-ups, "self-testing code," and the
+critique of the *ice-cream-cone* anti-pattern — a term coined by Alister Scott),
+and **Jeremy D. Miller** (pragmatic, fast-feedback testing; testability as a
+design force).
+
+This module both **assesses the inherited safety net** and **defines the bar new
+work must meet** — consistent with the project's mandatory Definition of Done
+(unit + integration + full-system tests in the same change).
+
+## 8.1 The pyramid (Cohn)
+
+```
+        /\        Full-system / UI  — few, slow, high-value
+       /  \       (Playwright for web/Blazor; FlaUI/COM for desktop/Excel).
+      /----\      All third-party interfaces STUBBED/SIMULATED.
+     /      \     Integration      — module boundaries: DB, messaging,
+    /--------\                        HTTP endpoints, adapters.
+   /          \   Unit             — many, fast, isolated logic.
+  /____________\
+```
+
+**Anti-pattern:** the *ice-cream cone* / *testing hourglass* — lots of slow
+end-to-end tests, little or no unit coverage. AI-generated projects usually have
+**no** tests, or a few brittle happy-path E2E tests.
+
+## 8.1b Discover & classify EVERY test suite (scales to dozens)
+
+A large codebase may have **dozens of test suites** across many projects/packages,
+and the pyramid is only meaningful once each is discovered and placed in a layer.
+Do this mechanically, not by assumption — automate it in the metrics `.csx` when
+there are more than a handful.
+
+**Step 1 — discover every test suite.** A "suite" is the finest independently
+runnable/attributable unit — usually a test *project/assembly* (`.csproj`
+referencing a test SDK), but split further by top-level namespace/folder/fixture
+when one project mixes layers. Find them by their framework markers, not folder
+names: `Microsoft.NET.Test.Sdk`/`xunit`/`nunit`/`MSTest` (.NET),
+`pytest`/`unittest` (Python), `jest`/`vitest`/`mocha` (JS), `junit`/`testng`
+(Java), `_test.go` (Go), `*.feature` (SpecFlow/Cucumber).
+
+**Step 2 — count each suite with the runner** (`--list-tests`/`--collect-only`),
+never by grepping attributes (Module 9).
+
+**Step 3 — classify each suite by *evidence*, not by its name**, into
+**unit / integration / acceptance(full-system)** using the strongest signal present:
+
+| Layer | Positive signals (package refs, usings, base classes, attributes) |
+|-------|-------------------------------------------------------------------|
+| **Unit** | only the SUT + a mocking/assertion lib (Moq, NSubstitute, FakeItEasy, FluentAssertions, Shouldly); no DB driver, no HTTP, no container, no host bootstrap; fast |
+| **Integration** | EF/ORM, a DB driver or real SQLite/SQL, `WebApplicationFactory`/`TestServer`, Testcontainers, a DI-container/host boot (Lamar/Autofac), message-bus/queue clients, filesystem/network, **bUnit component render** (renders a component in isolation — NOT full-system) |
+| **Acceptance / full-system** | drives the real UI or whole running app: Selenium, Playwright, Cypress, FlaUI/WinAppDriver/COM, SpecFlow `.feature` against a running host, or end-to-end against a live endpoint |
+
+> bUnit is a component-level library (unit/integration), not full-system — do not
+> file bUnit suites under Acceptance or the pyramid cap will be over-stated.
+
+Rules for honest classification:
+- Classify on the **dominant signal**; when a project genuinely mixes layers,
+  split its count by namespace/fixture and report the breakdown rather than
+  forcing one label — or mark it `mixed` with sub-counts.
+- A folder called `IntegrationTests` that only news-up POCOs and mocks is **unit**;
+  a `UnitTests` project that opens a real SQLite file is **integration**. Trust the
+  signal over the name and note the discrepancy (it is itself a finding).
+- Record the deciding signal per suite so the classification is auditable.
+
+**Step 4 — emit a suite matrix and roll up to the pyramid.** One row per suite:
+`suite, project/package, framework, test count (runner), layer, deciding signal`.
+Sum counts per layer to get the pyramid shape. This table is what §5 of the report
+and the testing C4 diagram (Module 10) are built from.
+
+## 8.2 What to assess
+
+- **Presence & shape:** is there a test project at all? What's the ratio of
+  unit / integration / full-system? Is it inverted (ice-cream cone)? **Count tests
+  with the runner, not by hand** — `dotnet test --list-tests`, `pytest
+  --collect-only -q`, `go test -list '.*' ./...`, etc. — per project/layer; attribute-grepping
+  miscounts parameterized/skipped cases (see Module 9). Report the tool numbers.
+- **Coverage of risk:** are the god classes and money/rule logic tested, or only
+  trivial getters?
+- **Boundary tests:** integration tests wherever the code crosses to a DB,
+  queue, HTTP endpoint, or third party?
+- **Full-system:** does any test start the whole app and drive the real UI with
+  externals stubbed?
+- **Quality:** deterministic (no `DateTime.Now`/random/sleep flakiness)? Assert
+  behavior, not implementation? Isolated (no shared mutable state)?
+- **Testability as design signal:** code that is hard to test is telling you
+  about DIP/SRP/coupling violations — cross-reference Modules 1, 2, 6.
+
+**Inspection prompt**
+> Assess the test suite of {scope}. (0) **Discover EVERY test suite** (all test
+> projects/assemblies by framework marker, split mixed ones by namespace/fixture),
+> **count each with the runner** (`--list-tests`/`--collect-only`), and **classify
+> each as unit / integration / acceptance(full-system) by evidence** (package refs,
+> usings, base classes) not by folder name — emit a suite matrix (suite, project,
+> framework, count, layer, deciding signal) and note any suite whose name
+> contradicts its signal. (1) Roll the matrix up by layer and report the pyramid
+> shape — flag an inverted ice-cream-cone/hourglass. (2) Determine whether the
+> highest-risk logic (the god classes,
+> money/date/business rules, boundary code) is actually covered or only trivial
+> paths are. (3) Check for boundary/integration tests at every DB/queue/HTTP/
+> third-party seam. (4) Check whether any full-system test starts the app and
+> drives the real UI with externals stubbed. (5) Flag flakiness sources
+> (`DateTime.Now`, random, sleeps, shared state) and tests that assert
+> implementation detail. Report gaps by risk.
+
+## 8.3 Remediation strategy (order matters)
+
+1. **Characterize before you refactor.** For untested code you must change,
+   first write *characterization tests* that pin current behavior (Feathers,
+   *Working Effectively with Legacy Code*). Then refactor safely.
+2. **Break dependencies for testability** using DIP/IoC (Modules 1.5, 6.1):
+   inject the clock, config, and I/O so units can run isolated.
+3. **Build the pyramid bottom-up:** fast unit tests for logic, integration tests
+   at each boundary, a thin full-system layer driving the UI with stubs.
+4. **Enforce the Definition of Done** on all new/changed behavior: unit +
+   integration + full-system in the same change, externals simulated, runnable
+   headlessly in CI where possible.
+
+**Cross-links:** hard-to-test code ⇒ inspect DIP (1.5), SRP (1.1), Onion (2),
+IoC & persistence ignorance (6). Testability is the fastest litmus test for the
+whole audit.

--- a/.claude/skills/codebase-cartography-audit/references/09-inventory-and-metrics.md
+++ b/.claude/skills/codebase-cartography-audit/references/09-inventory-and-metrics.md
@@ -1,0 +1,200 @@
+# Module 9 — Inventory, Metrics & Linting (tool-driven)
+
+This module produces the **objective, measured** half of the audit: lines of
+code, cyclomatic complexity, and lint/analyzer findings — gathered by running
+real command-line tools, not by eyeballing. Every number in the report must be
+reproducible by re-running a command that is recorded in the report.
+
+## 9.1 Principle
+
+- **Every objective number comes from an executable tool, never from inference.**
+  LOC, class/method counts, cyclomatic complexity, test counts, lint counts,
+  duplication, function points, and cost are all produced by a command or a
+  committed `.csx` script whose output is captured in `metrics/`. Do NOT eyeball a
+  directory and assert "~600 tests" or "about 300 classes" — run the tool and
+  quote its number with the command. Only the *qualitative* defect findings are
+  analyst-authored, and each still cites `file:line`. If a number cannot be
+  produced by a tool, label it explicitly as an estimate and show the method.
+- **Test counts come from the test runner, not from counting `[Test]` attributes
+  by hand.** Attribute-grepping miscounts parameterized cases (`[TestCase]`,
+  `[Theory]`) and disabled tests. Use the framework's own enumeration —
+  `dotnet test <proj> --list-tests` (.NET/VSTest), `pytest --collect-only -q`,
+  `go test -list '.*' ./...`, and for Java the Surefire run summary
+  (`Tests run: N` — NOT `-DskipTests`, which runs nothing). For Jest, `--listTests`
+  lists test *files* only; get case counts from a run with `--json`/a reporter.
+  Count what the runner reports, per project/layer.
+- **Scripting language for helpers: single-file C#.** Any custom analysis logic
+  (rollups, McCabe counting, function-point math, parsing tool JSON) is written
+  as a **single-file C# script** (`.csx`) run with `dotnet-script` — NOT Python
+  and NOT PowerShell. C# suits this logic (many typed variables, weight tables,
+  records) and keeps the toolchain aligned with a .NET target. PowerShell is fine
+  for build/orchestration glue, but the metric/FP computation lives in `.csx`.
+  Acquire the runner with `dotnet tool install -g dotnet-script` (pin `--version
+  1.5.0` on SDK 6). Run with `dotnet script metrics/metrics.csx`.
+- **Right tool for the stack.** Detect the languages first (Module: architecture
+  map), then pick tools that actually parse those languages. A polyglot repo
+  needs a polyglot LOC tool plus per-language complexity/lint tools.
+- **Component-level rollups.** Aggregate file metrics up to the architectural
+  components (projects/modules/packages) so they can annotate the logical C4
+  diagram (Module 10) and rank refactor risk.
+
+## 9.2 Tool selection matrix
+
+| Need | Language-agnostic | .NET / C# | JS/TS | Python | Java | Go |
+|------|-------------------|-----------|-------|--------|------|-----|
+| LOC + file complexity | **scc** (fast, single Go binary; gives Lines/Code/Comments/Complexity per file & per language) or `cloc` | scc | scc | scc | scc | scc |
+| Cyclomatic complexity | **own `.csx` McCabe counter** (§9.4) is the portable default | `Microsoft.CodeAnalysis.Metrics` (`msbuild /t:Metrics`) for per-method CC; else the `.csx` counter | ESLint `complexity` rule, `plato`, `ts-complex` | `radon cc` | `pmd`, `checkstyle` | `gocyclo` |
+| Lint / analyzers | — | **Roslynator analyze** (diagnostics only — it has no CC command), `dotnet format --verify-no-changes`, built-in Roslyn analyzers | ESLint | `ruff`, `flake8`, `pylint` | `checkstyle`, `pmd`, SpotBugs | `go vet`, `staticcheck` |
+| Duplication | `jscpd` (polyglot clone-block detector) | jscpd | jscpd | jscpd | pmd-cpd | dupl |
+
+> `dotnet-counters` is a runtime perf-counter monitor and cannot compute CC;
+> `roslynator analyze` emits analyzer diagnostics, not per-method complexity;
+> scc `--dup` only collapses whole-file duplicates (not clone blocks). Compute CC
+> with the `.csx` counter (§9.4) or `Microsoft.CodeAnalysis.Metrics`, and detect
+> clones with jscpd/PMD-CPD.
+
+**scc** is the workhorse for LOC + a fast complexity proxy across every language
+in one pass and needs no runtime. Use it first, always. Then add a per-language
+complexity/lint tool for the dominant language(s).
+
+### Acquiring tools when absent (record every step)
+- `scc`: download the release binary for the OS from `boyter/scc` GitHub releases
+  (single executable, no install). On Windows: fetch the `_Windows_x86_64.zip`,
+  unzip, run `scc.exe`.
+- `Roslynator.DotNet.Cli`: `dotnet tool install -g Roslynator.DotNet.Cli`. If the
+  SDK is older than the latest CLI's target (e.g. SDK 6 vs a net8 CLI), pin a
+  compatible older version (`--version 0.8.6` works on SDK 6).
+- `PlantUML`: download `plantuml.jar` from the plantuml GitHub release; needs a
+  JRE and (for component/deployment diagrams) Graphviz `dot` on PATH.
+- Python tools: `pip install radon ruff`. JS: `npm i -g jscpd eslint`.
+- Prefer no-install binaries and `-g`/`pipx` tools; never modify the target repo
+  to install a tool. Exclude `bin/`, `obj/`, `node_modules/`, `dist/`, generated
+  and vendored code from every metric run and say so.
+
+## 9.3 Commands (record these verbatim in the report)
+
+```bash
+# LOC + complexity, whole repo, per language, excluding build output
+# scc over the WHOLE REPO (not just src) so root build/deploy scripts are counted (9.3b)
+scc --exclude-dir bin,obj,node_modules,dist,.git,<report-dir> . > metrics/scc-summary.txt
+# machine-readable for rollups + diagram annotation
+scc --exclude-dir bin,obj,node_modules,dist,.git,<report-dir> --by-file --format json . > metrics/scc-by-file.json
+
+# C# analyzer / lint findings (diagnostics only — NOT cyclomatic complexity)
+roslynator analyze path/to.sln --output metrics/roslynator.xml
+
+# duplication (polyglot clone-block detector)
+jscpd --min-lines 8 --reporters json,console -o metrics/jscpd .
+```
+
+Always capture: tool name, version (`--version`), the exact command, and the
+raw output file path. The report cites these so the metrics are reproducible.
+
+> `--exclude-dir` only removes whole directories; the **file-pattern** exclusions
+> of §9.3b (`*.min.*`, `*.g.cs`, `*.designer.cs`, generated/seed dumps) are applied
+> **in `metrics.csx` when it classifies files** — the scc command alone does NOT
+> satisfy the exclusion rule. State this so no one claims the raw scc total is the
+> code total.
+
+## 9.3b Two LOC categories: System vs DevOps/Test
+
+Classify **all** code — including tests and build/deploy assets — into exactly two
+categories, and report a subtotal for each plus a grand total (for LOC, classes,
+CC, and downstream FP and cost):
+
+- **System code** — the product runtime delivered to end users (the application
+  projects/modules).
+- **DevOps/Test code** — everything that supports building, verifying, migrating,
+  and deploying the system: **all test suites**, **build/deploy scripts**
+  (`*.ps1`, `*.yml`, `Dockerfile`, `docker-compose`, `*.cake`, CI YAML),
+  database-migration/deploy projects, and one-off tooling utilities. These are
+  DevOps assets, not shipped functionality.
+
+Run scc over the **whole repository** (not just `src/`) so root-level build/deploy
+scripts are counted; then map each file to a category. The System/DevOps-Test LOC
+split is itself a finding — a test+DevOps estate larger than the product is common
+and worth calling out. Keep the classification list explicit and auditable in the
+script, and note any judgment calls (e.g. whether a data-load utility is product
+or tooling).
+
+**Reconciliation rule (mandatory — this is where LLMs go wrong).** Every LOC in a
+category subtotal MUST be attributable to a **named component line item**, and each
+subtotal MUST equal the sum of its listed components. Compute subtotals *as* the
+sum of the rows — never emit a subtotal larger than the visible rows. If a
+whole-repo walk adds LOC that no component claims (a "root/misc" bucket), that
+bucket must appear as its own explicit line item; a large unexplained gap (e.g.
+tens of thousands of LOC not shown against any component) is a **bug to fix, not a
+number to report** — it silently inflates FP and cost downstream. Print a
+reconciliation check: `Σ(components) == subtotal` per category and overall.
+
+**Exclude non-authored code from the LOC tally** (or list it in a clearly-separate
+"excluded" bucket, never inside System or DevOps/Test): vendored/third-party
+(`node_modules`, `packages`, `wwwroot/lib`, `Scripts` vendored libs), **minified**
+(`*.min.js`, `*.min.css`), **generated** (`*.g.cs`, `*.designer.cs`,
+`*.Generated.cs`, `obj/`, scaffolded migrations dumps, `*.feature.cs`), and pure
+data/config blobs (large `.json`/`.sql` seed dumps). Flag any single file or
+directory contributing >~2,000 LOC and confirm it is authored source before
+counting it — a lone generated/minified/seed file can add tens of thousands of
+phantom LOC and wreck the totals.
+
+## 9.4 Rolling up for the annotated diagram (single-file C# script)
+
+Write a `metrics/metrics.csx` that:
+1. Parses `scc-by-file.json` (`System.Text.Json`).
+2. Maps each file to its architectural component (usually its project/module —
+   the directory that owns the `.csproj`/`package.json`/`go.mod`).
+3. Sums `Code` (LOC) per component and computes **genuine McCabe cyclomatic
+   complexity** itself rather than trusting scc's keyword proxy: for each `.cs`/
+   `.razor` file, strip block/line comments and string literals, then
+   `CC = max(methodCount,1) + decisionPoints` where a decision point is
+   `if | for | foreach | while | case | catch | && | || | ?? | ?:`. Count only the
+   `if` (an `else`/`else if` adds its decision via that `if`; don't double-count).
+   **Do NOT count nullable-type `?` (e.g. `int?`) as a decision point** — that
+   over-states complexity badly for EF-generated entities; match only true
+   `??`/`?:` operators. Including `&&`/`||`/`??` makes this **extended (CC2-style)
+   McCabe**, so numbers read a little higher than strict-McCabe tools — state this
+   so the figures are comparable. The file-level `max(methods,1)+decisions` sum is
+   equivalent to summing per-method CC across the file.
+4. Counts **classes/objects** per component (`class|record|struct|interface`
+   declarations) and reports **average CC per class = total CC ÷ class count**
+   alongside total CC. (Note the Razor caveat: `.razor` files often declare no
+   `class` keyword, so CC/class is inflated for UI projects — flag it.)
+5. Computes **complexity density** = total CC ÷ code LOC (size-independent
+   hotspot signal).
+6. Emits `component-rollup.txt` + `.json` with
+   `component, category(System|DevOps/Test|Excluded), files, LOC, classes,
+   methods, CC, CC-per-class, density, hottestFile(maxCC)`, **per-category subtotal
+   rows** (System, DevOps/Test, and an **Excluded (non-authored)** row listing what
+   was removed and why), then the GRAND TOTAL, the System/DevOps-Test LOC split %,
+   and a top-15 most-complex-files list. Print the reconciliation identity
+   explicitly: **Σ(System) + Σ(DevOps/Test) + Σ(Excluded) == whole-repo scc code
+   total** — this is the clean check that the whole-repo scan and the categories
+   agree, with no phantom LOC.
+7. Feeds LOC + CC into the logical diagram box labels (Module 10.4).
+
+Keep it one file, run it with `dotnet script metrics/metrics.csx`, and commit the
+`.csx` alongside its output so the numbers are reproducible.
+
+## 9.5 Interpreting the numbers (don't just print them)
+
+- **Complexity per method > 10** = review; **> 20** = high risk / likely a god
+  method. scc reports per-file; a single file with complexity in the hundreds is
+  a god class or a mega-switch — cross-link to Modules 1 (SRP/OCP) and 4.
+- **High LOC + high density component** = the refactor-risk epicenter; it should
+  top the backlog and needs characterization tests first (Module 8).
+- **Lint volume** is a proxy for consistency debt; group analyzer hits by rule id
+  and report the top offenders, not the raw wall of warnings.
+- **Duplication blocks** map straight to the Duplicated Code smell (Module 4);
+  quote the two largest clone sites.
+
+**Inspection prompt**
+> Detect the languages in {scope}. Acquire scc (LOC) plus a per-language lint/
+> duplication tool for the dominant language(s), and `dotnet-script` for the C#
+> rollup; record how each was obtained and its version. Run them excluding build/
+> vendor output, saving raw output to `metrics/`. Produce (every number from a
+> tool, not inference): (a) a language breakdown table; (b) a per-component
+> rollup with files, LOC, class count, methods, total McCabe CC, **average CC per
+> class**, and density; (c) the top 10 most-complex files; (d) a lint summary
+> grouped by rule; (e) the largest duplication clones; (f) **test counts per
+> layer from the test runner** (`--list-tests`/`--collect-only`), not from
+> attribute grepping. Cite every command so the numbers are reproducible.

--- a/.claude/skills/codebase-cartography-audit/references/10-c4-plantuml-diagrams.md
+++ b/.claude/skills/codebase-cartography-audit/references/10-c4-plantuml-diagrams.md
@@ -1,0 +1,127 @@
+# Module 10 — C4 Architecture Diagrams (PlantUML) + Rendering
+
+Produce a **set of PlantUML diagrams** that capture the system from five
+complementary viewpoints, render them to PNG, and *inspect the rendered image*
+for legibility before accepting it. Diagrams are derived from evidence gathered
+in the architecture map (Modules 2–3), the dependency graph, and the metrics
+(Module 9) — never invented.
+
+## 10.1 The five required views
+
+1. **Logical (C4 Component)** — the domain/application/infrastructure components
+   and their responsibilities and relationships. This is the diagram that gets
+   **annotated with LOC + cyclomatic complexity** (see 10.4).
+2. **Runtime (C4 Container / dynamic)** — the processes/containers that actually
+   run (web app, API, worker/job, desktop client, database, message broker,
+   blob storage, external SaaS) and the calls between them at run time.
+3. **Dependencies** — the build-time dependency graph between
+   modules/projects/packages, with arrow direction. This is where you visualize
+   onion/clean violations (an arrow pointing the wrong way) and any cycles.
+4. **Testing** — test projects/suites mapped to what they exercise, labelled by
+   layer (unit / integration / full-system) and count; shows the pyramid shape.
+5. **Build / DevOps / Deploy** — source → CI pipeline → artifacts → environments,
+   including registries, IaC, and deployment targets discovered from
+   pipeline/compose/IaC files.
+
+**Use the C4-PlantUML template library by default** for visual quality. Recent
+PlantUML ships it in the bundled stdlib, so `!include <C4/C4_Container>` (and
+`<C4/C4_Component>`, `<C4/C4_Deployment>`) renders **fully offline** with Graphviz
+— no internet needed. Use the C4 macros (`System_Boundary`, `Container`,
+`ContainerDb`, `ContainerQueue`, `Component`, `System_Ext`, `Rel`,
+`Deployment_Node`), `AddElementTag`/`AddRelTag` for color-coding, and
+`SHOW_LEGEND()`. Map the views: logical → `C4_Component`, runtime → `C4_Container`,
+dependencies → `C4_Component`, deploy → `C4_Deployment`. Only if the bundled
+stdlib is unavailable, fall back to plain PlantUML rather than produce nothing.
+
+**Encoding:** write labels in ASCII — use `-` not `—`/`–` and `>` not `→`;
+non-ASCII punctuation renders as mojibake (`â€"`) in PlantUML output.
+
+**Reflect the two code categories (Module 9.3b) in every diagram.** Put System
+components in one `System_Boundary` and DevOps/Test components (tests, build/
+deploy scripts, tooling) in another, each with a distinct `AddElementTag` color,
+and label each boundary with its LOC/FP subtotal. The category split should be
+visible at a glance in the logical, dependency, testing, and deploy views.
+
+## 10.2 Authoring conventions (for legibility)
+
+- One view per `.puml` file under `diagrams/`; name them
+  `01-logical.puml … 05-deploy.puml`.
+- `left to right direction` for wide dependency/runtime graphs; top-down for
+  layered logical views.
+- Group with `package "Ring/Layer" { … }` so the dependency direction reads
+  visually (domain core innermost/leftmost).
+- Keep labels short; put detail in `note` blocks, not node names.
+- Use `skinparam dpi 150` (or `-DPLANTUML_LIMIT_SIZE`/`-Sdpi`) so PNGs are crisp
+  but not enormous. Add `skinparam wrapWidth 200` to wrap long labels.
+- Color the domain core distinctly from infrastructure so onion violations pop.
+
+## 10.3 Rendering + the mandatory legibility inspection
+
+```bash
+java -jar plantuml.jar -tpng -o ../report/images diagrams/*.puml   # PNG
+java -jar plantuml.jar -tsvg -o ../report/images diagrams/*.puml   # optional SVG
+```
+
+**Inspect every rendered PNG — this step is not optional.** A `.puml` that
+"compiles" can still be unreadable. After rendering, **Read each PNG image** and
+check:
+- Nothing is clipped at the canvas edge; the whole graph is inside the frame.
+- No overlapping boxes or label-over-arrow collisions; text is readable.
+- Arrow directions match the intended dependency direction.
+- The annotations (LOC/complexity) are present and legible.
+- Reasonable aspect ratio (not a 10:1 sliver); size is sane.
+
+If a diagram fails inspection, fix the source (change direction, split a
+package, shorten labels, raise/lower dpi, add `hidden` layout edges) and
+re-render. Iterate until it reads cleanly. Record in the report that each image
+was visually verified.
+
+Common fixes: too wide → `top to bottom direction` or split into two diagrams;
+overlap → `skinparam nodesep`/`ranksep`; clipped → lower dpi or wrap labels;
+tangled arrows → group into packages and use `[A] --> [B]` sparingly.
+
+## 10.4 Annotating the logical diagram with metrics
+
+Take the per-component rollup from Module 9.4 and embed **LOC** and **total
+cyclomatic complexity** into each component's box label so the diagram doubles
+as a heat map. Example (C4-PlantUML, ASCII labels, two category boundaries):
+
+```plantuml
+@startuml logical-annotated
+!include <C4/C4_Component>
+LAYOUT_TOP_DOWN()
+skinparam dpi 140
+title Logical Architecture - annotated with LOC and Cyclomatic Complexity (McCabe)
+
+AddElementTag("hot",  $bgColor="#F5B7B1", $legendText="high complexity")
+AddElementTag("warm", $bgColor="#F9E79F", $legendText="medium complexity")
+AddElementTag("devops",$bgColor="#D5D8DC", $legendText="DevOps/Test asset")
+
+System_Boundary(sys, "SYSTEM code - 45,386 LOC (46%)") {
+  Component(core, "Core (Domain)", "C#", "LOC 11,959 / CC 1,117", $tags="hot")
+  Component(data, "DataAccess", "EF/Dapper", "LOC 5,889 / CC 367", $tags="warm")
+}
+System_Boundary(dev, "DEVOPS/TEST code - 52,589 LOC (54%)") {
+  Component(itest, "IntegrationTests", "NUnit", "LOC 30,872 / CC 1,227 / 991 tests", $tags="devops")
+}
+Rel(data, core, "depends on")
+Rel(itest, data, "tests")
+SHOW_LEGEND()
+@enduml
+```
+
+- Show LOC and Cyclomatic on separate lines; optionally density and the single
+  worst file. Consider a color ramp (green→red) keyed to complexity density so
+  the hotspot is obvious at a glance.
+- Keep numbers formatted (thousands separators) and consistent across boxes.
+- This annotated diagram is a *distinct* file from the plain logical view; keep
+  both (`01-logical.puml` and `01-logical-annotated.puml`).
+
+**Inspection prompt**
+> From the architecture map, dependency graph, and Module 9 metrics, author five
+> PlantUML diagrams (logical, runtime, dependencies, testing, deploy) under
+> `diagrams/`, plus an annotated logical diagram whose component boxes carry LOC
+> and cyclomatic complexity. Render all to PNG with plantuml.jar. Then Read each
+> PNG and verify legibility (no clipping/overlap, correct arrow direction,
+> annotations readable); fix the source and re-render any that fail. Embed the
+> verified PNGs in the report README.

--- a/.claude/skills/codebase-cartography-audit/references/11-function-points.md
+++ b/.claude/skills/codebase-cartography-audit/references/11-function-points.md
@@ -1,0 +1,205 @@
+# Module 11 — Function Point Counting (IFPUG + Jones backfiring)
+
+Size the delivered functionality in **function points (FP)** — a language- and
+implementation-independent measure of how much the software *does* for its users
+— and validate the number with a second, independently-derived estimate.
+Function points complement LOC and complexity (Module 9): LOC measures *how much
+code*, FP measures *how much capability*; the ratio between them (LOC/FP) is a
+productivity and bloat signal.
+
+Research base: **IFPUG** *Counting Practices Manual* (the formal method,
+descended from **Allan Albrecht**'s 1979 work at IBM) and **Capers Jones**
+(*Applied Software Measurement*, *Programming Productivity*) — the authority on
+LOC-per-FP "backfiring" tables and on using two methods as a mutual checkpoint.
+
+## 11.0-pre — Required output: FULL TABLES, and reproducibility
+
+**Emit every FP figure as a full table — never collapse it to a prose one-liner.**
+An LLM's instinct is to summarize ("IFPUG: EI59 EO25 EQ53 ILF18 EIF13, VAF 1.21");
+that is *not acceptable* — it hides the counts and makes the estimate unauditable.
+The report MUST contain, as literal tables:
+1. **IFPUG function-type table** — one row per type (EI/EO/EQ/ILF/EIF) with
+   `count | low/avg/high chosen | weight | FP`, and a UFP total row.
+2. **GSC table** — all **14** characteristics, each with its 0–5 rating **and a
+   one-line justification**, a ΣGSC row, and the VAF computation.
+3. **Backfiring table per category** — `category | LOC | LOC/FP | FP`.
+4. **Subtotals + total table** — System FP / DevOps-Test FP / Total, with shares.
+
+**Reproducibility — why two analysts (or LLMs) diverge, and how to minimize it.**
+Two correct-looking FP counts can differ 40–60%. Observed drivers, in priority
+order — control each:
+- **LOC-driven (largest):** the DevOps/Test backfiring inherits any LOC error. If
+  the Module 9 subtotal doesn't reconcile with its components (phantom LOC from
+  generated/vendored/config files), the equivalent FP is inflated 1:1. **Fix LOC
+  first** (Module 9 reconciliation + exclusions) before backfiring.
+- **Data-function granularity:** count **ILF/EIF as logical files (aggregate
+  roots / logical groups), NOT one-per-table**. A 40-table ShoWorks schema is a
+  handful of logical files, not 40. Over-counting ILF/EIF is the #1 IFPUG inflator.
+- **GSC subjectivity:** ΣGSC swings the VAF from 0.65 to 1.35. Rate conservatively,
+  show every rating with a justification, and default mid-range (2–3) unless the
+  characteristic is clearly high — don't stack 4s and 5s.
+- **Backfiring is the more reproducible anchor** than hand-IFPUG (it's mechanical
+  once LOC is right). When IFPUG and backfiring diverge, treat backfiring as the
+  sanity bound and re-examine the IFPUG counts — the ±30% check "passing" does NOT
+  mean the counts are right, only that they're not wildly off. "Re-examine" means
+  audit the IFPUG basis (are ILFs table-counted? GSCs stacked high?), **not**
+  silently scale IFPUG to match backfiring; if backfiring is high because of code
+  bloat, say so rather than laundering it into the FP count.
+
+## 11.0 Two FP subtotals: System vs DevOps/Test
+
+Report function points in the **two categories from Module 9.3b** plus a total:
+
+- **System FP** — count with **IFPUG** (below); this is delivered user
+  functionality. Cross-check with backfiring of the System code LOC.
+- **DevOps/Test FP** — test suites and build/deploy assets deliver no user
+  functionality, so IFPUG does not apply; size them by **backfiring their LOC**
+  (§11.3) and label the result **equivalent FP** (a size/effort proxy, not
+  features).
+- **Total FP = System + DevOps/Test.** Give both subtotals and the total; the
+  DevOps/Test share is often large (a heavily-tested system can have more
+  test-equivalent FP than product FP).
+
+Everything below is the System (IFPUG) method; §11.3 backfiring is applied per
+category.
+
+## 11.1 Why two methods
+
+A single FP number is easy to get wrong (miscount a file type, mis-weight). The
+discipline is to compute FP **two independent ways** and confirm they agree
+within a tolerance (**±30% is this audit's chosen "same
+ballpark" threshold** for an estimate-grade count). If they diverge more,
+something is wrong — re-examine the component counts or the LOC baseline.
+Agreement validates the estimate; the gap itself is diagnostic (a large
+backfiring-over-IFPUG gap usually means generated or duplicated code inflating LOC
+without delivering functionality). Note ±30% is a working threshold, not a
+guarantee: Jones reports backfiring accuracy for individual projects can vary
+±50% or worse, so divergence inside the band is *consistency*, not proof.
+
+## 11.2 Method A — IFPUG Function Point Analysis
+
+Count five **function types**, classify each as low/average/high complexity, and
+weight it. For an estimate, count at **average** unless you have data.
+
+| Function type | Low | Avg | High | What it is |
+|---------------|----:|----:|-----:|-----------|
+| External Input (EI) | 3 | **4** | 6 | user/interface data-in that changes state (a create/update command) |
+| External Output (EO) | 4 | **5** | 7 | data-out with derived/calculated content (report, export, statement) |
+| External Inquiry (EQ) | 3 | **4** | 6 | data-out that is pure retrieval, no derivation (a lookup/query) |
+| Internal Logical File (ILF) | 7 | **10** | 15 | a logical group of data **this app maintains** (an aggregate/entity group) |
+| External Interface File (EIF) | 5 | **7** | 10 | a logical group of data **another app maintains** that this one reads |
+
+**Unadjusted FP (UFP)** = Σ (count × weight).
+
+**Value Adjustment Factor (VAF)** from the 14 General System Characteristics,
+each rated 0–5 (Degree of Influence): data communications, distributed
+processing, performance, heavily-used config, transaction rate, online data
+entry, end-user efficiency, online update, complex processing, reusability,
+installation ease, operational ease, multiple sites, facilitate change.
+
+```
+VAF = 0.65 + 0.01 × ΣGSC          (ranges 0.65 … 1.35)
+Adjusted FP (AFP) = UFP × VAF
+```
+
+**Rate the 14 GSCs conservatively and SHOW them.** Emit all 14 as a table with
+each 0–5 rating and a one-line justification; do not report VAF as a bare number.
+Default to **2–3** unless a characteristic is clearly high — piling on 4s/5s
+inflates VAF toward 1.35 and is the second-biggest IFPUG divergence source between
+analysts. Note: IFPUG CPM 4.3+/ISO 20926 make VAF **optional** and benchmark on
+**UFP**; if you carry AFP into Module 12, say so and keep it consistent.
+
+**Deriving the counts from code (estimate-grade heuristics):**
+- **EI** ← state-changing command handlers (CQRS `*Command`, POST/PUT endpoints,
+  form submits). Count the *business transaction*, not every method overload.
+- **EQ** ← retrieval queries/lookups (`*Query`, GET endpoints returning stored
+  data with no derivation).
+- **EO** ← outputs with **derived/calculated** content only (reports, statements,
+  exports, dashboards). A plain list/grid of stored rows is an EQ, not an EO —
+  don't double-file the same read as both.
+- **ILF** ← logical data groups the app **maintains**, counted as **aggregate
+  roots / logical files, emphatically NOT one-per-database-table**. A 40-table
+  ShoWorks schema is a handful of ILFs (Auction, Buyer, Payment, …), not 40.
+  This is the single biggest IFPUG inflator — if your ILF count approaches the
+  table count, you are counting wrong.
+- **EIF** ← logical groups of data owned by **another** app that this one reads
+  (integration feeds, another product's DB, third-party master data) — again
+  grouped logically, not per table.
+
+**Sanity bounds (flag if exceeded):** ILF+EIF together are usually a small
+multiple of the number of aggregate roots, and total data-function FP (ILF+EIF)
+rarely exceeds transaction-function FP (EI+EO+EQ) for a line-of-business app. If
+data functions dominate, you're table-counting — regroup.
+
+Document the basis for every count (grep results, handler lists) so the estimate
+is auditable.
+
+## 11.3 Method B — Capers Jones backfiring (LOC → FP)
+
+Backfiring converts measured LOC to FP using Jones/SPR empirical median
+**LOC-per-FP** ratios by language:
+
+| Language | ~LOC/FP | source | | Language | ~LOC/FP | source |
+|----------|--------:|--------|-|----------|--------:|--------|
+| C# | 54 | SPR table | | JavaScript/TS | 47 | SPR table |
+| Java | 53 | SPR table | | Python | ~42 | analyst-assumed* |
+| C++ | 55 | SPR table | | SQL | 13–21 | SPR (varies) |
+| Markup (Razor/HTML) | ~40 | analyst-assumed* | | Go | ~45 | analyst-assumed* |
+
+*Ratios marked analyst-assumed do not trace to a specific SPR/QSM edition (Python/
+Go post-date the classic SPR table; QSM medians differ) — cite the exact table you
+use and widen the sensitivity band for these.
+
+```
+FP_backfired = Σ over languages ( LOC_lang / LOCperFP_lang )
+```
+
+**Physical vs logical LOC.** The SPR ratios are calibrated to *logical statements*;
+scc counts *physical* code lines, which for C# run ~1.2–1.5× logical — so raw
+backfiring from scc over-states FP by 20–50%. Either apply a documented physical→
+logical factor or use physical-LOC-calibrated ratios (QSM), and say which; keep it
+consistent across categories. Always report a sensitivity band, not a single
+number — Jones himself cautions backfiring is approximate.
+
+**Run per category (Module 11.0), not "production only":** backfire the System-code
+LOC (cross-checks IFPUG) *and* the DevOps/Test-code LOC (its primary equivalent-FP
+size) separately; exclude only generated/vendored code from both.
+
+## 11.4 Reconciliation & interpretation
+
+- Report both numbers, the % divergence, and a verdict (agree ≤30% / review).
+- **LOC per delivered FP** = productionLOC ÷ AFP — a bloat/productivity signal.
+  Much higher than the language's Jones ratio ⇒ generated/duplicated code or
+  over-engineering (cross-link Modules 4, 7).
+- FP gives a size-normalized denominator for other metrics: **defects per FP**,
+  **cost per FP**, **FP per developer-month** — useful for planning the refactor
+  backlog and for comparing this system to industry baselines.
+- Keep it estimate-grade and say so; a certified IFPUG count is a manual
+  exercise. The value here is a defensible order-of-magnitude size, validated two
+  ways.
+
+## 11.5 Implementation
+
+Compute this in a **single-file C# script** (`metrics/functionpoints.csx`, run
+with `dotnet-script`) — the weight tables, GSC list, and per-language ratios are
+exactly the kind of multi-variable logic C# handles cleanly. Take the function-
+type counts and the per-category LOC (Module 9.3b) as inputs, print the IFPUG
+table, the per-category backfiring tables + sensitivity band, the System
+reconciliation, and the **two subtotals + total** (§11.0). Commit the `.csx` and
+its captured output. **The `.csx` must print the four required tables (§11.0-pre)
+as ready-to-paste Markdown; the README embeds that output verbatim — do not
+re-summarize it in prose.** State which figure feeds Module 12 — modern IFPUG (CPM 4.3+)
+and ISO 20926 treat VAF/AFP as optional and often benchmark on **UFP**; if you
+carry AFP through, say so consistently.
+
+**Inspection prompt**
+> Size the application in function points, in two categories (Module 9.3b) and two
+> methods. (A) IFPUG for the SYSTEM: derive EI/EO/EQ/ILF/EIF counts (command
+> handlers, queries, reports, app-owned aggregates, external data sources —
+> document each basis), weight at average, estimate the 14 GSCs, compute
+> UFP → VAF → AFP. (B) Backfiring per category: System LOC → FP (cross-checks
+> IFPUG); DevOps/Test LOC → **equivalent FP** (its primary size), with a
+> sensitivity band and the physical-vs-logical caveat. Report: System
+> reconciliation (% divergence, agree within ±30%?), then **System FP + DevOps/Test
+> FP + Total** and the System LOC-per-FP ratio. Implement as a single-file C# `.csx`
+> and cite it.

--- a/.claude/skills/codebase-cartography-audit/references/12-economic-valuation.md
+++ b/.claude/skills/codebase-cartography-audit/references/12-economic-valuation.md
@@ -1,0 +1,141 @@
+# Module 12 — Economic Valuation (effort, cost, replacement value)
+
+Turn the function-point size (Module 11) into **effort (staff-months)**, a
+**build cost / replacement-investment range ($)**, and a **schedule sanity
+check** — so the audit can state what the software would cost to rebuild at
+market rates. This frames the maintainability debt in money: a system that costs
+$X to replace but is expensive to change has quantifiable technical debt.
+
+Be explicit about what this is: an **estimate of cost-to-build / replacement
+value**, derived from published productivity and salary research. It is **not** a
+business-value or market appraisal, and not a certified estimate. Present it as
+order-of-magnitude with an honest range.
+
+## 12.1 Effort — MULTIPLE productivity bands (Capers Jones + Steve McConnell)
+
+Effort = **Function Points ÷ productivity rate**. Productivity varies **more than
+10×** with project size, domain, ceremony, and team skill, so a single rate is
+misleading — always report a **band of several levels**, expressed in **FP per
+man-day** (convert with ~22 man-days/month, ~260 workdays/year). A defensible
+band uses **four levels from 0.5 → 3.0 FP/man-day**:
+
+Include a band row **at the full-lifecycle baseline** so the recommended headline
+is a row you can read off (not a rate outside the band):
+
+| FP/man-day | ≈ FP/staff-month | Level |
+|-----------:|-----------------:|-------|
+| 0.32 | ~7 | **Jones full-lifecycle baseline (recommended headline)** |
+| 0.50 | ~11 | below baseline (large / high-ceremony) |
+| 1.00 | ~22 | coding-centric / well-run |
+| 2.00 | ~44 | high-performing small team |
+| 3.00 | ~66 | elite / best-in-class small project |
+
+Citations (**put both in the report**):
+- **Capers Jones**, *"Software Economics and Function Point Metrics," IFPUG (2017)*;
+  *"Applied Software Measurement," 3rd ed.*: full-lifecycle average ≈ **7
+  FP/staff-month (~0.32 FP/day)**; coding-only ≈ 25 FP/month (~1.1 FP/day);
+  >10 FP/staff-month good, <7 poor, some Agile >15. Jones' *low end* for large /
+  high-compliance work is well below 7 FP/month, so treat 0.5 FP/day as "below
+  baseline," not Jones' floor.
+- **Steve McConnell**, *"Software Estimation: Demystifying the Black Art"*; *"Code
+  Complete"*: cite for the **order-of-magnitude productivity spread** by size/
+  domain/team (his central, well-supported claim). Do **not** attribute a "1 FP/day
+  nominal" figure to McConnell — he reports productivity in LOC/staff-month by
+  project size (ISBSG/Putnam), not FP/day; the ~1 FP/day figure is nearer Jones'
+  coding-only/agile rate.
+
+Tie the FP/day rates back to **LOC per man-day** using the measured LOC/FP from
+Module 11.4 (e.g. at ~56 LOC/FP, 0.32–3.0 FP/day ≈ 18–168 LOC/day). This makes the
+productivity assumption concrete and shows why "125 LOC/day vs 10 LOC/day" swings
+the cost by an order of magnitude. Apply every band to the System FP and the
+DevOps/Test FP separately (Module 11.0) — except the **0.32 full-lifecycle row**,
+where DevOps/Test is marked "n/a (in System)" in both the effort and cost tables
+(§12.2), because Jones' lifecycle rate already includes writing the system's tests.
+
+**Two anchors to call out explicitly**, because they differ ~3× and readers
+conflate them:
+- **Full-lifecycle replacement (recommended headline)** — Jones' 7 FP/staff-month
+  (0.32 FP/day) counts requirements→design→code→test→docs→PM.
+- **Coding-centric best case** — elite team, coding-dominated (~3 FP/day).
+
+## 12.2 Cost — median salary surveys × burden
+
+Fully-loaded monthly cost per engineer = **annual base salary × burden ÷ 12**
+(or day rate = annual × burden ÷ 260 workdays).
+
+- **Base salary:** use current medians from named surveys and cite each with its
+  figure and access date. Anchor on generalist-median sources (PayScale,
+  Salary.com) and a government source (US BLS software developer), and note the
+  higher aggregator numbers (Indeed, ZipRecruiter, Glassdoor) for range. Pick a
+  blended median base and say how you blended it. **Look these up live** (web
+  search) rather than hardcoding stale numbers — salaries move.
+- **Burden multiplier:** 1.4–2.0 fully-loaded (benefits, payroll tax, overhead,
+  facilities, tooling). Default **1.5× (lean)** to **1.75× (typical)**.
+
+Cost = effort × fully-loaded rate. Report cost **for every productivity band**
+(not a single trio) AND **split into the two categories from Module 9.3b —
+System, DevOps/Test, and Total** — using each category's FP subtotal (Module
+11.0). Each band row shows System $, DevOps/Test $, and Total $.
+
+**Avoid double-counting — and never present a full-lifecycle Total that sums both
+categories.** Capers Jones' full-lifecycle rate (7 FP/staff-month) *already
+includes writing the system's tests*. So:
+- The **System full-lifecycle figure is the recommended headline replacement
+  cost** (it already covers testing effort). Report it alone as the headline.
+- A per-band **Total column is coding-centric only** (each category sized as
+  separate code-production effort at that FP/day rate) — valid because at
+  coding rates the two bodies of code are distinct build efforts. Label the Total
+  column "coding-centric" so no one reads it as a lifecycle cost.
+- **Do NOT** compute a Total at the 0.32 full-lifecycle row by adding System +
+  DevOps/Test — that double-counts test-writing (it's already inside the System
+  lifecycle figure). At the 0.32 row, show the System headline and leave the
+  DevOps/Test full-lifecycle cell blank or marked "n/a (in System)".
+
+Then give the coding-centric best case and a single headline range.
+
+## 12.3 Schedule sanity check
+
+Capers Jones' rule of thumb: **calendar months ≈ FunctionPoints ^ exponent**,
+where the exponent rises with project class/ceremony — roughly **0.32** for small
+agile, **~0.4** mid-sized, up to **~0.45** for large military/systems work. Pick
+the exponent to match the audited system's class and state it. Implied **average
+team size = staff-months ÷ calendar months**. If the implied team is absurd (e.g.
+40 people for 500 FP), the effort estimate or the productivity rate is off —
+re-check. A plausible team shape validates the whole valuation.
+
+## 12.4 Implementation & honesty
+
+- Compute in a **single-file C# script** (`metrics/valuation.csx`, `dotnet-script`)
+  — the salary/burden/productivity matrix is exactly multi-variable logic C#
+  suits. Take FP (from Module 11), the productivity band, the salary figures, and
+  the burden band as inputs; print the effort table and a **per-band cost table
+  with System / DevOps-Test / Total columns** (not a single trio), the two anchors,
+  and the schedule check — as **ready-to-paste Markdown that the README embeds
+  verbatim** (do not re-summarize in prose).
+- **Do not price the DevOps/Test subtotal at full-lifecycle rates and also count
+  it inside the System headline** — the System full-lifecycle figure already
+  includes writing the system's tests. Price DevOps/Test with a coding-centric
+  rate, label it the more speculative figure, and keep the System full-lifecycle
+  number as the headline.
+- **Cite every external number** (Jones for productivity; each salary survey with
+  its value) so the estimate is auditable.
+- State the caveat: replacement cost, not market value; order-of-magnitude; and
+  that maintainability debt (the findings) makes *changing* the code cost more per
+  FP than a clean rebuild — which is the debt the audit quantifies.
+
+**Inspection prompt**
+> Using the Module 11 function-point size, estimate cost-to-build / replacement
+> value across MULTIPLE productivity bands. (1) Effort: man-days = FP ÷ FP-per-
+> man-day for a band of 0.32 / 0.5 / 1 / 2 / 3 FP/day incl. the 0.32 baseline row
+> (convert to man-months at ~22 days); cite Capers Jones ("Software Economics and
+> Function Point Metrics", IFPUG 2017; full-lifecycle ~7 FP/staff-month) AND Steve
+> McConnell ("Software Estimation") for the 10× productivity spread (not a 1 FP/day
+> figure); show the LOC/man-day equivalent from the measured LOC/FP. (2) Cost:
+> fully-loaded day rate = median base × burden (1.5–1.75×) ÷ 260; look up current
+> medians from PayScale, Salary.com, US BLS (+ note aggregators) and cite each;
+> give a cost row per band **split System / DevOps-Test / Total** (using the Module
+> 11.0 FP subtotals). (3) Two anchors: full-lifecycle (Jones baseline, recommended
+> headline = System figure) vs coding-centric best case; single headline range across
+> all bands. (4) Schedule check: calendar months ≈ FP^0.4 and implied team size.
+> Implement as a single-file C# `.csx`; state the replacement-cost (not market-
+> value) caveat.

--- a/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj
+++ b/src/ChurchBulletin.AppHost/ChurchBulletin.AppHost.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Pin transitive MessagePack (from Aspire SDK) above 2.5.192 to resolve NU1902/NU1903. -->
+    <PackageReference Include="MessagePack" Version="2.5.302" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\UI\Server\UI.Server.csproj" />
     <ProjectReference Include="..\Worker\Worker.csproj" />
   </ItemGroup>

--- a/src/DataAccess/DataAccess.csproj
+++ b/src/DataAccess/DataAccess.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="NServiceBus.Persistence.Sql.TransactionalSession" Version="8.3.0" />
+    <!-- Pin transitive SQLitePCLRaw above 2.1.11 to resolve NU1903 (GHSA-2m69-gcr7-jv3q). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
 	</ItemGroup>
 

--- a/src/McpServer/McpServer.csproj
+++ b/src/McpServer/McpServer.csproj
@@ -17,6 +17,8 @@
 		<PackageReference Include="MediatR" Version="12.4.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+		<!-- Pin transitive SQLitePCLRaw above 2.1.11 to resolve NU1903 (GHSA-2m69-gcr7-jv3q). -->
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />


### PR DESCRIPTION
Adds the `codebase-cartography-audit` skill (SKILL.md, PROMPT.md, and reference docs) to `.claude/skills/` so it is checked into the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)