### PR TITLE
Make Octopus publish check non-blocking for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -532,7 +532,13 @@ jobs:
   publish-octopus:
     name: Publish to Octopus Deploy
     needs: [build-linux]
-    if: success()
+    # Only publish to Octopus from the default branch. Deployments (deploy.yml)
+    # only ever run from master, so PR/feature-branch builds do not need Octopus
+    # packages. Scoping this here keeps the job off PR branches so it is never a
+    # blocking check for a pull request.
+    if: success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    # Non-fatal: an Octopus publishing failure must not fail the overall build.
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
The **Publish to Octopus Deploy** job in `build.yml` ran on every push, including PR feature branches, and surfaced as a failing/blocking check on pull requests.

Octopus packages are consumed exclusively by `deploy.yml`, which triggers only from `master`. PR/feature-branch builds therefore never need Octopus packages.

## Change
- Scope `publish-octopus` to the default branch only: `if: success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')`. The job no longer runs on PR branches, so it can no longer appear as a blocking check on a PR.
- Add `continue-on-error: true` so an Octopus publishing hiccup does not fail the master build either.

## Notes
- No active branch/ruleset required-status-check references this job, so no ruleset change is required.
- No application code touched; CI-only change. No module boundary crossed — no automated test layer applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)