### PR TITLE
[aidevtest-1d08d920] Show work request count on dashboard

### DIFF
--- a/src/Core/Queries/WorkOrderCountQuery.cs
+++ b/src/Core/Queries/WorkOrderCountQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace ClearMeasure.Bootcamp.Core.Queries;
+
+public record WorkOrderCountQuery : IRequest<int>, IRemotableRequest;

--- a/src/DataAccess/Handlers/WorkOrderCountQueryHandler.cs
+++ b/src/DataAccess/Handlers/WorkOrderCountQueryHandler.cs
@@ -1,0 +1,19 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.DataAccess.Mappings;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClearMeasure.Bootcamp.DataAccess.Handlers;
+
+public class WorkOrderCountQueryHandler(DataContext context) :
+    IRequestHandler<WorkOrderCountQuery, int>
+{
+    public async Task<int> Handle(WorkOrderCountQuery request,
+        CancellationToken cancellationToken = default)
+    {
+        return await context.Set<WorkOrder>()
+            .AsNoTracking()
+            .CountAsync(cancellationToken);
+    }
+}

--- a/src/IntegrationTests/DataAccess/WorkOrderCountQueryHandlerTests.cs
+++ b/src/IntegrationTests/DataAccess/WorkOrderCountQueryHandlerTests.cs
@@ -1,0 +1,50 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.DataAccess.Handlers;
+using ClearMeasure.Bootcamp.DataAccess.Mappings;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.DataAccess;
+
+[TestFixture]
+public class WorkOrderCountQueryHandlerTests
+{
+    [Test]
+    public async Task ShouldReturnTotalWorkOrderCount()
+    {
+        new DatabaseTests().Clean();
+
+        var creator = new Employee("1", "1", "1", "1");
+        var order1 = new WorkOrder { Creator = creator, Number = "123" };
+        var order2 = new WorkOrder { Creator = creator, Number = "456" };
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(creator);
+            context.Add(order1);
+            context.Add(order2);
+            context.SaveChanges();
+        }
+
+        var dataContext = TestHost.GetRequiredService<DataContext>();
+        var handler = new WorkOrderCountQueryHandler(dataContext);
+
+        var count = await handler.Handle(new WorkOrderCountQuery());
+
+        count.ShouldBe(2);
+    }
+
+    [Test]
+    public async Task ShouldReturnZeroWhenNoWorkOrdersExist()
+    {
+        new DatabaseTests().Clean();
+
+        var dataContext = TestHost.GetRequiredService<DataContext>();
+        var handler = new WorkOrderCountQueryHandler(dataContext);
+
+        var count = await handler.Handle(new WorkOrderCountQuery());
+
+        count.ShouldBe(0);
+    }
+}

--- a/src/UI.Shared/Pages/Index.razor
+++ b/src/UI.Shared/Pages/Index.razor
@@ -1,10 +1,17 @@
 @page "/"
+@using ClearMeasure.Bootcamp.Core.Queries
+@inherits AppComponentBase
 
 <PageTitle>Clear Measure - .NET Bootcamp - Work Order Application</PageTitle>
 
 <div class="greeting-banner" data-testid="@nameof(Elements.GreetingBanner)">
     <span class="greeting-banner-emoji" aria-hidden="true" data-testid="@nameof(Elements.GreetingBannerEmoji)">⛪</span>
     <p>Welcome to the AI Software Factory!</p>
+</div>
+
+<div class="work-request-count" data-testid="@nameof(Elements.WorkRequestCount)">
+    <span class="work-request-count-number">@_workRequestCount</span>
+    <span class="work-request-count-label">Total Work Requests</span>
 </div>
 
 <div class="church-hero">
@@ -57,9 +64,17 @@
 </div>
 
 @code {
+    private int _workRequestCount;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _workRequestCount = await Bus.Send(new WorkOrderCountQuery());
+    }
+
     public enum Elements
     {
         GreetingBanner,
-        GreetingBannerEmoji
+        GreetingBannerEmoji,
+        WorkRequestCount
     }
 }

--- a/src/UI.Shared/Pages/Index.razor.css
+++ b/src/UI.Shared/Pages/Index.razor.css
@@ -26,6 +26,34 @@
     margin: 0;
 }
 
+.work-request-count {
+    background: #fff;
+    border-radius: 10px;
+    padding: 1.25rem 2rem;
+    margin-bottom: 1.5rem;
+    text-align: center;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.work-request-count-number {
+    font-size: 2.5rem;
+    font-weight: 700;
+    line-height: 1;
+    color: #2c3e50;
+}
+
+.work-request-count-label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #7f8c8d;
+}
+
 .church-hero {
     background: linear-gradient(135deg, #4a90e2 0%, #7b68ee 50%, #87ceeb 100%);
     min-height: 80vh;

--- a/src/UnitTests/UI.Shared/Pages/IndexPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/IndexPageTests.cs
@@ -28,4 +28,18 @@ public class IndexPageTests
         emoji.GetAttribute("aria-hidden").ShouldBe("true");
         emoji.TextContent.ShouldContain("⛪");
     }
+
+    [Test]
+    public void ShouldDisplayTotalWorkRequestCount()
+    {
+        using var ctx = new TestContext();
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new StubBus { WorkRequestCount = 42 });
+
+        var component = ctx.RenderComponent<IndexPage>();
+
+        var count = component.Find($"[data-testid='{nameof(IndexPage.Elements.WorkRequestCount)}']");
+        count.TextContent.ShouldContain("42");
+        count.TextContent.ShouldContain("Total Work Requests");
+    }
 }

--- a/src/UnitTests/UI.Shared/Pages/StubBus.cs
+++ b/src/UnitTests/UI.Shared/Pages/StubBus.cs
@@ -8,6 +8,8 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
 
 public class StubBus() : Bus(null!)
 {
+    public int WorkRequestCount { get; set; } = 7;
+
     public override Task Publish(INotification notification)
     {
         return Task.CompletedTask;
@@ -33,6 +35,11 @@ public class StubBus() : Bus(null!)
         if (request is WorkOrderAttachmentsQuery)
         {
             return Task.FromResult<TResponse>((TResponse)(object)Array.Empty<WorkOrderAttachment>());
+        }
+
+        if (request is WorkOrderCountQuery)
+        {
+            return Task.FromResult<TResponse>((TResponse)(object)WorkRequestCount);
         }
 
         if (request is WorkOrderByNumberQuery)


### PR DESCRIPTION
Closes #7025

Add a read-only count of total work requests to the dashboard/home page. Follow existing CQRS query patterns and add a unit test.