### PR TITLE
UI: Clarify Login page portal heading

### DIFF
--- a/src/UI.Shared/Pages/Login.razor
+++ b/src/UI.Shared/Pages/Login.razor
@@ -3,7 +3,7 @@
 <div class="login-container">
     <div class="login-card card">
         <div class="login-header">
-            <h3>Church Staff Portal</h3>
+            <h3>Church Staff Sign-In Portal</h3>
             <div class="login-subtitle">First Church of Shelbyville</div>
         </div>
         <div class="login-body">


### PR DESCRIPTION
Closes #6975

Update the login page heading text.

**File:** `src/UI.Shared/Pages/Login.razor`

**Change:** Replace the heading `Church Staff Portal` with `Church Staff Sign-In Portal`.

**Acceptance criteria:**
- The login card header shows the new heading.
- UI-only copy change; keep the build green.