### PR TITLE
Add roslynator-analysis skill

### DIFF
--- a/.claude/skills/roslynator-analysis/SKILL.md
+++ b/.claude/skills/roslynator-analysis/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: roslynator-analysis
+description: Run Roslynator static analysis against a .NET solution, then parse and summarize the diagnostics. Use when the user wants to run Roslynator, analyze C#/.NET code quality, run static/code analysis on a solution (.sln), or mentions Roslynator, analyzers, or code smells in a .NET repo.
+---
+
+# Roslynator Analysis
+
+Runs the Roslynator CLI `analyze` command against a solution and prints a parsed summary
+(severity breakdown, compiler-vs-analyzer split, top rules, report link). The heavy lifting
+lives in `scripts/analyze.ps1` — a deterministic, self-healing wrapper.
+
+## Quick start
+
+From the repo root, run the script (use this skill's directory for the path):
+
+```powershell
+pwsh <skill-dir>/scripts/analyze.ps1 -Solution src/ChurchBulletin.sln
+```
+
+Then relay its printed summary to the user.
+
+## Workflow
+
+1. **Resolve the solution.** If the user named a `.sln`/`.slnx`, pass it via `-Solution`.
+   Otherwise call the script with no `-Solution`; it auto-uses the sole solution, or exits 3
+   listing candidates. On that exit-3 list, ask the user which one (AskUserQuestion) and
+   re-invoke with `-Solution`.
+
+2. **Run the script.** `pwsh <skill-dir>/scripts/analyze.ps1 -Solution <path>`
+   Optional: `-SeverityLevel info|hidden|warning|error`, `-Output <dir>`, `-TopRules <n>`.
+   The script never runs `roslynator fix` and never modifies source.
+
+3. **Handle exit codes.**
+   - `0` → success; relay the summary it printed.
+   - `2` → Roslynator not installed. Ask the user, then `dotnet tool install -g roslynator.dotnet.cli`, and re-run.
+   - `3` → solution resolution problem (none found, or several — pick one and pass `-Solution`).
+   - `4` → analysis failed for another reason. See [resources/TROUBLESHOOTING.md](resources/TROUBLESHOOTING.md).
+
+4. **Report back** what the script printed: the solution, total + severity breakdown, the
+   compiler-vs-analyzer split (call out that `CS*` entries are usually resolution noise, not
+   defects), the top analyzer rules, and the clickable report link.
+
+## What the script handles for you
+
+- Verifies the Roslynator CLI is installed (exit 2 if not).
+- Writes the XML report to an OS-agnostic temp folder (`<temp>/roslynator-results/analysis.xml`).
+- **Self-heals** the known .NET 10 SDK MSBuild conflict (a `FileUtilities` `TypeLoadException`)
+  by neutralizing the bundled `Microsoft.Build.Framework.dll` and retrying once. Details and the
+  manual fallback are in [resources/TROUBLESHOOTING.md](resources/TROUBLESHOOTING.md).
+- Splits compiler (`CS*`) diagnostics from analyzer rules so resolution noise doesn't read as defects.
+
+## Notes
+
+- Prefer the CLI over the `Roslynator.Analyzers` NuGet package — the CLI needs no `.csproj`/package changes.
+- The report lives in the OS temp folder, so it is not tracked by git and may be cleared by the OS.
+- Large/multi-targeted solutions can take a while; let the run finish.

--- a/.claude/skills/roslynator-analysis/SKILL.md
+++ b/.claude/skills/roslynator-analysis/SKILL.md
@@ -43,7 +43,7 @@ Then relay its printed summary to the user.
 ## What the script handles for you
 
 - Verifies the Roslynator CLI is installed (exit 2 if not).
-- Writes a timestamped XML report under the repo (`<repo-root>/.roslynator-results/analysis-<timestamp>.xml`), so repeated runs never collide.
+- Writes a timestamped XML report under the OS temp directory (`<temp>/roslynator-analysis/analysis-<timestamp>.xml`), so repeated runs never collide.
 - **Self-heals** the known .NET 10 SDK MSBuild conflict (a `FileUtilities` `TypeLoadException`)
   by neutralizing the bundled `Microsoft.Build.Framework.dll` and retrying once. Details and the
   manual fallback are in [resources/TROUBLESHOOTING.md](resources/TROUBLESHOOTING.md).
@@ -52,5 +52,5 @@ Then relay its printed summary to the user.
 ## Notes
 
 - Prefer the CLI over the `Roslynator.Analyzers` NuGet package — the CLI needs no `.csproj`/package changes.
-- Reports land in `.roslynator-results/` at the repo root (git-ignored). Each run is timestamped, so old reports accumulate — clear the folder periodically.
+- Reports land in the OS temp directory under `roslynator-analysis/`. Each run is timestamped, so old reports accumulate — clear the folder periodically.
 - Large/multi-targeted solutions can take a while; let the run finish.

--- a/.claude/skills/roslynator-analysis/SKILL.md
+++ b/.claude/skills/roslynator-analysis/SKILL.md
@@ -43,7 +43,7 @@ Then relay its printed summary to the user.
 ## What the script handles for you
 
 - Verifies the Roslynator CLI is installed (exit 2 if not).
-- Writes the XML report to an OS-agnostic temp folder (`<temp>/roslynator-results/analysis.xml`).
+- Writes a timestamped XML report under the repo (`<repo-root>/roslynator-results/analysis-<timestamp>.xml`), so repeated runs never collide.
 - **Self-heals** the known .NET 10 SDK MSBuild conflict (a `FileUtilities` `TypeLoadException`)
   by neutralizing the bundled `Microsoft.Build.Framework.dll` and retrying once. Details and the
   manual fallback are in [resources/TROUBLESHOOTING.md](resources/TROUBLESHOOTING.md).
@@ -52,5 +52,5 @@ Then relay its printed summary to the user.
 ## Notes
 
 - Prefer the CLI over the `Roslynator.Analyzers` NuGet package — the CLI needs no `.csproj`/package changes.
-- The report lives in the OS temp folder, so it is not tracked by git and may be cleared by the OS.
+- Reports land in `roslynator-results/` at the repo root (git-ignored). Each run is timestamped, so old reports accumulate — clear the folder periodically.
 - Large/multi-targeted solutions can take a while; let the run finish.

--- a/.claude/skills/roslynator-analysis/SKILL.md
+++ b/.claude/skills/roslynator-analysis/SKILL.md
@@ -43,7 +43,7 @@ Then relay its printed summary to the user.
 ## What the script handles for you
 
 - Verifies the Roslynator CLI is installed (exit 2 if not).
-- Writes a timestamped XML report under the repo (`<repo-root>/roslynator-results/analysis-<timestamp>.xml`), so repeated runs never collide.
+- Writes a timestamped XML report under the repo (`<repo-root>/.roslynator-results/analysis-<timestamp>.xml`), so repeated runs never collide.
 - **Self-heals** the known .NET 10 SDK MSBuild conflict (a `FileUtilities` `TypeLoadException`)
   by neutralizing the bundled `Microsoft.Build.Framework.dll` and retrying once. Details and the
   manual fallback are in [resources/TROUBLESHOOTING.md](resources/TROUBLESHOOTING.md).
@@ -52,5 +52,5 @@ Then relay its printed summary to the user.
 ## Notes
 
 - Prefer the CLI over the `Roslynator.Analyzers` NuGet package — the CLI needs no `.csproj`/package changes.
-- Reports land in `roslynator-results/` at the repo root (git-ignored). Each run is timestamped, so old reports accumulate — clear the folder periodically.
+- Reports land in `.roslynator-results/` at the repo root (git-ignored). Each run is timestamped, so old reports accumulate — clear the folder periodically.
 - Large/multi-targeted solutions can take a while; let the run finish.

--- a/.claude/skills/roslynator-analysis/resources/TROUBLESHOOTING.md
+++ b/.claude/skills/roslynator-analysis/resources/TROUBLESHOOTING.md
@@ -12,7 +12,7 @@ from assembly 'Microsoft.Build.Framework, Version=15.1.0.0, ...'
 
 Roslynator typically exits 2 for this failure; `scripts/analyze.ps1` detects the signature, applies the workaround, and retries. If the workaround does not resolve it, `analyze.ps1` exits 4 (analysis failed).
 
-**Cause.** Roslynator 0.12.0 (the latest release) ships its own `Microsoft.Build.Framework.dll`
+**Cause.** Roslynator 0.12.0 (a known-affected version) ships its own `Microsoft.Build.Framework.dll`
 inside the tool store. Against the .NET 10 SDK, that bundled copy shadows the SDK's MSBuild and
 mismatches `Microsoft.Build.dll` — 0.12.0 was built for MSBuild 17.7, the SDK 10 MSBuild is 17.14,
 and the `FileUtilities` type moved between them. The `15.1.0.0` in the message is MSBuild's

--- a/.claude/skills/roslynator-analysis/resources/TROUBLESHOOTING.md
+++ b/.claude/skills/roslynator-analysis/resources/TROUBLESHOOTING.md
@@ -10,7 +10,7 @@ from assembly 'Microsoft.Build.Framework, Version=15.1.0.0, ...'
    at Microsoft.Build.Construction.SolutionFile.Parse(String solutionFile)
 ```
 
-Exit code 2; the solution never loads.
+Roslynator typically exits 2 for this failure; `scripts/analyze.ps1` detects the signature, applies the workaround, and retries. If the workaround does not resolve it, `analyze.ps1` exits 4 (analysis failed).
 
 **Cause.** Roslynator 0.12.0 (the latest release) ships its own `Microsoft.Build.Framework.dll`
 inside the tool store. Against the .NET 10 SDK, that bundled copy shadows the SDK's MSBuild and

--- a/.claude/skills/roslynator-analysis/resources/TROUBLESHOOTING.md
+++ b/.claude/skills/roslynator-analysis/resources/TROUBLESHOOTING.md
@@ -1,0 +1,58 @@
+# Roslynator Analysis — Troubleshooting
+
+## `TypeLoadException: Could not load type 'Microsoft.Build.Framework.FileUtilities'`
+
+**Symptom.** `roslynator analyze` fails at "Loading solution ..." with:
+
+```
+System.AggregateException: ... Could not load type 'Microsoft.Build.Framework.FileUtilities'
+from assembly 'Microsoft.Build.Framework, Version=15.1.0.0, ...'
+   at Microsoft.Build.Construction.SolutionFile.Parse(String solutionFile)
+```
+
+Exit code 2; the solution never loads.
+
+**Cause.** Roslynator 0.12.0 (the latest release) ships its own `Microsoft.Build.Framework.dll`
+inside the tool store. Against the .NET 10 SDK, that bundled copy shadows the SDK's MSBuild and
+mismatches `Microsoft.Build.dll` — 0.12.0 was built for MSBuild 17.7, the SDK 10 MSBuild is 17.14,
+and the `FileUtilities` type moved between them. The `15.1.0.0` in the message is MSBuild's
+back-compat *assembly* version and is not the real version — check *file* versions instead.
+MSBuildLocator is supposed to load `Microsoft.Build.*` from the registered SDK; shipping the DLL
+locally breaks that contract.
+
+**What does NOT fix it.**
+
+- `--msbuild-path <sdk>` — the bundled DLL still shadows the SDK's copy.
+- `dotnet tool update` / uninstall + reinstall — 0.12.0 is already the latest; same DLL returns.
+- Clearing MSBuild env vars / restarting the shell — it is a packaging conflict, not env state.
+
+**Fix (automated).** `scripts/analyze.ps1` detects this signature and neutralizes the bundled
+DLL automatically, then retries. No action needed.
+
+**Fix (manual).** Rename the bundled framework DLL so MSBuildLocator supplies the SDK's version:
+
+```powershell
+$dll = Join-Path $HOME '.dotnet/tools/.store/roslynator.dotnet.cli/0.12.0/roslynator.dotnet.cli/0.12.0/tools/net10.0/any/Microsoft.Build.Framework.dll'
+Rename-Item $dll "$dll.bak"
+```
+
+Adjust the `0.12.0` and `net10.0` segments to match the installed tool version and runtime. On
+non-Windows hosts the store is under `~/.dotnet/tools/.store`.
+
+**Caveat — it re-breaks after tool updates.** Any `dotnet tool update`/reinstall restores the bad
+DLL, so the workaround must be re-applied. The script re-applies it on demand; a manual fix does not.
+If Tasks/Utilities conflicts surface later (during restore/build rather than solution load), the same
+approach applies to `Microsoft.Build.Tasks.Core.dll` / `Microsoft.Build.Utilities.Core.dll`.
+
+---
+
+## A large block of `CS####` errors in the results
+
+Not a tool failure. `CS*` are C# *compiler* diagnostics (e.g. `CS0117`, `CS0103`, `CS0246`,
+`CS0234`), and a big cluster of them means Roslynator's MSBuild workspace didn't fully
+restore/resolve references or run source generators — **not** that the code is broken. The
+summary from `analyze.ps1` separates `CS*` from analyzer rules for this reason.
+
+- If a normal build (`. .\build.ps1 ; Build`) is green, ignore the `CS*` entries.
+- Running `dotnet restore` on the solution before analyzing usually reduces them.
+- Focus on the analyzer rules (`CA*`, `NUnit*`, `SYSLIB*`, `RCS*`, …) — those are the real findings.

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -9,7 +9,7 @@
       * self-healing: detects the SDK-10 MSBuild `FileUtilities` TypeLoadException and
         neutralizes the bundled Microsoft.Build.Framework.dll, then retries once
         (see resources/TROUBLESHOOTING.md for the underlying cause)
-      * running `analyze` to an XML report in an OS-agnostic temp folder
+      * running `analyze` to a timestamped XML report under the repo's roslynator-results/
       * parsing the report: severity breakdown, compiler (CS*) vs analyzer split, top rules
 
     Non-interactive by design. If -Solution is omitted it uses the sole discovered
@@ -22,7 +22,8 @@
     Minimum severity to report: hidden | info | warning | error. Default: info.
 
 .PARAMETER Output
-    Directory for the XML report. Default: <temp>/roslynator-results.
+    Directory for the XML report. Default: <repo-root>/roslynator-results (falls back to the
+    current directory if not in a git repo). Each run writes a timestamped file.
 
 .PARAMETER TopRules
     How many analyzer rules to list in the summary. Default: 20.
@@ -77,11 +78,14 @@ if (-not (Test-Path $Solution)) {
 $Solution = (Resolve-Path $Solution).Path
 Write-Host "Solution: $Solution"
 
-# --- 3. Output path (OS-agnostic temp) -----------------------------------------
-if (-not $Output) { $Output = Join-Path ([System.IO.Path]::GetTempPath()) 'roslynator-results' }
+# --- 3. Output path (repo-relative, timestamped filename) ----------------------
+if (-not $Output) {
+    $repoRoot = (& git rev-parse --show-toplevel 2>$null)
+    if (-not $repoRoot) { $repoRoot = (Get-Location).Path }
+    $Output = Join-Path $repoRoot 'roslynator-results'
+}
 New-Item -ItemType Directory -Force -Path $Output | Out-Null
-$report = Join-Path $Output 'analysis.xml'
-if (Test-Path $report) { Remove-Item $report -Force }
+$report = Join-Path $Output ("analysis-{0}.xml" -f (Get-Date -Format 'yyyyMMdd-HHmmssfff'))
 
 # --- Helper: neutralize the bundled MSBuild framework DLL (SDK-10 workaround) ---
 function Repair-BundledMSBuild {

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -132,7 +132,7 @@ if (-not (Test-Path $report) -or $result.ExitCode -ge 2) {
 }
 
 # --- 5. Parse and summarize ----------------------------------------------------
-[xml]$xml = Get-Content $report
+[xml]$xml = Get-Content -Raw $report
 $summary = @($xml.Roslynator.CodeAnalysis.Summary.Diagnostic)
 $total = ($summary | Measure-Object -Property Count -Sum).Sum
 if (-not $total) { $total = 0 }

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -135,7 +135,12 @@ if (-not (Test-Path $report) -or $result.ExitCode -ge 2) {
 }
 
 # --- 5. Parse and summarize ----------------------------------------------------
-[xml]$xml = Get-Content -Raw $report
+try {
+    [xml]$xml = Get-Content -Raw $report
+}
+catch {
+    Fail "Failed to read/parse Roslynator report XML: $report. $($_.Exception.Message)" 4
+}
 $summary = @($xml.Roslynator.CodeAnalysis.Summary.Diagnostic)
 $total = ($summary | Measure-Object -Property Count -Sum).Sum
 if (-not $total) { $total = 0 }

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -99,9 +99,14 @@ function Repair-BundledMSBuild {
         Get-ChildItem -Path $root -Recurse -Filter 'Microsoft.Build.Framework.dll' -ErrorAction SilentlyContinue |
             Where-Object { $_.FullName -match 'roslynator\.dotnet\.cli' } |
             ForEach-Object {
-                Rename-Item $_.FullName "$($_.FullName).bak" -Force
-                Write-Host "  neutralized $($_.FullName)"
-                $renamed++
+                try {
+                    Rename-Item $_.FullName "$($_.FullName).bak" -Force
+                    Write-Host "  neutralized $($_.FullName)"
+                    $renamed++
+                }
+                catch {
+                    Write-Host "  failed to neutralize $($_.FullName): $($_.Exception.Message)"
+                }
             }
     }
     return $renamed
@@ -153,10 +158,10 @@ if ($total -gt 0) {
     $compilerTotal = ($compiler | Measure-Object Count -Sum).Sum
     $analyzerTotal = ($analyzer | Measure-Object Count -Sum).Sum
 
-Write-Host ''
-Write-Host ("Compiler (CS*): {0} across {1} rules  <- usually workspace-resolution noise, not defects." -f ([int]$compilerTotal), $compiler.Count)
-Write-Host '   If a normal build is green, ignore these. `dotnet restore` first reduces them.'
-Write-Host ("Analyzer:       {0} across {1} rules  <- the actionable findings." -f ([int]$analyzerTotal), $analyzer.Count)
+    Write-Host ''
+    Write-Host ("Compiler (CS*): {0} across {1} rules  <- usually workspace-resolution noise, not defects." -f ([int]$compilerTotal), $compiler.Count)
+    Write-Host '   If a normal build is green, ignore these. `dotnet restore` first reduces them.'
+    Write-Host ("Analyzer:       {0} across {1} rules  <- the actionable findings." -f ([int]$analyzerTotal), $analyzer.Count)
 
     if ($analyzer.Count -gt 0) {
         Write-Section ("Top analyzer rules (max {0})" -f $TopRules)

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -176,7 +176,8 @@ if ($total -gt 0) {
 }
 
 Write-Section "Report"
-$uri = ([System.Uri]$report).AbsoluteUri
-Write-Host "  $report"
+$fullReportPath = [System.IO.Path]::GetFullPath($report)
+$uri = ([System.Uri]$fullReportPath).AbsoluteUri
+Write-Host "  $fullReportPath"
 Write-Host "  $uri"
 exit 0

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -9,7 +9,7 @@
       * self-healing: detects the SDK-10 MSBuild `FileUtilities` TypeLoadException and
         neutralizes the bundled Microsoft.Build.Framework.dll, then retries once
         (see resources/TROUBLESHOOTING.md for the underlying cause)
-      * running `analyze` to a timestamped XML report under the repo's .roslynator-results/
+      * running `analyze` to a timestamped XML report under the OS temp directory
       * parsing the report: severity breakdown, compiler (CS*) vs analyzer split, top rules
 
     Non-interactive by design. If -Solution is omitted it uses the sole discovered
@@ -22,8 +22,8 @@
     Minimum severity to report: hidden | info | warning | error. Default: info.
 
 .PARAMETER Output
-    Directory for the XML report. Default: <repo-root>/.roslynator-results (falls back to the
-    current directory if not in a git repo). Each run writes a timestamped file.
+    Directory for the XML report. Default: <temp>/roslynator-analysis. Each run writes a
+    timestamped file.
 
 .PARAMETER TopRules
     How many analyzer rules to list in the summary. Default: 20.
@@ -81,11 +81,9 @@ if (-not (Test-Path $Solution)) {
 $Solution = (Resolve-Path $Solution).Path
 Write-Host "Solution: $Solution"
 
-# --- 3. Output path (repo-relative, timestamped filename) ----------------------
+# --- 3. Output path (temp-directory default, timestamped filename) -------------
 if (-not $Output) {
-    $repoRoot = (& git rev-parse --show-toplevel 2>$null)
-    if (-not $repoRoot) { $repoRoot = (Get-Location).Path }
-    $Output = Join-Path $repoRoot '.roslynator-results'
+    $Output = Join-Path ([System.IO.Path]::GetTempPath()) 'roslynator-analysis'
 }
 New-Item -ItemType Directory -Force -Path $Output | Out-Null
 $report = Join-Path $Output ("analysis-{0}.xml" -f (Get-Date -Format 'yyyyMMdd-HHmmssfff'))

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -9,7 +9,7 @@
       * self-healing: detects the SDK-10 MSBuild `FileUtilities` TypeLoadException and
         neutralizes the bundled Microsoft.Build.Framework.dll, then retries once
         (see resources/TROUBLESHOOTING.md for the underlying cause)
-      * running `analyze` to a timestamped XML report under the repo's roslynator-results/
+      * running `analyze` to a timestamped XML report under the repo's .roslynator-results/
       * parsing the report: severity breakdown, compiler (CS*) vs analyzer split, top rules
 
     Non-interactive by design. If -Solution is omitted it uses the sole discovered
@@ -22,7 +22,7 @@
     Minimum severity to report: hidden | info | warning | error. Default: info.
 
 .PARAMETER Output
-    Directory for the XML report. Default: <repo-root>/roslynator-results (falls back to the
+    Directory for the XML report. Default: <repo-root>/.roslynator-results (falls back to the
     current directory if not in a git repo). Each run writes a timestamped file.
 
 .PARAMETER TopRules
@@ -82,7 +82,7 @@ Write-Host "Solution: $Solution"
 if (-not $Output) {
     $repoRoot = (& git rev-parse --show-toplevel 2>$null)
     if (-not $repoRoot) { $repoRoot = (Get-Location).Path }
-    $Output = Join-Path $repoRoot 'roslynator-results'
+    $Output = Join-Path $repoRoot '.roslynator-results'
 }
 New-Item -ItemType Directory -Force -Path $Output | Out-Null
 $report = Join-Path $Output ("analysis-{0}.xml" -f (Get-Date -Format 'yyyyMMdd-HHmmssfff'))

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -1,0 +1,167 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Runs Roslynator `analyze` against a .NET solution and prints a parsed summary.
+
+.DESCRIPTION
+    Deterministic wrapper for the roslynator-analysis skill. Handles:
+      * preflight: verifies the Roslynator CLI is installed
+      * self-healing: detects the SDK-10 MSBuild `FileUtilities` TypeLoadException and
+        neutralizes the bundled Microsoft.Build.Framework.dll, then retries once
+        (see resources/TROUBLESHOOTING.md for the underlying cause)
+      * running `analyze` to an XML report in an OS-agnostic temp folder
+      * parsing the report: severity breakdown, compiler (CS*) vs analyzer split, top rules
+
+    Non-interactive by design. If -Solution is omitted it uses the sole discovered
+    solution, or exits 3 listing candidates so the caller can pick one and re-invoke.
+
+.PARAMETER Solution
+    Path to a .sln/.slnx. If omitted, discovers solutions under the current directory.
+
+.PARAMETER SeverityLevel
+    Minimum severity to report: hidden | info | warning | error. Default: info.
+
+.PARAMETER Output
+    Directory for the XML report. Default: <temp>/roslynator-results.
+
+.PARAMETER TopRules
+    How many analyzer rules to list in the summary. Default: 20.
+
+.OUTPUTS
+    Human-readable summary on stdout.
+
+.NOTES
+    Exit codes: 0 success (report produced, diagnostics allowed) · 2 tool not installed ·
+    3 solution resolution failed · 4 analysis failed for another reason.
+#>
+[CmdletBinding()]
+param(
+    [string]$Solution,
+    [ValidateSet('hidden', 'info', 'warning', 'error')]
+    [string]$SeverityLevel = 'info',
+    [string]$Output,
+    [int]$TopRules = 20
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Section($text) { Write-Host ''; Write-Host "=== $text ===" }
+function Fail($msg, $code) { [Console]::Error.WriteLine($msg); exit $code }
+
+# --- 1. Preflight: Roslynator installed? ---------------------------------------
+$version = $null
+try { $version = (& roslynator --version) 2>$null } catch { }
+if (-not $version) {
+    Fail "Roslynator CLI not found. Install with: dotnet tool install -g roslynator.dotnet.cli" 2
+}
+Write-Host "Roslynator $version"
+
+# --- 2. Resolve the solution ---------------------------------------------------
+if (-not $Solution) {
+    $found = Get-ChildItem -Path (Get-Location) -Recurse -Include *.sln, *.slnx -File -ErrorAction SilentlyContinue
+    if (@($found).Count -eq 0) {
+        Fail "No .sln/.slnx found under $(Get-Location). Pass -Solution explicitly." 3
+    }
+    elseif (@($found).Count -eq 1) {
+        $Solution = $found[0].FullName
+    }
+    else {
+        Write-Host "Multiple solutions found - pass one via -Solution:"
+        $found | ForEach-Object { Write-Host "  $($_.FullName)" }
+        exit 3
+    }
+}
+if (-not (Test-Path $Solution)) {
+    Fail "Solution not found: $Solution" 3
+}
+$Solution = (Resolve-Path $Solution).Path
+Write-Host "Solution: $Solution"
+
+# --- 3. Output path (OS-agnostic temp) -----------------------------------------
+if (-not $Output) { $Output = Join-Path ([System.IO.Path]::GetTempPath()) 'roslynator-results' }
+New-Item -ItemType Directory -Force -Path $Output | Out-Null
+$report = Join-Path $Output 'analysis.xml'
+if (Test-Path $report) { Remove-Item $report -Force }
+
+# --- Helper: neutralize the bundled MSBuild framework DLL (SDK-10 workaround) ---
+function Repair-BundledMSBuild {
+    $roots = @(
+        (Join-Path $HOME '.dotnet/tools/.store'),
+        (Join-Path $env:USERPROFILE '.dotnet/tools/.store')
+    ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -Unique
+    $renamed = 0
+    foreach ($root in $roots) {
+        Get-ChildItem -Path $root -Recurse -Filter 'Microsoft.Build.Framework.dll' -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match 'roslynator\.dotnet\.cli' } |
+            ForEach-Object {
+                Rename-Item $_.FullName "$($_.FullName).bak" -Force
+                Write-Host "  neutralized $($_.FullName)"
+                $renamed++
+            }
+    }
+    return $renamed
+}
+
+# --- 4. Run analysis (self-healing retry on the SDK-10 MSBuild conflict) --------
+function Invoke-Analyze {
+    $out = & roslynator analyze $Solution --output $report --severity-level $SeverityLevel --verbosity minimal 2>&1
+    return [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = ($out -join "`n") }
+}
+
+Write-Section "Analyzing"
+$result = Invoke-Analyze
+# roslynator: exit 0 = clean, 1 = diagnostics found (both success). >=2 = failure.
+if ($result.ExitCode -ge 2 -and $result.Output -match 'FileUtilities|Microsoft\.Build\.Framework') {
+    Write-Host "Detected SDK/MSBuild assembly conflict - applying workaround (see resources/TROUBLESHOOTING.md):"
+    if ((Repair-BundledMSBuild) -gt 0) {
+        Write-Host "Retrying analysis..."
+        $result = Invoke-Analyze
+    }
+}
+
+if (-not (Test-Path $report) -or $result.ExitCode -ge 2) {
+    Write-Host $result.Output
+    Fail "Roslynator analysis failed (exit $($result.ExitCode)). See resources/TROUBLESHOOTING.md." 4
+}
+
+# --- 5. Parse and summarize ----------------------------------------------------
+[xml]$xml = Get-Content $report
+$summary = @($xml.Roslynator.CodeAnalysis.Summary.Diagnostic)
+$total = ($summary | Measure-Object -Property Count -Sum).Sum
+if (-not $total) { $total = 0 }
+
+Write-Section "Summary"
+Write-Host ("Total diagnostics: {0}  (distinct rules: {1})" -f $total, $summary.Count)
+
+if ($total -gt 0) {
+    # Detail nodes carry Severity as a child element: <Diagnostic Id="..."><Severity>Info</Severity>...
+    $detail = @($xml.SelectNodes('//Projects//Diagnostic'))
+    if ($detail.Count -gt 0) {
+        Write-Host ''
+        Write-Host "By severity:"
+        $detail | Group-Object { $_.Severity } | Sort-Object { $_.Count } -Descending |
+            ForEach-Object { Write-Host ("  {0,-9} {1}" -f $_.Name, $_.Count) }
+    }
+
+    $compiler = @($summary | Where-Object { $_.Id -like 'CS*' })
+    $analyzer = @($summary | Where-Object { $_.Id -notlike 'CS*' })
+    $compilerTotal = ($compiler | Measure-Object Count -Sum).Sum
+    $analyzerTotal = ($analyzer | Measure-Object Count -Sum).Sum
+
+    Write-Host ''
+    Write-Host ("Compiler (CS*): {0} across {1} rules  <- usually workspace-resolution noise, not defects." -f ([int]$compilerTotal), $compiler.Count)
+    Write-Host ("   If a normal build is green, ignore these. `dotnet restore` first reduces them.")
+    Write-Host ("Analyzer:       {0} across {1} rules  <- the actionable findings." -f ([int]$analyzerTotal), $analyzer.Count)
+
+    if ($analyzer.Count -gt 0) {
+        Write-Section ("Top analyzer rules (max {0})" -f $TopRules)
+        $analyzer | Sort-Object { [int]$_.Count } -Descending | Select-Object -First $TopRules |
+            ForEach-Object { Write-Host ("  {0,-11} {1,4}  {2}" -f $_.Id, $_.Count, $_.Title) }
+    }
+}
+
+Write-Section "Report"
+$uri = ([System.Uri]$report).AbsoluteUri
+Write-Host "  $report"
+Write-Host "  $uri"
+exit 0

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -59,7 +59,10 @@ Write-Host "Roslynator $version"
 
 # --- 2. Resolve the solution ---------------------------------------------------
 if (-not $Solution) {
-    $found = Get-ChildItem -Path (Get-Location) -Recurse -Include *.sln, *.slnx -File -ErrorAction SilentlyContinue
+    $found = @(
+        Get-ChildItem -Path (Get-Location) -Recurse -File -Filter '*.sln' -ErrorAction SilentlyContinue
+        Get-ChildItem -Path (Get-Location) -Recurse -File -Filter '*.slnx' -ErrorAction SilentlyContinue
+    )
     if (@($found).Count -eq 0) {
         Fail "No .sln/.slnx found under $(Get-Location). Pass -Solution explicitly." 3
     }

--- a/.claude/skills/roslynator-analysis/scripts/analyze.ps1
+++ b/.claude/skills/roslynator-analysis/scripts/analyze.ps1
@@ -152,10 +152,10 @@ if ($total -gt 0) {
     $compilerTotal = ($compiler | Measure-Object Count -Sum).Sum
     $analyzerTotal = ($analyzer | Measure-Object Count -Sum).Sum
 
-    Write-Host ''
-    Write-Host ("Compiler (CS*): {0} across {1} rules  <- usually workspace-resolution noise, not defects." -f ([int]$compilerTotal), $compiler.Count)
-    Write-Host ("   If a normal build is green, ignore these. `dotnet restore` first reduces them.")
-    Write-Host ("Analyzer:       {0} across {1} rules  <- the actionable findings." -f ([int]$analyzerTotal), $analyzer.Count)
+Write-Host ''
+Write-Host ("Compiler (CS*): {0} across {1} rules  <- usually workspace-resolution noise, not defects." -f ([int]$compilerTotal), $compiler.Count)
+Write-Host '   If a normal build is green, ignore these. `dotnet restore` first reduces them.'
+Write-Host ("Analyzer:       {0} across {1} rules  <- the actionable findings." -f ([int]$analyzerTotal), $analyzer.Count)
 
     if ($analyzer.Count -gt 0) {
         Write-Section ("Top analyzer rules (max {0})" -f $TopRules)

--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,6 @@ coverage.cobertura.xml
 /build
 /.claude/settings.local.json
 nul
+
+# Roslynator analysis reports (roslynator-analysis skill)
+/roslynator-results/

--- a/.gitignore
+++ b/.gitignore
@@ -359,6 +359,3 @@ coverage.cobertura.xml
 /build
 /.claude/settings.local.json
 nul
-
-# Roslynator analysis reports (roslynator-analysis skill)
-/.roslynator-results/

--- a/.gitignore
+++ b/.gitignore
@@ -361,4 +361,4 @@ coverage.cobertura.xml
 nul
 
 # Roslynator analysis reports (roslynator-analysis skill)
-/roslynator-results/
+/.roslynator-results/


### PR DESCRIPTION
## Summary

Adds a repo-level Claude Code skill (`.claude/skills/roslynator-analysis/`) that runs Roslynator `analyze` against a .NET solution and returns a parsed summary.

## What's included

- **`scripts/analyze.ps1`** — deterministic, non-interactive wrapper:
  - Preflight install check (distinct exit codes for missing tool / solution / failure).
  - Resolves the solution (`-Solution`, sole auto-detect, or lists candidates for the caller to pick).
  - Writes the XML report to an OS-agnostic temp folder.
  - Prints a summary: severity breakdown, **compiler (`CS*`) vs analyzer split**, top analyzer rules, and a clickable report link.
  - **Self-heals** the .NET 10 SDK MSBuild `FileUtilities` `TypeLoadException` by neutralizing the bundled `Microsoft.Build.Framework.dll` and retrying once.
- **`resources/TROUBLESHOOTING.md`** — progressively disclosed cause/fix for the MSBuild conflict and the `CS*`-noise explanation.
- **`SKILL.md`** — thin workflow: resolve solution → run script → interpret exit codes.

## Testing

- Ran end-to-end against `src/ChurchBulletin.sln`: 476 diagnostics (Error 333 / Info 139 / Warning 4), 337 `CS*` separated from 139 actionable analyzer findings.
- Verified the exit-code contract (bad path → 3).
- Verified the self-heal against a genuinely regressed tool install (reinstall restores the bad DLL): the script detected the conflict, neutralized the bundled DLL across the net8/net9/net10 tool folders, retried, and exited 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)