### PR TITLE
Add k6-load-testing skill

### DIFF
--- a/.claude/skills/k6-load-testing/PROMPT.md
+++ b/.claude/skills/k6-load-testing/PROMPT.md
@@ -1,0 +1,75 @@
+# Portable k6-Load-Testing Prompt (standalone)
+
+Paste into any capable coding-agent session when you can't load the skill. It
+compresses the full pipeline: inventory → environment → script → run → analyze →
+report (+ CI gate).
+
+---
+
+You are performing a **k6 load and performance test** of an application's HTTP
+surface. Produce a **self-contained report directory** (`k6-load-report/` with
+`README.md` and `metrics/`) that measures latency and throughput against
+threshold-encoded SLOs, with every claim citing a saved k6 run and a concrete
+metric. Put generated scripts in a `k6/` directory. Install k6 as a standalone
+binary — do not mutate the target repo to obtain it.
+
+**Output-fidelity rules (do not skip):** (a) Every result cites a saved
+`metrics/*.json` run with the exact command and `k6 version` — never "seems fast"
+without the number. (b) A 429 from a rate limiter working as configured is
+designed back-pressure, NOT a failure — state whether the limiter was on and
+categorize 429s separately from `http_req_failed`. (c) Never load-test a deployed
+environment or a real database without explicit opt-in; default to a local app
+and a throwaway DB, and never pollute shared data with write load. (d) Run smoke
+with status/body `checks` first — a fast 500 is not a pass. (e) Use an open-model
+arrival-rate executor for any capacity/throughput claim and say so; closed-model
+VUs understate latency (coordinated omission). (f) Interpret numbers against the
+target's own limits (rate-limit ceiling, request timeout, un-throttled paths).
+(g) Discard or annotate cold-start iterations so warm-up doesn't skew p99.
+
+Run this ordered pipeline:
+
+1. **Scope & inventory.** Confirm the target (default local; deployed only on
+   explicit opt-in). Enumerate every load-testable endpoint with its method,
+   route, auth requirement (header name + config), rate-limit behaviour, and
+   request/response payload shape. Choose the profiles and SLOs. Create the
+   `k6-load-report/` + `metrics/` + `k6/` skeleton.
+2. **Environment prep.** Bring the target up reproducibly: throwaway DB,
+   background jobs/agents off, seed data applied. Decide the rate-limiter state
+   deliberately and set SLOs to match. Health-gate before any load.
+3. **Author baseline scripts.** k6 scripts for the cheap read endpoints, each
+   with a correctness `check` and thresholds (`http_req_duration` p95/p99,
+   `http_req_failed` rate, `checks` rate). Drive all profiles from one script via
+   a `PROFILE` env var and pick executors per profile (open-model for capacity).
+4. **Author domain-load scripts.** Scripts for the realistic write/read paths
+   (correct payload envelope, valid seeded identifiers, auth header). Keep write
+   load pointed at the throwaway DB.
+5. **Rate-limit handling.** Add a 429 carve-out (custom `Rate` for real errors vs
+   designed throttling); when validating the limiter, enable it, keep one
+   partition, drive past the ceiling, and assert the expected 429 shape + headers.
+6. **Run staged profiles.** Smoke → average load → stress → spike (breakpoint/soak
+   only if requested). Save a summary JSON per profile to `metrics/`; record the
+   command and k6 version.
+7. **Analyze.** Read percentiles/throughput vs SLOs, separate 429s from real
+   failures, identify the bottleneck, classify severity (Critical: breach under
+   smoke/nominal or no spike recovery; High: p95 breach under expected load;
+   Medium: only-under-stress degradation; Low: soak/cold-start/marginal).
+8. **Standards & budgets.** Derive SLO budgets from the measured smoke baseline
+   and the reliability target (don't invent round numbers); cite Grafana k6
+   guidance, Google SRE error budgets, and HTTP 429 semantics.
+9. **CI gate (if on a pipeline).** Under GitHub Actions, append a per-profile
+   table to `$GITHUB_STEP_SUMMARY`, upload `k6-load-report/` as an artifact, and
+   let k6's threshold-driven non-zero exit fail the job. Surface the workflow as
+   an opt-in snippet; do not auto-commit pipeline files.
+10. **Assemble the report.** Write `k6-load-report/README.md`: how-to-reproduce,
+    executive summary, endpoint inventory, per-profile result tables, findings by
+    severity, and the sequenced remediation backlog.
+
+**Self-check before delivering:** (i) every number traces to a saved run with
+its command + k6 version; (ii) smoke passed correctness before any scaled
+profile; (iii) capacity claims used an open-model executor and say so; (iv)
+designed 429s are separated from failures; (v) nothing hit a deployed env or real
+DB without opt-in; (vi) the environment (DB, limiter state, warm-up) is stated so
+the run reproduces.
+
+Deliver the path to the finished report directory and a short summary of the
+worst findings.

--- a/.claude/skills/k6-load-testing/SKILL.md
+++ b/.claude/skills/k6-load-testing/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: k6-load-testing
+description: >-
+  Full load and performance test of an application's HTTP surface using Grafana
+  k6. Produces a self-contained report directory covering: an inventory of every
+  load-testable endpoint (open diagnostics GETs, auth-gated reads, and the domain
+  write paths) with the auth header, rate-limit ceiling, and payload envelope each
+  requires; generated k6 scripts with correctness checks and threshold-encoded
+  SLOs, run across staged profiles (smoke, average load, stress, spike, and
+  optionally breakpoint/soak) using the right open- or closed-model executor;
+  results captured as raw k6 summary JSON and rolled up into per-profile latency
+  (p50/p95/p99), throughput (RPS), error-rate and checks tables; a severity-ranked
+  set of findings each citing the exact k6 run, metric, and governing standard
+  (Grafana k6 guidance, Google SRE error budgets, HTTP 429 semantics); explicit
+  separation of designed rate-limiter back-pressure (429) from real failures; and,
+  when run inside a GitHub Actions pipeline, a job-summary table, an uploaded
+  report artifact, and a threshold-gated non-zero exit that fails the job on an
+  SLO breach. Use when performance-testing an API before a release or capacity
+  review, validating a rate limiter or autoscaling behaviour, establishing a
+  latency/throughput baseline, or wiring load testing into CI.
+---
+
+# k6 Load Testing
+
+A focused sibling of `codebase-cartography-audit` and `cryptography-audit`:
+instead of mapping architecture or auditing crypto, this skill exercises a
+running application under load with Grafana k6, measures latency and throughput
+against threshold-encoded SLOs, and produces a sequenced performance backlog.
+
+Deliverable: a new directory (default `./k6-load-report/`) containing
+`README.md` (the report) and `metrics/` (raw k6 summary JSON per profile, plus
+the `k6 version` used). A working `k6/` directory holds the generated scripts.
+Every claim cites a saved k6 run and a concrete metric — no "seems fast" without
+the p95 and the run it came from.
+
+## When to use this
+
+- Performance-testing an application's API before a release, a capacity review,
+  or a customer load/SLA commitment.
+- Validating a rate limiter, request-timeout, or autoscaling policy behaves as
+  designed under sustained and bursty traffic.
+- Establishing a latency/throughput baseline for an endpoint so future
+  regressions are measurable (especially AI-generated code, which rarely has any
+  performance characterization).
+- Wiring load testing into CI so an SLO breach fails the build rather than being
+  discovered in production.
+
+## The inspection catalogue
+
+| # | Module | File | Focus |
+|---|--------|------|-------|
+| 1 | Test types & load profiles | `references/01-test-types-and-profiles.md` | Grafana k6 test types; executors; open vs closed |
+| 2 | Thresholds & SLOs | `references/02-thresholds-and-slos.md` | k6 thresholds; SRE error/latency budgets; CI gate |
+| 3 | Scripting this app | `references/03-scripting-this-app.md` | endpoint inventory; X-Api-Key; WebServiceMessage; multipart |
+| 4 | Rate limiting & back-pressure | `references/04-rate-limiting-and-backpressure.md` | 100/60s window; 429 vs real failure |
+| 5 | Environment & data setup | `references/05-environment-and-data-setup.md` | throwaway SQLite; seed data; warm-up |
+| 6 | Metrics, results & reporting | `references/06-metrics-results-reporting.md` | built-in/custom metrics; summary JSON |
+| 7 | CI integration (GitHub Actions) | `references/07-ci-github-actions.md` | job summary; artifact; threshold-gated exit |
+| 8 | Standards & targets mapping | `references/08-standards-and-targets-mapping.md` | SLO budgets; k6/SRE citations; severity |
+
+## How to run the load test (ordered pipeline)
+
+1. **Scope & inventory.** Confirm the target (default the local app at
+   `https://localhost:7174`; the deployed environment is an explicit opt-in
+   only). Enumerate the load-testable endpoints and their auth/rate-limit/payload
+   shape (Module 3), and choose the profiles and SLOs to run (Modules 1–2, 8).
+   Install k6 as a standalone binary — **never mutate the target repo** to get
+   it. Create the **self-contained** report directory skeleton
+   (`k6-load-report/` with `metrics/`) plus a working `k6/` scripts directory.
+
+2. **Environment prep.** Bring the target up reproducibly (Module 5): local app
+   against a **throwaway SQLite DB** (`ConnectionStrings__SqlConnectionString="Data Source=loadtest.db"`),
+   background AI agent off (`DISABLE_AUTO_REFORMAT_AGENT=true`), seed data applied
+   via `Build`. Decide deliberately whether the rate limiter is on and set SLOs to
+   match (Module 4). Health-gate on `/_healthcheck` and confirm `/api/ping` → `pong`
+   before any load.
+
+3. **Author scripts.** Generate parameterized k6 scripts (Module 3): baseline
+   GETs for latency/throughput, and the domain write path (`bulk-import` /
+   `blazor-wasm-single-api`) for realistic DB load. Every request carries a
+   correctness `check`; every script carries threshold-encoded SLOs (Module 2)
+   and a 429 carve-out where the limiter applies (Module 4). Drive all profiles
+   from one script via a `PROFILE` env var.
+
+4. **Run staged profiles.** Smoke first (correctness gate) → average load →
+   stress → spike (→ breakpoint/soak only if explicitly requested). Use the
+   open-model arrival-rate executor for any capacity/throughput claim (Module 1).
+   Save a raw summary JSON per profile into `metrics/` and record the `k6 version`
+   and exact command (Module 6). Run stress/spike against a deployed environment
+   only with explicit opt-in.
+
+5. **Analyze results.** Separate real failures from designed 429s (Module 4),
+   read latency percentiles and throughput against the SLOs, identify the
+   bottleneck (DB, limiter, cold start, contention), and classify each finding's
+   severity per Module 8. Distinguish "the limiter did its job" from "the app
+   fell over."
+
+6. **CI integration (when on a pipeline).** When running under GitHub Actions
+   (`$GITHUB_ACTIONS`/`$CI`), append a per-profile results table to
+   `$GITHUB_STEP_SUMMARY`, upload `k6-load-report/` as an artifact, and let k6's
+   threshold-driven non-zero exit fail the job (Module 7). The workflow file is
+   surfaced as an opt-in snippet — **not auto-committed** (pipeline files need
+   approval per `CLAUDE.md`).
+
+7. **Assemble the report.** Write `k6-load-report/README.md`: how-to-reproduce,
+   executive summary, endpoint inventory, per-profile results tables, findings
+   sorted by severity, and the sequenced remediation backlog. **Self-check before
+   delivering** — any missing item means the run is not done: (i) every reported
+   number traces to a saved `metrics/*.json` run with the command and k6 version;
+   (ii) smoke passed its correctness checks before any scaled profile ran; (iii)
+   capacity/throughput claims used an open-model executor and say so; (iv)
+   designed 429s are categorized separately and not counted as failures; (v)
+   nothing was run against a deployed environment or a real DB without explicit
+   opt-in; (vi) the environment (DB, limiter state, warm-up) is stated so the run
+   is reproducible.
+
+## Finding format (required for every result)
+
+```
+### [SEVERITY] <profile> — <endpoint(s)>
+- **Module:** <e.g. Module 4 — Rate Limiting & Back-Pressure>
+- **Profile / executor:** <e.g. ramping-arrival-rate, 0→200 RPS over 2m>
+- **Command:** <the exact `k6 run …` invocation — reproducible>
+- **Metrics:** <p50/p95/p99 http_req_duration; RPS; error rate; checks%>
+- **Threshold verdict:** <pass/fail against the stated SLO, with the numbers>
+- **Bottleneck / why:** <what the numbers indicate — DB, rate limiter, cold start…>
+- **Recommendation:** <the specific fix or follow-up>
+- **Evidence:** metrics/<run>.json
+```
+
+## Report structure (`k6-load-report/README.md`)
+
+1. **Title + how-to-reproduce** — target, k6 version, environment (DB, limiter
+   state, warm-up), and the exact commands, so every result can be regenerated.
+2. **Executive summary** — overall performance posture, the headline
+   latency/throughput/error numbers, 3–5 systemic issues, single
+   highest-leverage fix.
+3. **Inventory** — the load-testable endpoints and the auth/rate-limit/payload
+   shape of each (Module 3).
+4. **Per-profile results** — smoke/load/stress/spike tables (p50/p95/p99, RPS,
+   error rate, checks%, threshold verdict).
+5. **Prioritized findings** — sorted by severity, using the finding format.
+6. **Standards & severity mapping** — the SLO derivation and citations from
+   Module 8, annotated with which findings map to which control/budget.
+7. **Remediation backlog** — sequenced, flagging fixes that need a config change,
+   an infra change, or coordinated capacity planning.
+
+## Output fidelity rules (avoid these common LLM failure modes)
+
+1. **Every result cites a saved k6 run**, with the real metric numbers from
+   `metrics/*.json` — never "seems fast" or a number with no run behind it.
+2. **Distinguish designed back-pressure from real failure.** A 429 from the rate
+   limiter working as configured is not a defect; state whether the limiter was
+   on and categorize 429s separately from `http_req_failed`.
+3. **Never load-test a deployed environment or a real database without explicit
+   opt-in.** Default to the local app + a throwaway SQLite DB; never pollute a
+   shared/real DB with `bulk-import` or command writes.
+4. **Smoke and correctness before scale.** Run smoke with status/body `checks`
+   first — a fast 500 is not a pass, and scaling a broken endpoint measures
+   nothing.
+5. **Use an open-model executor for capacity/throughput claims and say which.**
+   Closed-model VUs understate latency under load (coordinated omission).
+6. **Interpret numbers against the target's own limits** — the 100/60s rate-limit
+   ceiling, the request timeout, and the un-throttled single-api path — so a
+   plateau isn't mistaken for max capacity.
+7. **Discard or annotate cold-start iterations** (.NET JIT + first-request cost)
+   so a warm-up spike doesn't distort p99.
+
+## Guiding stance
+
+- **Evidence over vibes.** Every number comes from a saved k6 run; every SLO
+  claim cites the governing k6/SRE guidance and the metric.
+- **Smoke before scale.** Correctness checks gate the run before any latency or
+  throughput claim.
+- **Model the client honestly.** Open vs closed executor is a deliberate choice,
+  stated in the report — capacity claims are open-model only.
+- **Respect the target.** Local app + throwaway DB by default; the deployed
+  environment and destructive write load are explicit opt-ins.
+- **Thresholds are the contract.** A run's verdict is threshold pass/fail with a
+  non-zero exit gating CI, not prose.
+- **k6 JS is tool input, not a repo helper.** Any results post-processing is a
+  single-file C# script (`.csx` via `dotnet-script`) to match the repo's
+  .NET-only toolchain — never Python/PowerShell for analysis logic.
+
+See `PROMPT.md` for a portable single-paste version of this whole pipeline.

--- a/.claude/skills/k6-load-testing/references/01-test-types-and-profiles.md
+++ b/.claude/skills/k6-load-testing/references/01-test-types-and-profiles.md
@@ -1,0 +1,55 @@
+# Module 1 — Test Types & Load Profiles
+
+Standards: Grafana k6 Test Types (smoke/average/stress/spike/breakpoint/soak),
+k6 Scenarios & Executors reference, closed-vs-open workload modelling.
+
+## The load profiles to run
+
+| Profile | What it answers | Shape | k6 executor |
+|---|---|---|---|
+| Smoke | Does the system work at all under minimal load? (correctness gate) | 1–5 VUs, 30s–1m | `constant-vus` |
+| Average load | How does it behave under normal expected traffic? | ramp to expected RPS, hold ~5–10m | `ramping-arrival-rate` |
+| Stress | Where does it degrade beyond normal peaks? | ramp past expected to 2–4× | `ramping-arrival-rate` |
+| Spike | Does a sudden surge break it, and does it recover? | jump to a high RPS for a short burst, drop back | `ramping-arrival-rate` (steep stages) |
+| Breakpoint | At what exact RPS does it fall over? | slow open-ended ramp until thresholds fail (`abortOnFail`) | `ramping-arrival-rate` |
+| Soak | Do leaks/degradation appear over hours? | modest RPS held 1h+ | `constant-arrival-rate` |
+
+Always run **smoke first**; only proceed to load/stress/spike once smoke passes
+its correctness checks. Soak and breakpoint are optional and opt-in (long/costly).
+
+## Closed vs open workload model (pick deliberately, state which)
+
+| Model | k6 executors | Behaviour | Use for |
+|---|---|---|---|
+| Closed | `constant-vus`, `ramping-vus`, `per-vu-iterations`, `shared-iterations` | A fixed number of VUs; each waits for the previous request before sending the next. Throughput is *bounded by response time* — if the server slows, offered load drops. | Reproducing a fixed-concurrency client (e.g. N browsers). |
+| Open | `constant-arrival-rate`, `ramping-arrival-rate` | Requests arrive at a target *rate* regardless of how fast the server responds; k6 allocates VUs to keep the rate. | Any capacity/throughput/latency claim — this is what real internet traffic looks like. |
+
+**Capacity and latency claims must use an open model.** Closed-model VUs suffer
+*coordinated omission*: when the server stalls, the client stops sending, so the
+slow requests are never counted and p99 looks artificially good.
+
+## What "good" looks like
+
+- One k6 script per logical target (baseline GETs; domain write path), with
+  `scenarios` selected by an `env` var (`PROFILE=smoke|load|stress|spike`) so a
+  single script drives every profile — no copy-paste per profile.
+- `ramping-arrival-rate` with an explicit `preAllocatedVUs` and `maxVUs` sized
+  above the target rate ÷ expected-latency, so k6 never starves itself of VUs
+  (a "insufficient VUs" warning invalidates the run).
+- Each profile's stages documented in the report so the run is reproducible.
+- A short warm-up stage (or discarded first iterations) before measurement —
+  see Module 5 for the .NET cold-start caveat.
+
+## Detection commands
+
+```
+# List scenarios/executors available and validate a script without load:
+k6 inspect k6/baseline.js
+
+# Drive a profile by env var (script defines scenarios keyed on __ENV.PROFILE):
+PROFILE=smoke k6 run k6/baseline.js
+PROFILE=load  k6 run k6/baseline.js
+```
+
+Cross-reference Module 2 for the thresholds each profile is gated on, and
+Module 5 for warm-up / environment setup that keeps the profile honest.

--- a/.claude/skills/k6-load-testing/references/02-thresholds-and-slos.md
+++ b/.claude/skills/k6-load-testing/references/02-thresholds-and-slos.md
@@ -1,0 +1,58 @@
+# Module 2 — Thresholds & SLOs
+
+Standards: Grafana k6 Thresholds reference, Google SRE Workbook (SLIs/SLOs,
+latency & error budgets), k6 exit-code semantics (thresholds → non-zero exit).
+
+## Anti-patterns to hunt
+
+| Pattern | Why it hurts | Evidence to look for |
+|---|---|---|
+| No `thresholds` block at all | The run has no pass/fail verdict — it can't gate CI, and "looks fine" is not a result | `options` with `scenarios` but no `thresholds` key |
+| Threshold only on the average (`avg`), not a percentile | Averages hide tail latency; a p99 of 5s can sit behind a 200ms average | `http_req_duration: ['avg<...']` with no `p(95)`/`p(99)` |
+| `http_req_failed` counting designed 429s as failures | Rate-limiter back-pressure (429) inflates the error rate and fails a healthy run | a failure threshold with no carve-out for expected 429 (see Module 4) |
+| Thresholds present but not gating (results ignored, exit code unchecked) | CI goes green while SLOs are breached | `k6 run` whose exit code is discarded; no `abortOnFail` on the breakpoint run |
+| One global SLO reused for every profile | Smoke and spike have different acceptable latencies; a single budget is either too loose for smoke or too strict for spike | identical `thresholds` regardless of `PROFILE` |
+
+## What "good" looks like
+
+- Thresholds expressed as the SLO contract, gating the run's exit code:
+  ```js
+  export const options = {
+    thresholds: {
+      http_req_duration: ['p(95)<500', 'p(99)<1000'],   // latency budget
+      http_req_failed:   ['rate<0.01'],                  // <1% real errors
+      checks:            ['rate>0.99'],                  // correctness
+      // abortOnFail for breakpoint runs so k6 stops at the breaking point:
+      // http_req_duration: [{ threshold: 'p(95)<500', abortOnFail: true }],
+    },
+  };
+  ```
+- **Per-profile budgets**, tightest on smoke (system idle, no excuse for slow),
+  looser under stress/spike (degradation is expected, collapse is not):
+
+  | Profile | p95 budget | error budget | note |
+  |---|---|---|---|
+  | Smoke | p95 < 300ms | rate < 0.001 | correctness gate; a fast 500 still fails `checks` |
+  | Average load | p95 < 500ms, p99 < 1s | rate < 0.01 | the real SLO |
+  | Stress | p95 < 2s | rate < 0.05 | degrade, don't collapse |
+  | Spike | recovers within N s after burst | rate < 0.10 during burst | recovery matters more than peak |
+
+  (Tune the numbers to the target's measured baseline — see Module 8 for how to
+  set them; do not copy these verbatim as if measured.)
+- A dedicated `Rate` metric for **real** failures that excludes expected 429s
+  (Module 4), thresholded separately from `http_req_failed`.
+- k6's non-zero exit on a failed threshold is the CI gate (Module 7) — never
+  swallow it.
+
+## Detection commands
+
+```
+# A failed threshold makes k6 exit non-zero — this is the gate:
+k6 run k6/baseline.js ; echo "exit=$?"     # expect non-zero when a threshold breaches
+
+# Emit the machine-readable summary the report + CI consume:
+k6 run --summary-export=k6-load-report/metrics/smoke-summary.json k6/baseline.js
+```
+
+Cross-reference Module 6 for turning the summary JSON into the report tables,
+Module 4 for the 429 carve-out, and Module 8 for choosing the actual budgets.

--- a/.claude/skills/k6-load-testing/references/03-scripting-this-app.md
+++ b/.claude/skills/k6-load-testing/references/03-scripting-this-app.md
@@ -1,0 +1,184 @@
+# Module 3 — Scripting This App (bootcamp-palermo-workorders)
+
+Standards: Grafana k6 HTTP requests / checks / `http.file` (multipart) reference.
+This module is stack-specific — it maps the app's actual HTTP surface to k6
+scripts. For a different target, rebuild this inventory first (see the pipeline
+in `SKILL.md`).
+
+## Endpoint inventory (k6 targets)
+
+| Method | Route | Auth-gated when key on? | Rate-limited (prod)? | Success | Notes |
+|---|---|---|---|---|---|
+| GET | `/api/ping` | No (always open) | Yes | 200 `text/plain` `pong` | cheapest baseline target |
+| GET | `/api/time` | No (always open) | Yes | 200 text / 304 | weak ETag |
+| GET | `/api/version` | No (always open) | Yes | 200 JSON / 304 | output-cached 10m |
+| GET | `/api/health`, `/api/health/detailed` | Yes | Yes | 200 JSON / 304 | |
+| GET | `/api/diagnostics` | Yes | Yes | 200 JSON / 304 | |
+| GET | `/api/v1.0/WeatherForecast` | Yes | Yes | 200 JSON / 304 | 5-item array |
+| POST | `/api/work-orders/bulk-import` | Yes | Yes | 200 JSON | multipart `file` (CSV); realistic write load |
+| POST | `/api/blazor-wasm-single-api` | Yes | **No** (no attribute) | 200 JSON-string | MediatR envelope; realistic DB read/write, un-throttled |
+
+Baseline latency/throughput → the open GETs (`/api/ping`, `/api/time`,
+`/api/version`). Realistic DB-backed load → `bulk-import` (writes) and
+`blazor-wasm-single-api` (reads/commands). The single-api path is **not**
+rate-limited, so it's the right target for capacity numbers that shouldn't be
+capped at 100/60s (see Module 4).
+
+## Anti-patterns to hunt (when scripting)
+
+| Pattern | Why it hurts | Evidence to look for |
+|---|---|---|
+| No `check()` on status/body | A fast error counts as a fast success; latency numbers become meaningless | `http.get(...)` with no following `check(res, {...})` |
+| Hardcoded base URL / API key in the script | Not portable across local/deployed; leaks a key into git | literal `https://localhost:7174` or a key string instead of `__ENV.BASE_URL` / `__ENV.API_KEY` |
+| Wrong header casing for the API key | `X-Api-Key` (auth) vs `X-API-Key` (rate-limit partition) are different headers | sending only one when both matter |
+| Guessed `WebServiceMessage` type names | The server deserializes by assembly-qualified name; a typo yields a 500, not a domain error | `TypeName` without the `, Core` assembly suffix |
+| Reusing the localhost dev cert without `--insecure-skip-tls-verify` | k6 aborts on the self-signed cert; every request "fails" | TLS errors in k6 output against `https://localhost` |
+
+## Authentication & TLS
+
+- API-key header is **`X-Api-Key`** (config `ApiKeyAuthentication:Enabled` +
+  `:ValidationKey`; **off by default**). Only `/api/*` paths are gated; `ping`,
+  `time`, `version` stay open even when the key is on. Supply via
+  `__ENV.API_KEY` and send it on every gated request.
+- Rate-limit **partition** header is separately **`X-API-Key`** (note casing) —
+  set it to spread or isolate buckets when testing the limiter (Module 4).
+- Localhost uses a self-signed dev cert: run with
+  `k6 run --insecure-skip-tls-verify …` (local only — never against deployed).
+
+## Worked k6 skeleton — baseline GETs
+
+```js
+import http from 'k6/http';
+import { check } from 'k6';
+
+const BASE = __ENV.BASE_URL || 'https://localhost:7174';
+const PROFILE = __ENV.PROFILE || 'smoke';
+
+const SCENARIOS = {
+  smoke: { executor: 'constant-vus', vus: 2, duration: '30s' },
+  load:  { executor: 'ramping-arrival-rate', startRate: 10, timeUnit: '1s',
+           preAllocatedVUs: 50, maxVUs: 200,
+           stages: [{ target: 50, duration: '1m' }, { target: 50, duration: '5m' }] },
+  spike: { executor: 'ramping-arrival-rate', startRate: 10, timeUnit: '1s',
+           preAllocatedVUs: 50, maxVUs: 500,
+           stages: [{ target: 10, duration: '10s' }, { target: 300, duration: '10s' },
+                    { target: 300, duration: '30s' }, { target: 10, duration: '10s' }] },
+};
+
+export const options = {
+  scenarios: { [PROFILE]: SCENARIOS[PROFILE] },
+  thresholds: {
+    http_req_duration: ['p(95)<500', 'p(99)<1000'],
+    http_req_failed:   ['rate<0.01'],
+    checks:            ['rate>0.99'],
+  },
+};
+
+export default function () {
+  const res = http.get(`${BASE}/api/ping`);
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'body is pong':  (r) => r.body === 'pong',
+  });
+}
+```
+
+Run: `PROFILE=smoke k6 run --insecure-skip-tls-verify k6/baseline.js`
+
+## Worked k6 skeleton — domain read via `blazor-wasm-single-api`
+
+The endpoint takes JSON `WebServiceMessage { TypeName, Body }`; `TypeName` is an
+assembly-qualified .NET type name, `Body` is the JSON of the inner request. The
+response is a JSON *string* that is itself a serialized `WebServiceMessage`.
+
+```js
+import http from 'k6/http';
+import { check } from 'k6';
+
+const BASE = __ENV.BASE_URL || 'https://localhost:7174';
+const API_KEY = __ENV.API_KEY || '';
+
+// Assembly-qualified names (verify against src/Core/Queries before running):
+const T = {
+  employeeGetAll: 'ClearMeasure.Bootcamp.Core.Queries.EmployeeGetAllQuery, Core',
+  workOrderByNumber: 'ClearMeasure.Bootcamp.Core.Queries.WorkOrderByNumberQuery, Core',
+};
+
+export const options = {
+  scenarios: { load: { executor: 'ramping-arrival-rate', startRate: 5, timeUnit: '1s',
+    preAllocatedVUs: 50, maxVUs: 200,
+    stages: [{ target: 40, duration: '1m' }, { target: 40, duration: '3m' }] } },
+  thresholds: { http_req_duration: ['p(95)<800'], http_req_failed: ['rate<0.02'], checks: ['rate>0.98'] },
+};
+
+export default function () {
+  const envelope = JSON.stringify({
+    TypeName: T.employeeGetAll,
+    Body: JSON.stringify({}),          // EmployeeGetAllQuery has no fields
+  });
+  const headers = { 'Content-Type': 'application/json' };
+  if (API_KEY) headers['X-Api-Key'] = API_KEY;
+
+  const res = http.post(`${BASE}/api/blazor-wasm-single-api`, envelope, { headers });
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'has envelope body': (r) => r.body && r.body.length > 0,
+  });
+}
+```
+
+## Worked k6 skeleton — write load via `bulk-import` (multipart CSV)
+
+`CreatorUsername` must be a seeded employee that can create (e.g. `jpalermo`).
+`RoomNumber` is free-text and optional. `Number` is server-generated — never
+supplied. Seed usernames from the DbUp seed / `ZDataLoader`: `jpalermo`,
+`jborys`, `mpeck`, `bsides`, `csullivan`, etc.
+
+```js
+import http from 'k6/http';
+import { check } from 'k6';
+
+const BASE = __ENV.BASE_URL || 'https://localhost:7174';
+const API_KEY = __ENV.API_KEY || '';
+
+const csv = [
+  'Title,Description,CreatorUsername,RoomNumber',
+  'Broken window,Glass cracked in the east wall,jpalermo,Sanctuary',
+  'Leaking tap,Drip in the kitchen sink,jpalermo,Church Office',
+].join('\n');
+
+export const options = {
+  scenarios: { load: { executor: 'constant-arrival-rate', rate: 5, timeUnit: '1s',
+    duration: '2m', preAllocatedVUs: 20, maxVUs: 50 } },
+  thresholds: { http_req_duration: ['p(95)<1500'], http_req_failed: ['rate<0.02'], checks: ['rate>0.98'] },
+};
+
+export default function () {
+  const headers = {};
+  if (API_KEY) headers['X-Api-Key'] = API_KEY;
+  const res = http.post(`${BASE}/api/work-orders/bulk-import`,
+    { file: http.file(csv, 'load.csv', 'text/csv') }, { headers });
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'created rows': (r) => { try { return JSON.parse(r.body).createdCount >= 1; } catch { return false; } },
+  });
+}
+```
+
+Note: `bulk-import` writes real rows — always run it against the throwaway
+SQLite DB (Module 5), never a shared/real database.
+
+## Detection commands
+
+```
+# Confirm the target is up and the baseline endpoint works before any load:
+curl -sk https://localhost:7174/_healthcheck
+curl -sk https://localhost:7174/api/ping        # expect: pong
+
+# Verify assembly-qualified type names against the source before scripting single-api:
+grep -rniE "class .*Query|record .*Query" src/Core/Queries
+```
+
+Cross-reference Module 4 (rate-limit behaviour on these routes), Module 5
+(bringing the target up with a throwaway DB + seed data), and Module 6
+(capturing the results).

--- a/.claude/skills/k6-load-testing/references/04-rate-limiting-and-backpressure.md
+++ b/.claude/skills/k6-load-testing/references/04-rate-limiting-and-backpressure.md
@@ -1,0 +1,81 @@
+# Module 4 — Rate Limiting & Back-Pressure
+
+Standards: Grafana k6 custom-metrics (`Rate`) & response-handling reference;
+HTTP 429 semantics (RFC 6585 §4, `Retry-After`).
+
+This app has a **custom sliding-window limiter** that materially changes how a
+load test's numbers must be read. Getting this wrong is the most common
+load-testing false-finding: reporting the limiter *doing its job* as a defect.
+
+## The limiter, as configured
+
+| Property | Value | Source |
+|---|---|---|
+| Policy | `ApiSlidingWindow` | `src/UI/Api/ApiRateLimiting.cs` |
+| Limit | **100 requests / 60 s** per client, 4 segments, `QueueLimit=0` (fail fast) | `src/UI/Server/ApiRateLimitingOptions.cs`, `appsettings.json` |
+| Partition key | `X-API-Key` header → else `User.Identity.Name` → else remote IP → else `anonymous` | `src/UI/Server/ApiRateLimitingExtensions.cs` |
+| Throttled response | **HTTP 429**, `text/plain`, headers `Retry-After`, `X-RateLimit-{Limit,Remaining,Reset}` | `src/UI/Server/RateLimiting/RateLimitingMiddleware.cs` |
+| Scope | endpoints with `[EnableRateLimiting]` under `/api` — Ping, Time, Version, Health, Diagnostics, WeatherForecast, bulk-import | (attribute-gated) |
+| **Not** limited | `/api/blazor-wasm-single-api` (no attribute), `/mcp`, gRPC | |
+| **Default state** | **DISABLED in Development**; enabled (100/60s) in base `appsettings.json` (prod/other) | `appsettings.Development.json` |
+
+## Anti-patterns to hunt
+
+| Pattern | Why it hurts | Evidence to look for |
+|---|---|---|
+| Counting expected 429s as `http_req_failed` | Back-pressure inflates the error rate; a healthy limiter fails the run | no 429 carve-out; error rate jumps exactly at 100 req/60s per client |
+| Reporting "the API errors under load" when it's the limiter | Mislabels a working control as a defect | 429s (not 5xx) dominating the "failures" |
+| Testing throughput on a rate-limited route and reporting the cap as "max capacity" | The number is the limiter's ceiling, not the app's | RPS plateaus at ~1.67/s (100/60s) on `/api/ping` with one partition |
+| One partition (anonymous/IP) for a throughput test | All VUs share one 100/60s bucket, so real capacity is masked | no `X-API-Key` variation; single IP |
+| Testing the limiter with it disabled (Development) | You measure nothing — no ceiling exists | limiter off but the report claims to validate it |
+
+## What "good" looks like
+
+- **Decide the intent first**, and state it in the report:
+  - *Measuring app capacity/latency* → target the **un-throttled**
+    `/api/blazor-wasm-single-api`, or enable a high/known limit, or spread
+    partitions so the limiter isn't the bottleneck. State that the limiter was
+    bypassed/raised and why.
+  - *Validating the limiter itself* → enable it
+    (`ApiRateLimiting__Enabled=true`, run in a non-Development environment),
+    keep **one** partition, drive > 100 req/60s, and assert the *expected* shape:
+    the first ~100 succeed, the rest return 429 with correct `Retry-After` /
+    `X-RateLimit-*` headers.
+- **Categorize 429 separately from failure** using a custom `Rate`:
+  ```js
+  import http from 'k6/http';
+  import { check } from 'k6';
+  import { Rate } from 'k6/metrics';
+
+  const throttled = new Rate('throttled_429');   // designed back-pressure
+  const realErrors = new Rate('real_errors');    // genuine failures
+
+  export const options = {
+    thresholds: {
+      real_errors: ['rate<0.01'],        // gate on REAL errors only
+      // throttled_429 is observed, not gated (it's expected when testing the limiter)
+    },
+  };
+
+  export default function () {
+    const res = http.get(`${__ENV.BASE_URL}/api/ping`);
+    throttled.add(res.status === 429);
+    realErrors.add(res.status >= 500 || res.status === 0);
+    check(res, { 'ok or throttled': (r) => r.status === 200 || r.status === 429 });
+  }
+  ```
+- Honour `Retry-After` in closed-model scripts so the client backs off like a
+  real one, rather than hammering a saturated bucket.
+
+## Detection commands
+
+```
+# Enable the limiter locally to exercise the 429 path (otherwise off in Dev):
+ASPNETCORE_ENVIRONMENT=Production ApiRateLimiting__Enabled=true dotnet run --project src/UI/Server
+
+# Confirm the 429 shape by hand (101st request within a window):
+for i in $(seq 1 105); do curl -sk -o /dev/null -w "%{http_code}\n" https://localhost:7174/api/ping; done | sort | uniq -c
+```
+
+Cross-reference Module 2 (gate on real errors, not 429), Module 3 (which routes
+carry the limiter), and Module 5 (setting the environment/config that toggles it).

--- a/.claude/skills/k6-load-testing/references/05-environment-and-data-setup.md
+++ b/.claude/skills/k6-load-testing/references/05-environment-and-data-setup.md
@@ -1,0 +1,80 @@
+# Module 5 — Environment & Data Setup
+
+Standards: repeatable-environment / test-data-isolation practice; .NET
+configuration precedence (env vars via `__`); DbUp migration seeding.
+
+A load number is only meaningful if you know exactly what it ran against. This
+module pins the target so runs are reproducible and never touch real data.
+
+## Anti-patterns to hunt
+
+| Pattern | Why it hurts | Evidence to look for |
+|---|---|---|
+| Load-testing against a real/shared DB | `bulk-import` and single-api commands write rows; you pollute or corrupt shared data | connection string pointing at a shared SQL Server |
+| Measuring the first (cold) iterations | .NET JIT + EF model build + first-connection cost skews p99 badly | no warm-up; p99 wildly above p95 on the first run only |
+| Not stating the environment/DB/limiter state | Numbers can't be compared run-to-run or trusted | report with no "environment" section |
+| Leaving the auto-reformat agent on | The background AI agent mutates Draft work orders and makes LLM calls mid-test, adding noise and cost | `DISABLE_AUTO_REFORMAT_AGENT` unset |
+| Running smoke against a not-yet-ready app | Startup/migration still in progress → spurious 500s | no `/_healthcheck` gate before load |
+
+## What "good" looks like
+
+- **Throwaway SQLite DB** — set the connection string to a `Data Source=` value;
+  the app auto-switches to SQLite + NServiceBus LearningTransport (no SQL Server
+  needed) and connection-pool clearing follows suit:
+  ```
+  ConnectionStrings__SqlConnectionString="Data Source=loadtest.db"
+  ```
+  Delete `loadtest.db` between runs for a clean slate.
+- **Background AI off** — `DISABLE_AUTO_REFORMAT_AGENT=true` (already the default
+  in `appsettings.json`, but set it explicitly so a config override can't
+  re-enable it during a run).
+- **Decide the limiter state deliberately** (Module 4): default `dotnet run` is
+  Development → limiter OFF (no ceiling). To exercise it, run in a non-Development
+  environment and/or set `ApiRateLimiting__Enabled=true`.
+- **Seed data** so payloads are valid — run the repo `Build` (applies DbUp
+  migrations incl. the employee seed) against the throwaway DB, or point at a DB
+  already seeded by `ZDataLoader`. Valid can-create username: `jpalermo`.
+- **Warm-up** — either a short warm-up scenario before the measured one, or
+  discard the first N iterations in analysis; note which in the report.
+- **Health-gate the start** — poll `/_healthcheck` until 200 before launching k6.
+
+## Reference launch (local, throwaway SQLite)
+
+```
+# 1. Seed a throwaway DB + build (applies DbUp migrations):
+ConnectionStrings__SqlConnectionString="Data Source=loadtest.db" . .\build.ps1 ; Build
+
+# 2. Run the app against the throwaway DB, agent off:
+$env:ConnectionStrings__SqlConnectionString="Data Source=loadtest.db"
+$env:DISABLE_AUTO_REFORMAT_AGENT="true"
+dotnet run --project src/UI/Server            # → https://localhost:7174
+
+# 3. Wait for health, then load-test (see Modules 3/6):
+curl -sk https://localhost:7174/_healthcheck  # expect Healthy
+```
+
+## Config keys a load test may set (env-var form uses `__`)
+
+| Key | Effect |
+|---|---|
+| `ConnectionStrings__SqlConnectionString` | `Data Source=…` → throwaway SQLite + LearningTransport |
+| `DISABLE_AUTO_REFORMAT_AGENT` | `true` stops the background AI reformat agent |
+| `ASPNETCORE_ENVIRONMENT` | non-`Development` enables the base-config limiter |
+| `ApiRateLimiting__Enabled` / `__PermitLimit` / `__WindowSeconds` | toggle/tune the limiter (Module 4) |
+| `ApiKeyAuthentication__Enabled` / `__ValidationKey` | enable + supply the `X-Api-Key` (Module 3) |
+| `ApiRequestTimeouts__TimeoutSeconds` | per-request timeout (default 120) on `/api/*` |
+
+## Detection commands
+
+```
+# Confirm SQLite mode (LearningTransport) was selected, not SQL Server:
+grep -niE "Data Source=|LearningTransport|LocalDb" src/UI/Server/Program.cs src/UI/Server/DatabaseConfiguration.cs
+
+# Confirm the app is healthy and seeded before load:
+curl -sk https://localhost:7174/_healthcheck
+curl -sk https://localhost:7174/api/blazor-wasm-single-api -H "Content-Type: application/json" \
+  -d '{"TypeName":"ClearMeasure.Bootcamp.Core.Queries.EmployeeGetAllQuery, Core","Body":"{}"}'
+```
+
+Cross-reference Module 3 (payloads that need the seed usernames) and Module 4
+(limiter/environment interplay).

--- a/.claude/skills/k6-load-testing/references/06-metrics-results-reporting.md
+++ b/.claude/skills/k6-load-testing/references/06-metrics-results-reporting.md
@@ -1,0 +1,78 @@
+# Module 6 — Metrics, Results & Reporting
+
+Standards: Grafana k6 built-in metrics, `handleSummary()` / `--summary-export`,
+custom metrics (`Trend`/`Counter`/`Rate`/`Gauge`).
+
+Every claim in the report must trace to a saved k6 run. This module covers
+capturing the raw numbers and turning them into the report tables.
+
+## k6 built-in metrics worth reporting
+
+| Metric | Meaning | Report as |
+|---|---|---|
+| `http_req_duration` | End-to-end request time | p50 / p95 / p99 latency |
+| `http_reqs` | Total requests + rate | throughput (RPS) |
+| `http_req_failed` | Fraction of failed requests | error rate (see Module 4 for the 429 carve-out) |
+| `iterations` / `iteration_duration` | VU loop completions | per-scenario work rate |
+| `vus` / `vus_max` | Concurrent/allocated VUs | concurrency reached |
+| `data_sent` / `data_received` | Bytes over the wire | bandwidth (useful for payload-heavy routes) |
+| `checks` | Fraction of passing checks | correctness % (a fast 500 shows up here) |
+
+## Anti-patterns to hunt
+
+| Pattern | Why it hurts | Evidence to look for |
+|---|---|---|
+| Reporting only the k6 terminal blurb, no saved JSON | Not reproducible; can't diff runs; fidelity rule violated | no `metrics/*.json` for a cited number |
+| Quoting `avg` latency | Hides the tail; SLOs are percentile-based | "average response 120ms" with no p95/p99 |
+| No k6 version recorded | Metric semantics shift across k6 versions | report without `k6 version` output |
+| Mixing profiles in one summary file | Can't attribute a number to a profile | one JSON overwritten across smoke/load/stress |
+| Ignoring `checks` rate | Latency looks great because errors returned instantly | thresholds pass but `checks` < 100% unremarked |
+
+## What "good" looks like
+
+- Persist a machine-readable summary **per profile** into `metrics/`:
+  ```
+  PROFILE=smoke k6 run --summary-export=k6-load-report/metrics/smoke-summary.json \
+    --insecure-skip-tls-verify k6/baseline.js
+  ```
+- Or emit a custom, report-shaped JSON via `handleSummary` (also keep the text
+  summary for humans):
+  ```js
+  export function handleSummary(data) {
+    return {
+      'k6-load-report/metrics/summary.json': JSON.stringify(data, null, 2),
+      'stdout': textSummary(data, { indent: ' ', enableColors: false }),
+    };
+  }
+  // import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
+  ```
+  (If the environment blocks the jslib import, use `--summary-export` instead.)
+- Record `k6 version` and the exact command alongside each result.
+- Build the report's per-profile table straight from the summary JSON fields
+  (`metrics.http_req_duration.values["p(95)"]`, `.http_reqs.values.rate`,
+  `.http_req_failed.values.rate`, `.checks.values.rate`). If post-processing the
+  JSON into rollup tables needs code, write a single-file **C# script (`.csx`
+  via `dotnet-script`)** — matching the repo's .NET-only helper norm — not
+  Python/PowerShell.
+- Keep the raw JSON in `metrics/` so every number in `README.md` is one grep away.
+
+## Report tables to produce (per run)
+
+- **Per-profile summary**: profile | executor/stages | p50 | p95 | p99 | RPS |
+  error rate | checks% | threshold verdict.
+- **Threshold verdict list**: each threshold → pass/fail (from k6's
+  `metrics.<name>.thresholds`).
+- **429 vs real-error split** when the limiter was exercised (Module 4).
+
+## Detection commands
+
+```
+k6 version
+
+# Pull the headline numbers back out of a saved summary:
+cat k6-load-report/metrics/smoke-summary.json | \
+  grep -oE '"p\(95\)":[0-9.]+|"rate":[0-9.]+' | head
+```
+
+Cross-reference Module 2 (thresholds → verdict), Module 4 (429 categorization),
+and Module 7 (surfacing these into a GitHub Actions summary).

--- a/.claude/skills/k6-load-testing/references/07-ci-github-actions.md
+++ b/.claude/skills/k6-load-testing/references/07-ci-github-actions.md
@@ -1,0 +1,97 @@
+# Module 7 — CI Integration (GitHub Actions)
+
+Standards: Grafana `grafana/setup-k6-action`, GitHub Actions job summaries
+(`$GITHUB_STEP_SUMMARY`), `actions/upload-artifact`, workflow exit-code gating.
+
+When the skill runs inside a pipeline, the load test becomes a gate: thresholds
+decide the job's pass/fail, the report is uploaded as an artifact, and a
+human-readable summary is written to the Actions run page.
+
+> **Repo rule:** do not auto-write files under `.github/workflows/`. Pipeline
+> files require explicit approval (see `CLAUDE.md` Key Conventions). The workflow
+> below is a **snippet the user opts to add**, surfaced in the report — not
+> committed by the skill.
+
+## Anti-patterns to hunt
+
+| Pattern | Why it hurts | Evidence to look for |
+|---|---|---|
+| Swallowing k6's exit code (`k6 run … || true`) | A threshold breach no longer fails the job — the gate is fake | `|| true`, `continue-on-error: true` on the k6 step |
+| No artifact upload | The report is lost when the runner is torn down | no `actions/upload-artifact` for `k6-load-report/` |
+| Nothing written to the run summary | Reviewers must dig into raw logs to see results | no `>> "$GITHUB_STEP_SUMMARY"` |
+| Load-testing a deployed env from CI without opt-in | Hits real infra/cost on every push | a workflow targeting the deployed URL on `push` with no guard |
+| Running the app + k6 with no health gate in CI | Race: k6 starts before the app is ready → false failures | k6 step immediately after `dotnet run` with no wait |
+
+## What "good" looks like
+
+- **Thresholds are the gate** — let k6's non-zero exit fail the step; do not
+  mask it. The job goes red exactly when an SLO is breached (Module 2).
+- **Summary to the run page** — append a compact markdown table to
+  `$GITHUB_STEP_SUMMARY` from the saved summary JSON (Module 6).
+- **Report as artifact** — upload the whole `k6-load-report/` directory.
+- **Detect CI** — the skill keys off `$GITHUB_ACTIONS` / `$CI` to switch on the
+  summary + artifact behaviour; locally it just writes the report dir.
+- **Local target in CI too** — spin the app up on the runner against throwaway
+  SQLite (Module 5); target the deployed env only via an explicit, guarded
+  `workflow_dispatch` input.
+
+## Embedded workflow snippet (opt-in — do not auto-commit)
+
+```yaml
+# .github/workflows/k6-load-test.yml  (add manually after review)
+name: k6 load test
+on:
+  workflow_dispatch:
+  # pull_request:            # opt in once baselines are stable
+jobs:
+  load-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with: { dotnet-version: '10.0.x' }
+      - name: Start app (throwaway SQLite, agent off)
+        env:
+          ConnectionStrings__SqlConnectionString: "Data Source=loadtest.db"
+          DISABLE_AUTO_REFORMAT_AGENT: "true"
+        run: |
+          dotnet run --project src/UI/Server &
+          for i in $(seq 1 60); do
+            curl -sk https://localhost:7174/_healthcheck && break || sleep 2
+          done
+      - uses: grafana/setup-k6-action@v1
+      - name: Run smoke + load (thresholds gate the job)
+        run: |
+          mkdir -p k6-load-report/metrics
+          PROFILE=smoke k6 run --insecure-skip-tls-verify \
+            --summary-export=k6-load-report/metrics/smoke-summary.json k6/baseline.js
+          PROFILE=load  k6 run --insecure-skip-tls-verify \
+            --summary-export=k6-load-report/metrics/load-summary.json  k6/baseline.js
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## k6 load test results"
+            echo "| profile | p95 (ms) | error rate | checks |"
+            echo "|---|---|---|---|"
+            # extract from metrics/*.json (jq or a .csx helper — see Module 6)
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: k6-load-report
+          path: k6-load-report/
+```
+
+## Detection commands
+
+```
+# Confirm the skill is running under CI:
+echo "GITHUB_ACTIONS=$GITHUB_ACTIONS CI=$CI"
+
+# Locally simulate the gate: a breached threshold must exit non-zero.
+PROFILE=smoke k6 run --insecure-skip-tls-verify k6/baseline.js ; echo "exit=$?"
+```
+
+Cross-reference Module 2 (the thresholds doing the gating), Module 5 (bringing
+the app up on the runner), and Module 6 (the summary JSON the summary step reads).

--- a/.claude/skills/k6-load-testing/references/08-standards-and-targets-mapping.md
+++ b/.claude/skills/k6-load-testing/references/08-standards-and-targets-mapping.md
@@ -1,0 +1,70 @@
+# Module 8 — Standards & Targets Mapping
+
+Use this module to turn each run into the citation line the finding format
+requires, to pick defensible SLO budgets, and to classify severity consistently
+rather than by gut feel.
+
+## References this skill leans on
+
+- **Grafana k6**: Test Types, Scenarios & Executors, Thresholds, Metrics,
+  `handleSummary` / results output — the tool's own guidance is the primary
+  authority for *how* to load-test.
+- **Google SRE (SRE Book / Workbook)**: SLIs, SLOs, and error budgets — the
+  framework for *what* latency/error target to hold and why breaching it matters.
+- **RFC 6585 §4 / RFC 9110**: HTTP 429 & `Retry-After` semantics — the contract
+  the rate limiter (Module 4) implements; a load test validates against it.
+- **This app's own config as the target of record**: the rate limit
+  (100 req/60 s), request timeout (120 s), and the un-throttled single-api path
+  are *the* constraints numbers must be read against — cite the config file, not
+  a generic "the API".
+
+## Choosing SLO budgets (don't invent them)
+
+1. Run **smoke** first to establish the idle-system baseline latency.
+2. Set the average-load p95 budget as a modest multiple of the smoke baseline
+   (e.g. baseline p95 × 2–3), not an arbitrary round number.
+3. Set the error budget from the intended reliability target (e.g. 99.9%
+   availability → `http_req_failed rate < 0.001` for the SLO tier), excluding
+   designed 429s (Module 4).
+4. Record the derivation in the report so the budget is auditable, not asserted.
+
+## Severity guidance specific to load-test findings
+
+- **Critical**: correctness or error-rate breach under **smoke or nominal load**
+  (5xx/timeouts, `checks` < target at low RPS), or the app failing to recover
+  after a spike. The system is not meeting its SLO under expected conditions.
+- **High**: **p95/p99 latency budget breached under expected (average) load**,
+  or throughput plateauing well below the expected peak for a non-rate-limited
+  reason (DB, contention).
+- **Medium**: degradation that appears **only under stress/spike** beyond
+  expected peaks — the system bends but doesn't break; a capacity-planning
+  concern, not a live SLO breach.
+- **Low**: marginal soak drift, cold-start-only tail latency, or defense-in-depth
+  observations (e.g. missing `Retry-After` nicety) with no SLO impact.
+
+Rate-limiter 429s returned *as designed* are **not** a finding — they are the
+control working (Module 4). Only report them as a finding if the limiter behaves
+incorrectly (wrong count, missing headers, limiting the wrong routes).
+
+## Finding-citation convention
+
+Every finding's **Threshold verdict** and **Evidence** lines must name the
+concrete k6 run and metric — e.g. `p(95)=812ms vs SLO p95<500ms (fail),
+metrics/load-summary.json` — plus the governing reference where a general
+principle is invoked (e.g. "open-model executor per k6 Scenarios guidance", or
+"error budget per Google SRE 99.9% target"). Never write "slow under load"
+without the metric, the profile, and the saved run.
+
+## Detection commands
+
+```
+# Re-derive a cited number from its saved run (reproducibility check):
+PROFILE=load k6 run --insecure-skip-tls-verify \
+  --summary-export=k6-load-report/metrics/load-summary.json k6/baseline.js
+
+# Confirm the target's own limits that numbers must be read against:
+grep -niE "PermitLimit|WindowSeconds|TimeoutSeconds" src/UI/Server/*Options.cs src/UI/Server/appsettings*.json
+```
+
+Cross-reference Module 2 (thresholds encode these SLOs) and Module 4 (429
+categorization feeds the severity call).


### PR DESCRIPTION
## Summary

Adds a **k6 load-testing skill** at `.claude/skills/k6-load-testing/`, the third in the repo's audit-skill family alongside `codebase-cartography-audit` and `cryptography-audit` and following the same house style (SKILL.md + PROMPT.md + numbered `references/`).

When invoked it inventories the app's HTTP surface, generates k6 scripts with threshold-encoded SLOs, runs staged load profiles (smoke → average → stress → spike), and produces a self-contained `k6-load-report/` (README + raw k6 summary JSON in `metrics/`). Run inside GitHub Actions it also writes a per-profile table to `$GITHUB_STEP_SUMMARY`, uploads the report as an artifact, and lets k6's threshold-driven non-zero exit fail the job on an SLO breach.

## Contents

- `SKILL.md` — frontmatter + 7-step ordered pipeline (scope → env → script → run → analyze → CI → report), finding format, fidelity rules, guiding stance.
- `PROMPT.md` — portable single-paste version of the pipeline.
- `references/01-08` — test types & profiles; thresholds & SLOs; **scripting this app** (endpoint inventory, `X-Api-Key`, the `WebServiceMessage` envelope, multipart bulk-import); rate limiting vs real failure; environment & throwaway-SQLite setup; metrics & reporting; CI/GitHub Actions; standards & severity mapping.

## App-specific accuracy

The app-targeting claims were verified against source: `X-Api-Key` header (`ApiHttpContracts.cs:11`), `/api/ping` → `pong`, rate limit 100 req/60s (`appsettings.json`), and `WebServiceMessage { TypeName, Body }` (`Core/Messaging/WebServiceMessage.cs`). Defaults are local-only (throwaway SQLite, background AI agent off); the deployed environment is an explicit opt-in.

## Notes

- Documentation only — no application code or pipeline files changed. The GitHub Actions workflow is an **embedded opt-in snippet** in Module 7, not auto-committed (per the repo's no-pipeline-changes-without-approval rule).
- A live functional smoke run (installing k6 + standing up the app) has **not** been executed in this session; structural conformance and factual accuracy of the skill were verified statically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)