### PR TITLE
Use claude-only image in dev-workstation; fix launcher nitpicks

### DIFF
--- a/.bob/skills/ai-factory-executor/container-manager.ps1
+++ b/.bob/skills/ai-factory-executor/container-manager.ps1
@@ -30,32 +30,64 @@ function Write-Info { param([string]$Message) Write-Host "[INFO] $Message" -Fore
 
 <#
 .SYNOPSIS
-    Ensures the Docker image is built and ready
+    Ensures the Docker image is built and ready for the selected agent.
+.DESCRIPTION
+    Selects the Dockerfile and image tag per agent and builds it if absent:
+      - claude: Dockerfile.agent.claude -> ai-factory-agent-claude:latest
+                (omits the private bobshell tarball, so it builds on hosts
+                 without that gitignored package)
+      - bob:    Dockerfile.agent        -> ai-factory-agent:latest
+    Sets $script:ImageName to the selected tag so callers reference the right
+    image, and returns that tag. If the claude variant Dockerfile is missing,
+    falls back to the full Dockerfile.agent.
 #>
 function Initialize-AgentImage {
-    Write-Progress "Checking Docker image: $script:ImageName"
-    
-    $imageExists = docker images -q $script:ImageName 2>$null
-    
-    if (-not $imageExists) {
-        Write-Progress "Building Docker image..."
-        
-        $dockerfilePath = Join-Path $PSScriptRoot "Dockerfile.agent"
-        
-        if (-not (Test-Path $dockerfilePath)) {
-            throw "Dockerfile.agent not found at $dockerfilePath"
+    [CmdletBinding()]
+    param(
+        [ValidateSet("claude", "bob")]
+        [string]$AiAgent = "bob"
+    )
+
+    if ($AiAgent.ToLower() -eq "claude") {
+        $dockerfileName = "Dockerfile.agent.claude"
+        $imageName = "ai-factory-agent-claude:latest"
+        # Fall back to the full Dockerfile if the claude variant is absent.
+        if (-not (Test-Path (Join-Path $PSScriptRoot $dockerfileName))) {
+            Write-Info "$dockerfileName not found; falling back to Dockerfile.agent"
+            $dockerfileName = "Dockerfile.agent"
+            $imageName = "ai-factory-agent:latest"
         }
-        
+    } else {
+        $dockerfileName = "Dockerfile.agent"
+        $imageName = "ai-factory-agent:latest"
+    }
+    $script:ImageName = $imageName
+
+    Write-Progress "Checking Docker image: $script:ImageName"
+
+    $imageExists = docker images -q $script:ImageName 2>$null
+
+    if (-not $imageExists) {
+        Write-Progress "Building Docker image from $dockerfileName..."
+
+        $dockerfilePath = Join-Path $PSScriptRoot $dockerfileName
+
+        if (-not (Test-Path $dockerfilePath)) {
+            throw "$dockerfileName not found at $dockerfilePath"
+        }
+
         docker build -t $script:ImageName -f $dockerfilePath $PSScriptRoot
-        
+
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to build Docker image"
         }
-        
+
         Write-Success "Docker image built"
     } else {
         Write-Success "Docker image ready"
     }
+
+    return $script:ImageName
 }
 
 <#
@@ -195,7 +227,7 @@ function Start-AgentContainer {
     )
 
     # Initialize infrastructure
-    Initialize-AgentImage
+    Initialize-AgentImage -AiAgent $AiAgent
     Initialize-AgentNetwork
     $tokenFile = Initialize-GitHubSecret
     $agentSecret = Initialize-AgentSecret -AiAgent $AiAgent

--- a/.bob/skills/ai-factory-executor/dev-entrypoint.ps1
+++ b/.bob/skills/ai-factory-executor/dev-entrypoint.ps1
@@ -42,7 +42,8 @@ try {
     # 2. Credentials: gh + git, Claude, Bob
     if (Test-Path "/run/secrets/gh_token") {
         Get-Content "/run/secrets/gh_token" | gh auth login --with-token
-        $ghToken = Get-Content "/run/secrets/gh_token" -Raw
+        # Trim: a trailing newline in the token file corrupts the credential URL.
+        $ghToken = (Get-Content "/run/secrets/gh_token" -Raw).Trim()
         git config --global user.name "AI Factory Bot"
         git config --global user.email "ai-factory-bot@users.noreply.github.com"
         git config --global credential.helper store

--- a/.bob/skills/ai-factory-executor/run-dev.ps1
+++ b/.bob/skills/ai-factory-executor/run-dev.ps1
@@ -45,6 +45,11 @@ if ($HttpPort  -eq 0) {
     # two independent Get-FreePort calls can otherwise return the same port.
     do { $HttpPort = Get-FreePort } while ($HttpPort -eq $HttpsPort)
 }
+# Fail fast on a duplicate host port mapping (e.g. both ports supplied equal),
+# rather than surfacing a cryptic docker run error later.
+if ($HttpPort -eq $HttpsPort) {
+    throw "HttpPort and HttpsPort must differ (both are $HttpPort)."
+}
 
 # Resolve the host repo path (default: three levels up from this skill dir -> repo root)
 if (-not $HostRepo) {

--- a/.bob/skills/ai-factory-executor/run-dev.ps1
+++ b/.bob/skills/ai-factory-executor/run-dev.ps1
@@ -40,17 +40,23 @@ function Get-FreePort {
 }
 
 if ($HttpsPort -eq 0) { $HttpsPort = Get-FreePort }
-if ($HttpPort  -eq 0) { $HttpPort  = Get-FreePort }
+if ($HttpPort  -eq 0) {
+    # Ensure a distinct port: each listener is closed before the next opens, so
+    # two independent Get-FreePort calls can otherwise return the same port.
+    do { $HttpPort = Get-FreePort } while ($HttpPort -eq $HttpsPort)
+}
 
 # Resolve the host repo path (default: three levels up from this skill dir -> repo root)
 if (-not $HostRepo) {
-    $HostRepo = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+    # Join-Path with separate ".." segments is portable (avoids a literal
+    # backslash path, which is not a separator on non-Windows PowerShell).
+    $HostRepo = (Resolve-Path (Join-Path $PSScriptRoot ".." ".." "..")).Path
 }
 if (-not (Test-Path (Join-Path $HostRepo "build.ps1"))) {
     throw "HostRepo '$HostRepo' does not look like the repo root (no build.ps1)."
 }
 
-Initialize-AgentImage
+Initialize-AgentImage -AiAgent $AiAgent
 Initialize-AgentNetwork
 $tokenFile = Initialize-GitHubSecret
 $agentSecret = Initialize-AgentSecret -AiAgent $AiAgent

--- a/.bob/skills/ai-factory-executor/run-experiment.ps1
+++ b/.bob/skills/ai-factory-executor/run-experiment.ps1
@@ -38,7 +38,7 @@ param(
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "container-manager.ps1")
 
-Initialize-AgentImage
+Initialize-AgentImage -AiAgent $AiAgent
 Initialize-AgentNetwork
 $tokenFile = Initialize-GitHubSecret
 $agentSecret = Initialize-AgentSecret -AiAgent $AiAgent


### PR DESCRIPTION
## Summary
Follow-up to #7017. Makes the AI-factory dev-workstation actually use the claude-only image and cleans up review nitpicks from that PR.

- **`Initialize-AgentImage` selects the Dockerfile/tag per agent** — claude → `Dockerfile.agent.claude` (`ai-factory-agent-claude:latest`), bob → `Dockerfile.agent` (`ai-factory-agent:latest`), with fallback to the full Dockerfile if the claude variant is absent. Previously `run-dev.ps1` (which defaults to the claude agent) always built `Dockerfile.agent`, which requires the private, gitignored `bobshell-1.0.6.tgz` and therefore failed on hosts without it — the exact failure that required a manual image build.
- **`run-dev.ps1`**: auto-picked HTTP/HTTPS ports are now guaranteed distinct; host-repo default uses a portable `Join-Path` (separate `..` segments) instead of a literal backslash path.
- **`dev-entrypoint.ps1`**: GH token is trimmed (a trailing newline corrupted the stored credential URL).

## Testing
Devops/launcher PowerShell scripts — no application module boundary crossed and the repo has no PowerShell (Pester) test harness, so no unit/integration/full-system .NET test applies. Verified manually:
- All three scripts pass PowerShell AST parse.
- `Initialize-AgentImage -AiAgent claude` selects/returns `ai-factory-agent-claude:latest`; `-AiAgent bob` selects `ai-factory-agent:latest` (both confirmed against the local Docker daemon with no rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)