### PR TITLE
UI: Rename Weather Report heading to Weather Forecast

### DIFF
--- a/src/UI.Shared/Pages/FetchData.razor
+++ b/src/UI.Shared/Pages/FetchData.razor
@@ -3,7 +3,7 @@
 <div class="weather-page">
     <div class="weather-container">
         <div class="weather-header">
-            <h2>🌤️ Springfield Weather Report</h2>
+            <h2>🌤️ Springfield Weather Forecast</h2>
             <div class="weather-subtitle">Weather conditions for church events and maintenance planning</div>
         </div>
 


### PR DESCRIPTION
Closes #6977

Update the weather page heading on the FetchData page.

**File:** `src/UI.Shared/Pages/FetchData.razor`

**Change:** Replace the heading `🌤️ Springfield Weather Report` with `🌤️ Springfield Weather Forecast` (keep the emoji).

**Acceptance criteria:**
- The weather page h2 shows "Springfield Weather Forecast".
- UI-only copy change; keep the build green.