### PR TITLE
UI: Rename Attachments section heading to File Attachments

### DIFF
--- a/src/UI.Shared/Pages/WorkOrderManage.razor
+++ b/src/UI.Shared/Pages/WorkOrderManage.razor
@@ -101,7 +101,7 @@
             @if (_attachments.Length > 0)
             {
                 <div class="attachments-section" data-testid="@Elements.AttachmentsSection">
-                    <h4>Attachments</h4>
+                    <h4>File Attachments</h4>
                     <table class="table table-sm">
                         <thead>
                             <tr>


### PR DESCRIPTION
Closes #6980

Update the attachments section heading on the Work Order manage page.

**File:** `src/UI.Shared/Pages/WorkOrderManage.razor`

**Change:** Replace the `<h4>Attachments</h4>` heading text with `File Attachments`.

**Acceptance criteria:**
- The attachments section heading reads "File Attachments".
- Do not change the data-testid. UI-only copy change; keep the build green.