### PR TITLE
Add voice input (speech-to-text dictation) for work order Title and D…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,11 +111,11 @@ DbUp scripts in `src/Database/scripts/Update/`, numbered sequentially (`###_Desc
 
 **UI.Server** — Lamar.Microsoft.DependencyInjection 15.0.1, Azure.Monitor.OpenTelemetry.AspNetCore 1.3.0, Microsoft.ApplicationInsights.AspNetCore 2.23.0, Microsoft.AspNetCore.Components.WebAssembly.Server 10.0.0, ModelContextProtocol 1.0.0, ModelContextProtocol.AspNetCore 1.0.0, NServiceBus.Extensions.Hosting 3.0.1, OpenTelemetry 1.12.0
 
-**UI.Client** — BlazorApplicationInsights 3.2.1, BlazorMvc 2.1.1, MediatR 12.4.1, Lamar.Microsoft.DependencyInjection 15.0.1, Microsoft.AspNetCore.Components.WebAssembly 10.0.0
+**UI.Client** — BlazorApplicationInsights 3.2.1, BlazorMvc 2.1.1, MediatR 12.4.1, Lamar.Microsoft.DependencyInjection 15.0.1, Microsoft.AspNetCore.Components.WebAssembly 10.0.0, Toolbelt.Blazor.SpeechRecognition 1.0.0, Toolbelt.Blazor.SpeechSynthesis 11.0.0
 
 **UI.Api** — Lamar.Microsoft.DependencyInjection 15.0.1
 
-**UI.Shared** — BlazorApplicationInsights 3.2.1, BlazorMvc 2.1.1, MediatR 12.4.1, Microsoft.ApplicationInsights 2.23.0, Microsoft.AspNetCore.Components.Authorization 10.0.0
+**UI.Shared** — BlazorApplicationInsights 3.2.1, BlazorMvc 2.1.1, MediatR 12.4.1, Microsoft.ApplicationInsights 2.23.0, Microsoft.AspNetCore.Components.Authorization 10.0.0, Toolbelt.Blazor.SpeechRecognition 1.0.0, Toolbelt.Blazor.SpeechSynthesis 11.0.0
 
 **LlmGateway** — Azure.AI.OpenAI 2.1.0, MediatR 12.4.1, Microsoft.Extensions.AI 9.7.0, Microsoft.Extensions.AI.OpenAI 9.7.1-preview.1.25365.4, Microsoft.Extensions.AI.Abstractions 9.7.1
 
@@ -127,7 +127,7 @@ DbUp scripts in `src/Database/scripts/Update/`, numbered sequentially (`###_Desc
 
 **ServiceDefaults** — Azure.Monitor.OpenTelemetry.AspNetCore 1.3.0, OpenTelemetry.Exporter.OpenTelemetryProtocol 1.12.0, OpenTelemetry.Extensions.Hosting 1.12.0, Microsoft.Extensions.Http.Resilience 9.9.0, Microsoft.Extensions.ServiceDiscovery 9.5.0
 
-**UnitTests** — NUnit 4.3.2, NUnit3TestAdapter 5.0.0, Shouldly 4.3.0, bunit 1.40.0, AutoBogus.Conventions 2.13.1, MediatR 12.4.1, coverlet.msbuild 6.0.4
+**UnitTests** — NUnit 4.3.2, NUnit3TestAdapter 5.0.0, Shouldly 4.3.0, bunit 1.40.0, AutoBogus.Conventions 2.13.1, MediatR 12.4.1, coverlet.msbuild 6.0.4, Toolbelt.Blazor.SpeechRecognition 1.0.0, Toolbelt.Blazor.SpeechSynthesis 11.0.0
 
 **IntegrationTests** — NUnit 4.3.2, NUnit3TestAdapter 5.0.0, Shouldly 4.3.0, Microsoft.EntityFrameworkCore 10.0.0, Microsoft.Extensions.Hosting 10.0.0, coverlet.msbuild 6.0.4
 

--- a/src/AcceptanceTests/WorkOrders/WorkOrderDictationTests.cs
+++ b/src/AcceptanceTests/WorkOrders/WorkOrderDictationTests.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+public class WorkOrderDictationTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldRenderDictateTitleButtonOnWorkOrderManagePage()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        var dictateTitleButton = Page.GetByTestId(nameof(WorkOrderManage.Elements.DictateTitle));
+        await Expect(dictateTitleButton).ToBeVisibleAsync();
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldRenderDictateDescriptionButtonOnWorkOrderManagePage()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        var dictateDescriptionButton = Page.GetByTestId(nameof(WorkOrderManage.Elements.DictateDescription));
+        await Expect(dictateDescriptionButton).ToBeVisibleAsync();
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldClickDictateTitleButtonWithoutError()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Click(nameof(WorkOrderManage.Elements.DictateTitle));
+
+        await Expect(Page).ToHaveURLAsync(new Regex("/workorder/manage/"));
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldClickDictateDescriptionButtonWithoutError()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Click(nameof(WorkOrderManage.Elements.DictateDescription));
+
+        await Expect(Page).ToHaveURLAsync(new Regex("/workorder/manage/"));
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldHideDictateButtonsOnReadOnlyWorkOrder()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order = await AssignExistingWorkOrder(order, CurrentUser.UserName);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order = await BeginExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        order = await CompleteExistingWorkOrder(order);
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.ReadOnlyMessage))).ToBeVisibleAsync();
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.SpeakTitle))).ToBeVisibleAsync();
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.DictateTitle))).ToBeHiddenAsync();
+        await Expect(Page.GetByTestId(nameof(WorkOrderManage.Elements.DictateDescription))).ToBeHiddenAsync();
+    }
+}

--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -46,6 +46,10 @@
                     <div>
                         <InputText data-testid="@Elements.Title" id="Title" @bind-Value="Model.Title" class="form-control input-text" disabled="@Model.IsReadOnly"/>
                         <button type="button" data-testid="@Elements.SpeakTitle" class="btn btn-sm btn-outline-secondary" aria-label="Speak title" title="Speak title" @onclick="SpeakTitleAsync">&#x1F50A;</button>
+                        @if (!Model.IsReadOnly)
+                        {
+                            <button type="button" data-testid="@Elements.DictateTitle" class="@DictateButtonClass(DictationTarget.Title)" aria-label="Dictate title" title="Dictate title" aria-pressed="@DictateAriaPressed(DictationTarget.Title)" @onclick="DictateTitleAsync">&#x1F3A4;</button>
+                        }
                     </div>
                 </div>
 
@@ -54,6 +58,10 @@
                     <div>
                         <InputTextArea data-testid="@Elements.Description" id="Description" @bind-Value="Model.Description" class="form-control input-textarea" disabled="@Model.IsReadOnly"/>
                         <button type="button" data-testid="@Elements.SpeakDescription" class="btn btn-sm btn-outline-secondary" aria-label="Speak description" title="Speak description" @onclick="SpeakDescriptionAsync">&#x1F50A;</button>
+                        @if (!Model.IsReadOnly)
+                        {
+                            <button type="button" data-testid="@Elements.DictateDescription" class="@DictateButtonClass(DictationTarget.Description)" aria-label="Dictate description" title="Dictate description" aria-pressed="@DictateAriaPressed(DictationTarget.Description)" @onclick="DictateDescriptionAsync">&#x1F3A4;</button>
+                        }
                     </div>
                 </div>
 
@@ -170,6 +178,8 @@
         AttachmentUploadedBy,
         AttachmentUploadedDate,
         SpeakTitle,
-        SpeakDescription
+        SpeakDescription,
+        DictateTitle,
+        DictateDescription
     }
 }

--- a/src/UI.Shared/Pages/WorkOrderManage.razor.cs
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor.cs
@@ -6,22 +6,26 @@ using ClearMeasure.Bootcamp.Core.Services.Impl;
 using ClearMeasure.Bootcamp.UI.Shared.Models;
 using Microsoft.AspNetCore.Components;
 using Palermo.BlazorMvc;
+using Microsoft.JSInterop;
 using System.Globalization;
+using Toolbelt.Blazor.SpeechRecognition;
 using Toolbelt.Blazor.SpeechSynthesis;
 
 namespace ClearMeasure.Bootcamp.UI.Shared.Pages;
 
 [Route("/workorder/manage/{id?}")]
-public partial class WorkOrderManage : AppComponentBase
+public partial class WorkOrderManage : AppComponentBase, IAsyncDisposable
 {
     private WorkOrder? _workOrder;
     private WorkOrderAttachment[] _attachments = [];
     private string _preferredLanguage = "en-US";
+    private DictationTarget _dictationTarget = DictationTarget.None;
     [Inject] public IWorkOrderBuilder? WorkOrderBuilder { get; set; }
     [Inject] public IUserSession? UserSession { get; set; }
     [Inject] private NavigationManager? NavigationManager { get; set; }
     [Inject] public ITranslationService? TranslationService { get; set; }
     [Inject] public SpeechSynthesis? SpeechSynthesis { get; set; }
+    [Inject] public SpeechRecognition? SpeechRecognition { get; set; }
 
     public WorkOrderManageModel Model { get; set; } = new();
     public List<SelectListItem> UserOptions { get; set; } = new();
@@ -35,6 +39,12 @@ public partial class WorkOrderManage : AppComponentBase
 
     protected override async Task OnInitializedAsync()
     {
+        if (SpeechRecognition != null)
+        {
+            SpeechRecognition.Result += OnSpeechResult;
+            SpeechRecognition.End += OnSpeechEnd;
+        }
+
         await LoadUserOptions();
         await LoadWorkOrder();
 
@@ -185,6 +195,131 @@ public partial class WorkOrderManage : AppComponentBase
         {
             // Speech synthesis may not be available in all environments
         }
+    }
+
+    private async Task DictateTitleAsync()
+    {
+        await ToggleDictationAsync(DictationTarget.Title);
+    }
+
+    private async Task DictateDescriptionAsync()
+    {
+        await ToggleDictationAsync(DictationTarget.Description);
+    }
+
+    private async Task ToggleDictationAsync(DictationTarget target)
+    {
+        if (SpeechRecognition == null)
+        {
+            return;
+        }
+
+        if (_dictationTarget == target)
+        {
+            _dictationTarget = DictationTarget.None;
+            try
+            {
+                await SpeechRecognition.StopAsync();
+            }
+            catch
+            {
+                // Speech recognition may not be available in all environments
+            }
+            return;
+        }
+
+        SpeechRecognition.Lang = _preferredLanguage;
+        SpeechRecognition.Continuous = false;
+        SpeechRecognition.InterimResults = false;
+        _dictationTarget = target;
+
+        try
+        {
+            await SpeechRecognition.StartAsync();
+        }
+        catch
+        {
+            // Speech recognition may not be available in all environments
+            _dictationTarget = DictationTarget.None;
+        }
+    }
+
+    private void OnSpeechResult(object? sender, SpeechRecognitionEventArgs args)
+    {
+        var transcripts = (args.Results ?? [])
+            .Skip(args.ResultIndex)
+            .Where(result => result.IsFinal)
+            .Select(result => result.Items?.FirstOrDefault()?.Transcript?.Trim())
+            .Where(transcript => !string.IsNullOrEmpty(transcript));
+        var transcript = string.Join(" ", transcripts);
+
+        if (string.IsNullOrEmpty(transcript))
+        {
+            return;
+        }
+
+        if (_dictationTarget == DictationTarget.Title)
+        {
+            Model.Title = AppendTranscript(Model.Title, transcript);
+        }
+        else if (_dictationTarget == DictationTarget.Description)
+        {
+            Model.Description = AppendTranscript(Model.Description, transcript);
+        }
+
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void OnSpeechEnd(object? sender, EventArgs e)
+    {
+        _dictationTarget = DictationTarget.None;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private static string AppendTranscript(string? existingText, string transcript)
+    {
+        return string.IsNullOrEmpty(existingText) ? transcript : $"{existingText} {transcript}";
+    }
+
+    private string DictateButtonClass(DictationTarget target)
+    {
+        return _dictationTarget == target ? "btn btn-sm btn-danger" : "btn btn-sm btn-outline-secondary";
+    }
+
+    private string DictateAriaPressed(DictationTarget target)
+    {
+        return _dictationTarget == target ? "true" : "false";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (SpeechRecognition == null)
+        {
+            return;
+        }
+
+        SpeechRecognition.Result -= OnSpeechResult;
+        SpeechRecognition.End -= OnSpeechEnd;
+
+        try
+        {
+            if (_dictationTarget != DictationTarget.None)
+            {
+                await SpeechRecognition.StopAsync();
+            }
+
+            await SpeechRecognition.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+    }
+
+    private enum DictationTarget
+    {
+        None,
+        Title,
+        Description
     }
 }
 

--- a/src/UI.Shared/UI.Shared.csproj
+++ b/src/UI.Shared/UI.Shared.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Toolbelt.Blazor.SpeechRecognition" Version="1.0.0" />
     <PackageReference Include="Toolbelt.Blazor.SpeechSynthesis" Version="11.0.0" />
 
   </ItemGroup>

--- a/src/UI/Client/Program.cs
+++ b/src/UI/Client/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddBlazorApplicationInsights(x =>
 // Add authentication services
 builder.Services.AddAuthorizationCore();
 builder.Services.AddSpeechSynthesis();
+builder.Services.AddSpeechRecognition();
 builder.ConfigureContainer<ServiceRegistry>(
     new LamarServiceProviderFactory(), registry =>
         registry.IncludeRegistry<UIClientServiceRegistry>());

--- a/src/UI/Client/UI.Client.csproj
+++ b/src/UI/Client/UI.Client.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
+    <PackageReference Include="Toolbelt.Blazor.SpeechRecognition" Version="1.0.0" />
     <PackageReference Include="Toolbelt.Blazor.SpeechSynthesis" Version="11.0.0" />
   </ItemGroup>
 

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageAttachmentsTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageAttachmentsTests.cs
@@ -48,6 +48,7 @@ public class WorkOrderManageAttachmentsTests
         ctx.Services.AddSingleton<IUserSession>(new StubUserSession(uploader));
         ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
         ctx.Services.AddSpeechSynthesis();
+        ctx.Services.AddSpeechRecognition();
 
         var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageDictationTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageDictationTests.cs
@@ -1,0 +1,307 @@
+using Bunit;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using MediatR;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Palermo.BlazorMvc;
+using Shouldly;
+using Toolbelt.Blazor.Extensions.DependencyInjection;
+using Toolbelt.Blazor.SpeechRecognition;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
+
+[TestFixture]
+public class WorkOrderManageDictationTests
+{
+    [Test]
+    public void ShouldRenderDictateTitleButton()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']");
+            element.ShouldNotBeNull();
+            element.TagName.ShouldBe("BUTTON", StringCompareShould.IgnoreCase);
+            element.GetAttribute("type").ShouldBe("button");
+            element.GetAttribute("aria-pressed").ShouldBe("false");
+        });
+    }
+
+    [Test]
+    public void ShouldRenderDictateDescriptionButton()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateDescription}']");
+            element.ShouldNotBeNull();
+            element.TagName.ShouldBe("BUTTON", StringCompareShould.IgnoreCase);
+            element.GetAttribute("type").ShouldBe("button");
+            element.GetAttribute("aria-pressed").ShouldBe("false");
+        });
+    }
+
+    [Test]
+    public void DictateTitleButtonShouldShowListeningStateWhenClicked()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        var dictateButton = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']");
+        dictateButton.Click();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']");
+            element.GetAttribute("aria-pressed").ShouldBe("true");
+            element.GetAttribute("class").ShouldNotBeNull().ShouldContain("btn-danger");
+        });
+
+        component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']").Click();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']");
+            element.GetAttribute("aria-pressed").ShouldBe("false");
+            element.GetAttribute("class").ShouldNotBeNull().ShouldContain("btn-outline-secondary");
+        });
+    }
+
+    [Test]
+    public async Task ShouldAppendFinalTranscriptToTitleWhenDictating()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']").Click();
+        await component.InvokeAsync(() =>
+            component.Instance.SpeechRecognition!._OnResult(CreateFinalResult("broken window")));
+
+        component.WaitForAssertion(() =>
+        {
+            component.Instance.Model.Title.ShouldBe("Test title broken window");
+        });
+    }
+
+    [Test]
+    public async Task ShouldSetDescriptionFromTranscriptWhenFieldIsEmpty()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.Find($"[data-testid='{WorkOrderManage.Elements.DictateDescription}']").Click();
+        await component.InvokeAsync(() =>
+            component.Instance.SpeechRecognition!._OnResult(CreateFinalResult("broken window")));
+
+        component.WaitForAssertion(() =>
+        {
+            component.Instance.Model.Description.ShouldBe("broken window");
+        });
+    }
+
+    [Test]
+    public async Task ShouldIgnoreInterimResultsWhenDictating()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']").Click();
+        var interimResult = new SpeechRecognitionEventArgs
+        {
+            ResultIndex = 0,
+            Results =
+            [
+                new SpeechRecognitionResult
+                {
+                    IsFinal = false,
+                    Items = [new SpeechRecognitionAlternative { Transcript = "broken window", Confidence = 0.5 }]
+                }
+            ]
+        };
+        await component.InvokeAsync(() =>
+            component.Instance.SpeechRecognition!._OnResult(interimResult));
+
+        component.WaitForAssertion(() =>
+        {
+            component.Instance.Model.Title.ShouldBe("Test title");
+        });
+    }
+
+    [Test]
+    public async Task ShouldResetListeningStateWhenRecognitionEnds()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']").Click();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']");
+            element.GetAttribute("aria-pressed").ShouldBe("true");
+        });
+
+        await component.InvokeAsync(() => component.Instance.SpeechRecognition!._OnEnd());
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']");
+            element.GetAttribute("aria-pressed").ShouldBe("false");
+        });
+    }
+
+    [Test]
+    public void ShouldHideDictateButtonsWhenWorkOrderIsReadOnly()
+    {
+        using var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var user = new Employee("jpalermo", "Jeffrey", "Palermo", "jp@example.com");
+        user.Id = Guid.NewGuid();
+
+        var creator = new Employee("someoneelse", "Someone", "Else", "se@example.com");
+        creator.Id = Guid.NewGuid();
+
+        var completedWorkOrder = new WorkOrder
+        {
+            Id = Guid.NewGuid(),
+            Number = "WO-DONE",
+            Status = WorkOrderStatus.Complete,
+            Creator = creator,
+            Assignee = creator,
+            Title = "Completed work order"
+        };
+
+        ctx.Services.AddSingleton<IBus>(new StubBus(completedWorkOrder));
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IWorkOrderBuilder>(new StubWorkOrderBuilder());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
+        ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
+        ctx.Services.AddSpeechSynthesis();
+        ctx.Services.AddSpeechRecognition();
+
+        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "Edit"));
+
+        var component = ctx.RenderComponent<WorkOrderManage>(parameters =>
+            parameters.Add(p => p.Id, "WO-DONE"));
+
+        component.WaitForAssertion(() =>
+        {
+            component.Find($"[data-testid='{WorkOrderManage.Elements.SpeakTitle}']").ShouldNotBeNull();
+            component.FindAll($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']").ShouldBeEmpty();
+            component.FindAll($"[data-testid='{WorkOrderManage.Elements.DictateDescription}']").ShouldBeEmpty();
+        });
+    }
+
+    private static TestContext CreateTestContext(out Employee user)
+    {
+        var ctx = new TestContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        user = new Employee("jpalermo", "Jeffrey", "Palermo", "jp@example.com");
+        user.Id = Guid.NewGuid();
+        user.PreferredLanguage = "es-ES";
+
+        ctx.Services.AddSingleton<IBus>(new StubBus(null));
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IWorkOrderBuilder>(new StubWorkOrderBuilder());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
+        ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
+        ctx.Services.AddSpeechSynthesis();
+        ctx.Services.AddSpeechRecognition();
+
+        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
+
+        return ctx;
+    }
+
+    private static SpeechRecognitionEventArgs CreateFinalResult(string transcript)
+    {
+        return new SpeechRecognitionEventArgs
+        {
+            ResultIndex = 0,
+            Results =
+            [
+                new SpeechRecognitionResult
+                {
+                    IsFinal = true,
+                    Items = [new SpeechRecognitionAlternative { Transcript = transcript, Confidence = 0.9 }]
+                }
+            ]
+        };
+    }
+
+    private class StubBus(WorkOrder? workOrderByNumber) : Bus(null!)
+    {
+        public override Task Publish(INotification notification) => Task.CompletedTask;
+
+        public override Task<TResponse> Send<TResponse>(IRequest<TResponse> request)
+        {
+            if (request is EmployeeGetAllQuery)
+            {
+                var employees = Array.Empty<Employee>();
+                return Task.FromResult<TResponse>((TResponse)(object)employees);
+            }
+
+            if (request is WorkOrderAttachmentsQuery)
+            {
+                var attachments = Array.Empty<WorkOrderAttachment>();
+                return Task.FromResult<TResponse>((TResponse)(object)attachments);
+            }
+
+            if (request is WorkOrderByNumberQuery && workOrderByNumber != null)
+            {
+                return Task.FromResult<TResponse>((TResponse)(object)workOrderByNumber);
+            }
+
+            throw new NotImplementedException($"Unhandled request type: {request.GetType().Name}");
+        }
+    }
+
+    private class StubWorkOrderBuilder : IWorkOrderBuilder
+    {
+        public WorkOrder CreateNewWorkOrder(Employee creator)
+        {
+            return new WorkOrder
+            {
+                Id = Guid.NewGuid(),
+                Number = "WO-TEST",
+                Status = WorkOrderStatus.Draft,
+                Creator = creator,
+                Title = "Test title"
+            };
+        }
+    }
+
+    private class StubUserSession(Employee user) : IUserSession
+    {
+        public Task<Employee?> GetCurrentUserAsync() => Task.FromResult<Employee?>(user);
+    }
+
+    private class StubTranslationService : ITranslationService
+    {
+        public Task<string> TranslateAsync(string text, string targetLanguageCode)
+        {
+            return Task.FromResult(text);
+        }
+    }
+}

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageSpeechTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageSpeechTests.cs
@@ -33,6 +33,7 @@ public class WorkOrderManageSpeechTests
         ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
         ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
         ctx.Services.AddSpeechSynthesis();
+        ctx.Services.AddSpeechRecognition();
 
         var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
@@ -62,6 +63,7 @@ public class WorkOrderManageSpeechTests
         ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
         ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
         ctx.Services.AddSpeechSynthesis();
+        ctx.Services.AddSpeechRecognition();
 
         var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
@@ -94,6 +96,7 @@ public class WorkOrderManageSpeechTests
         ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
         ctx.Services.AddSingleton<ITranslationService>(translationService);
         ctx.Services.AddSpeechSynthesis();
+        ctx.Services.AddSpeechRecognition();
 
         var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -48,6 +48,7 @@
 		<PackageReference Include="bunit" Version="1.40.0" />
 		<PackageReference Include="MediatR" Version="12.4.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+		<PackageReference Include="Toolbelt.Blazor.SpeechRecognition" Version="1.0.0" />
 		<PackageReference Include="Toolbelt.Blazor.SpeechSynthesis" Version="11.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
…escription

Mic buttons next to the Title and Description fields on the work order manage page use the browser SpeechRecognition API (via Toolbelt.Blazor.SpeechRecognition 1.0.0, sibling of the existing SpeechSynthesis package) to append dictated text in the employee's preferred language. Buttons toggle a listening state (red while active, aria-pressed for accessibility), auto-reset when recognition ends, and are hidden on read-only work orders. Final transcripts append with a space separator; interim results are ignored. Unsupported browsers get a silent no-op, matching the existing TTS behavior.

Includes 8 bUnit tests (simulating recognition via the package's JSInvokable seams) and 5 Playwright acceptance tests.

Submitter checklist
- [ ] Issue is clearly tagged
- [ ] Narrate status of the branch (feature complete, incremental build, etc)
- [ ] You expect the approval checklist to be satisfied

==========================
Approver checklist
- [ ] Issue is clearly tagged
- [ ] Build and all test suites passing
- [ ] Static analysis ran and passed
- [ ] All changes delivered with accompanying tests
- [ ] Changes to libraries/dependencies expected and pre-approved
- [ ] Team coding standard adhered to
- [ ] Another item
- [ ] Another item