### PR TITLE
UI: Reword Settings page subtitle

### DIFF
--- a/src/UI.Shared/Pages/Settings.razor
+++ b/src/UI.Shared/Pages/Settings.razor
@@ -4,7 +4,7 @@
     <div class="settings-container">
         <header class="settings-header">
             <h1>Settings</h1>
-            <p class="settings-subtitle">Manage preferences for this browser.</p>
+            <p class="settings-subtitle">Manage your preferences for this browser.</p>
         </header>
 
         <section class="settings-section" aria-labelledby="appearance-heading">


### PR DESCRIPTION
Closes #6976

Update the Settings page subtitle.

**File:** `src/UI.Shared/Pages/Settings.razor`

**Change:** Replace `Manage preferences for this browser.` with `Manage your preferences for this browser.`

**Acceptance criteria:**
- The settings subtitle shows the new wording.
- UI-only copy change; keep the build green.