### PR TITLE
[aidevtest-1d08d920] Add app version to footer

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-version" data-testid="@nameof(Elements.AppVersion)">v@(AppVersion)</span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using ClearMeasure.Bootcamp.UI.Shared.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -15,13 +16,33 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        AppVersion
     }
 
     /// <summary>
     /// Calendar year shown in the site copyright line (UTC, matches acceptance tests).
     /// </summary>
     protected int CopyrightYear => DateTime.UtcNow.Year;
+
+    /// <summary>
+    /// Application version (assembly informational version) shown in the site footer.
+    /// Any build-metadata suffix (after <c>+</c>) is trimmed for display.
+    /// </summary>
+    protected string AppVersion
+    {
+        get
+        {
+            var assembly = typeof(MainLayout).Assembly;
+            var informational = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
+            var version = string.IsNullOrWhiteSpace(informational)
+                ? assembly.GetName().Version?.ToString()
+                : informational.Split('+')[0];
+            return string.IsNullOrWhiteSpace(version) ? "unknown" : version;
+        }
+    }
 
     [Inject]
     private IJSRuntime Js { get; set; } = default!;

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -299,6 +299,14 @@
     word-wrap: break-word;
 }
 
+.site-footer-version {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    font-style: normal;
+    color: #a0aec0;
+}
+
 .site-footer-link {
     margin-left: 0.35rem;
     color: #4a5568;
@@ -559,6 +567,10 @@
 
 :global(html[data-theme="dark"]) .site-footer-line {
     color: #a0aec0;
+}
+
+:global(html[data-theme="dark"]) .site-footer-version {
+    color: #718096;
 }
 
 :global(html[data-theme="dark"]) .site-footer-link {

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Reflection;
 using Bunit;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Model;
@@ -203,6 +204,30 @@ public class MainLayoutTests
         footer.TextContent.ShouldContain(yearText);
         footer.TextContent.ShouldContain("ClearMeasure Labs");
         layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}'] .site-footer-link").GetAttribute("href")!.TrimEnd('/').ShouldBe("https://clearmeasure.com");
+    }
+
+    [Test]
+    public void ShouldRenderAppVersion_InFooter()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var footer = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}']");
+        var version = layout.Find($"[data-testid='{nameof(MainLayout.Elements.AppVersion)}']");
+
+        footer.TextContent.ShouldContain(version.TextContent.Trim());
+
+        var expectedVersion = typeof(MainLayout).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion?.Split('+')[0];
+        if (!string.IsNullOrWhiteSpace(expectedVersion))
+        {
+            version.TextContent.ShouldContain(expectedVersion);
+        }
+
+        version.TextContent.Trim().ShouldStartWith("v");
     }
 
     [Test]


### PR DESCRIPTION
Closes #7023

Display the application version (assembly informational version) in the site footer on every page. Keep the change minimal and add a bUnit test.