### PR TITLE
[aidevtest-urlreport] Add build date to footer tooltip

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,9 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-version"
+                      data-testid="@nameof(Elements.FooterVersion)"
+                      title="@BuildDateTooltip">v@AssemblyVersion</span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -82,7 +82,7 @@
                 </span>
                 <span class="site-footer-version"
                       data-testid="@nameof(Elements.FooterVersion)"
-                      title="@BuildDateTooltip">v@AssemblyVersion</span>
+                      title="@BuildDateTooltip">v@(AssemblyVersion)</span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        FooterVersion
     }
 
     /// <summary>
@@ -28,6 +29,14 @@ public partial class MainLayout : IAsyncDisposable
 
     [Inject]
     private ThemePreferenceService Theme { get; set; } = default!;
+
+    [Inject]
+    private AssemblyBuildDateService BuildDateService { get; set; } = default!;
+
+    protected string? BuildDateTooltip => BuildDateService.BuildDate;
+
+    protected string AssemblyVersion =>
+        typeof(MainLayout).Assembly.GetName().Version?.ToString() ?? string.Empty;
 
     private ElementReference _navToggleButtonRef;
     private DotNetObjectReference<MainLayout>? _dotNetRef;

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -321,6 +321,14 @@
     border-radius: 2px;
 }
 
+.site-footer-version {
+    display: block;
+    font-size: 0.75rem;
+    color: #a0aec0;
+    margin-top: 0.25rem;
+    cursor: default;
+}
+
 /* Responsive Design */
 @media (max-width: 1024px) {
     .modern-sidebar {
@@ -571,6 +579,10 @@
 
 :global(html[data-theme="dark"]) .site-footer-link:focus-visible {
     outline-color: #cbd5e0;
+}
+
+:global(html[data-theme="dark"]) .site-footer-version {
+    color: #718096;
 }
 
 :global(html[data-theme="dark"]) .user-section ::deep a:focus,

--- a/src/UI.Shared/Services/AssemblyBuildDateService.cs
+++ b/src/UI.Shared/Services/AssemblyBuildDateService.cs
@@ -1,0 +1,29 @@
+namespace ClearMeasure.Bootcamp.UI.Shared.Services;
+
+/// <summary>
+/// Provides the assembly build date for display in the UI.
+/// </summary>
+public sealed class AssemblyBuildDateService
+{
+    private static readonly string? _buildDate = ResolveBuildDate();
+
+    /// <summary>
+    /// Gets the UTC build date formatted as <c>yyyy-MM-dd</c>, or <c>null</c> if unavailable (e.g. WebAssembly).
+    /// </summary>
+    public string? BuildDate => _buildDate;
+
+    private static string? ResolveBuildDate()
+    {
+        var location = typeof(AssemblyBuildDateService).Assembly.Location;
+        if (string.IsNullOrEmpty(location))
+            return null;
+        try
+        {
+            return new FileInfo(location).LastWriteTimeUtc.ToString("yyyy-MM-dd");
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/UI.Shared/Services/AssemblyBuildDateService.cs
+++ b/src/UI.Shared/Services/AssemblyBuildDateService.cs
@@ -1,29 +1,19 @@
+using System.Reflection;
+
 namespace ClearMeasure.Bootcamp.UI.Shared.Services;
 
 /// <summary>
-/// Provides the assembly build date for display in the UI.
+/// Provides the assembly build date embedded at compile time, readable in both server and WebAssembly contexts.
 /// </summary>
 public sealed class AssemblyBuildDateService
 {
-    private static readonly string? _buildDate = ResolveBuildDate();
+    private static readonly string? _buildDate =
+        typeof(AssemblyBuildDateService).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "BuildDate")?.Value;
 
     /// <summary>
-    /// Gets the UTC build date formatted as <c>yyyy-MM-dd</c>, or <c>null</c> if unavailable (e.g. WebAssembly).
+    /// Gets the UTC build date formatted as <c>yyyy-MM-dd</c>, or <c>null</c> if not embedded.
     /// </summary>
     public string? BuildDate => _buildDate;
-
-    private static string? ResolveBuildDate()
-    {
-        var location = typeof(AssemblyBuildDateService).Assembly.Location;
-        if (string.IsNullOrEmpty(location))
-            return null;
-        try
-        {
-            return new FileInfo(location).LastWriteTimeUtc.ToString("yyyy-MM-dd");
-        }
-        catch
-        {
-            return null;
-        }
-    }
 }

--- a/src/UI.Shared/UI.Shared.csproj
+++ b/src/UI.Shared/UI.Shared.csproj
@@ -6,7 +6,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
 	  <AssemblyName>ClearMeasure.Bootcamp.$(MSBuildProjectName)</AssemblyName>
 	  <RootNamespace>ClearMeasure.Bootcamp.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <BuildDate>$([System.DateTime]::UtcNow.ToString("yyyy-MM-dd"))</BuildDate>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BuildDate</_Parameter1>
+      <_Parameter2>$(BuildDate)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 
 
   <ItemGroup>

--- a/src/UI/Client/UIClientServiceRegistry.cs
+++ b/src/UI/Client/UIClientServiceRegistry.cs
@@ -39,6 +39,7 @@ public class UIClientServiceRegistry : ServiceRegistry
         this.AddSingleton<ChatClientFactory>();
         this.AddTransient<WorkOrderTool>();
         this.AddSingleton<ThemePreferenceService>();
+        this.AddSingleton<AssemblyBuildDateService>();
 
         Scan(scanner =>
         {

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -223,6 +223,22 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderFooterVersionSpan_WithBuildDateTooltip()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var versionSpan = layout.Find($"[data-testid='{nameof(MainLayout.Elements.FooterVersion)}']");
+        versionSpan.ShouldNotBeNull();
+        var tooltip = versionSpan.GetAttribute("title");
+        tooltip.ShouldNotBeNullOrEmpty();
+        DateTime.TryParseExact(tooltip, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None, out _).ShouldBeTrue();
+    }
+
+    [Test]
     public async Task ShouldInvokeFocusOnNavRailToggleWhenClosingOverlayOnNarrowViewport()
     {
         using var ctx = CreateContext();
@@ -258,6 +274,7 @@ public class MainLayoutTests
         ctx.Services.AddSingleton<IUserSession>(new StubUserSession());
         ctx.Services.AddSingleton<IJSRuntime>(ctx.JSInterop.JSRuntime);
         ctx.Services.AddSingleton<ThemePreferenceService>();
+        ctx.Services.AddSingleton<AssemblyBuildDateService>();
         var customAuth = new CustomAuthenticationStateProvider();
         if (authenticateAsUser != null)
         {


### PR DESCRIPTION
Closes #7029

Add the assembly build date as a tooltip on the footer version text. Keep it minimal and add a bUnit test.