### PR TITLE
UI: Reword Work Order Search subtitle

### DIFF
--- a/src/UI.Shared/Pages/WorkOrderSearch.razor
+++ b/src/UI.Shared/Pages/WorkOrderSearch.razor
@@ -2,7 +2,7 @@
     <div class="search-container">
         <div class="search-header">
             <h2>Work Order Search</h2>
-            <div class="search-subtitle">Find and manage church maintenance requests</div>
+            <div class="search-subtitle">Search and manage church maintenance requests</div>
         </div>
 
         <div class="search-filters-card">


### PR DESCRIPTION
Closes #6978

Update the Work Order Search subtitle.

**File:** `src/UI.Shared/Pages/WorkOrderSearch.razor`

**Change:** Replace `Find and manage church maintenance requests` with `Search and manage church maintenance requests`.

**Acceptance criteria:**
- The search page subtitle shows the new wording.
- UI-only copy change; keep the build green.