### PR TITLE
[aidevtest-demo3] Add 'AI Dev Factory demo' badge to the home page

### DIFF
--- a/src/UI.Shared/Pages/Index.razor
+++ b/src/UI.Shared/Pages/Index.razor
@@ -2,6 +2,8 @@
 
 <PageTitle>Clear Measure - .NET Bootcamp - Work Order Application</PageTitle>
 
+<span class="ai-dev-factory-badge" data-testid="@nameof(Elements.AiDevFactoryBadge)">AI Dev Factory demo</span>
+
 <div class="greeting-banner" data-testid="@nameof(Elements.GreetingBanner)">
     <span class="greeting-banner-emoji" aria-hidden="true" data-testid="@nameof(Elements.GreetingBannerEmoji)">⛪</span>
     <p>Welcome to the AI Software Factory!</p>
@@ -60,6 +62,7 @@
     public enum Elements
     {
         GreetingBanner,
-        GreetingBannerEmoji
+        GreetingBannerEmoji,
+        AiDevFactoryBadge
     }
 }

--- a/src/UnitTests/UI.Shared/Pages/IndexPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/IndexPageTests.cs
@@ -12,6 +12,20 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
 public class IndexPageTests
 {
     [Test]
+    public void ShouldDisplayAiDevFactoryBadge()
+    {
+        using var ctx = new TestContext();
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+
+        var component = ctx.RenderComponent<IndexPage>();
+
+        var badge = component.Find($"[data-testid='{nameof(IndexPage.Elements.AiDevFactoryBadge)}']");
+        badge.ShouldNotBeNull();
+        badge.TextContent.ShouldBe("AI Dev Factory demo");
+    }
+
+    [Test]
     public void ShouldDisplayGreetingBanner()
     {
         using var ctx = new TestContext();


### PR DESCRIPTION
Closes #7032

On the home/dashboard page, add a small visible text badge reading 'AI Dev Factory demo' near the top of the page content. This is a new, clearly-absent UI element. Keep it minimal and add a bUnit test asserting the badge text renders.