### PR TITLE
[aidevtest-1d08d920] Add /_healthcheck 'ok' text

### DIFF
--- a/src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs
+++ b/src/AcceptanceTests/App/NeedsRebootHealthCheckTests.cs
@@ -79,6 +79,19 @@ public class NeedsRebootHealthCheckTests : AcceptanceTestBase
     }
 
     [Test, Retry(2)]
+    public async Task HealthCheck_WhenHealthy_ReturnsOkText()
+    {
+        using var client = CreateHttpClient();
+
+        await client.GetAsync("/_demo/setneedsreboot/false");
+
+        var healthResponse = await client.GetAsync("/_healthcheck");
+        healthResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var healthBody = await healthResponse.Content.ReadAsStringAsync();
+        healthBody.ShouldContain("ok", Case.Insensitive);
+    }
+
+    [Test, Retry(2)]
     public async Task SetNeedsRebootTrue_DetailedHealthCheckShowsCorruptionMessage()
     {
         using var client = CreateHttpClient();

--- a/src/UI/Server/HealthCheckResponseWriter.cs
+++ b/src/UI/Server/HealthCheckResponseWriter.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Writes a concise, friendly plain-text body for the <c>/_healthcheck</c> endpoint.
+/// A passing report yields a body containing "ok" alongside the overall status so
+/// callers get a human-readable acknowledgement in addition to the 200 status code.
+/// </summary>
+public static class HealthCheckResponseWriter
+{
+    /// <summary>
+    /// Writes the overall status of the <paramref name="report"/> to the response body.
+    /// When the report is not <see cref="HealthStatus.Unhealthy"/>, the friendly text
+    /// "ok" is appended so a healthy endpoint responds with e.g. "Healthy - ok".
+    /// </summary>
+    public static async Task WriteAsync(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "text/plain; charset=utf-8";
+
+        var body = report.Status == HealthStatus.Unhealthy
+            ? report.Status.ToString()
+            : $"{report.Status} - ok";
+
+        await context.Response.WriteAsync(body);
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -270,7 +270,10 @@ app.MapGet("/_demo/setneedsreboot/{value:bool}", (bool value) =>
     return Results.Text($"NeedsReboot set to {value}");
 });
 
-app.MapHealthChecks("_healthcheck");
+app.MapHealthChecks("_healthcheck", new HealthCheckOptions
+{
+    ResponseWriter = HealthCheckResponseWriter.WriteAsync
+});
 app.MapHealthChecks("_healthcheck/detailed", new HealthCheckOptions
 {
     ResponseWriter = DetailedHealthCheckResponseWriter.WriteAsync


### PR DESCRIPTION
Closes #7024

Ensure the health check endpoint returns a friendly 'ok' body in addition to 200. Add/adjust a test.