### PR TITLE
[aidevtest-sqldemo] Add 'Sample data loaded' note to dashboard

### DIFF
--- a/src/UI.Shared/Pages/Index.razor
+++ b/src/UI.Shared/Pages/Index.razor
@@ -2,6 +2,10 @@
 
 <PageTitle>Clear Measure - .NET Bootcamp - Work Order Application</PageTitle>
 
+<div class="sample-data-note" data-testid="@nameof(Elements.SampleDataNote)">
+    Sample data loaded
+</div>
+
 <div class="greeting-banner" data-testid="@nameof(Elements.GreetingBanner)">
     <span class="greeting-banner-emoji" aria-hidden="true" data-testid="@nameof(Elements.GreetingBannerEmoji)">⛪</span>
     <p>Welcome to the AI Software Factory!</p>
@@ -59,6 +63,7 @@
 @code {
     public enum Elements
     {
+        SampleDataNote,
         GreetingBanner,
         GreetingBannerEmoji
     }

--- a/src/UnitTests/UI.Shared/Pages/IndexPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/IndexPageTests.cs
@@ -12,6 +12,20 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
 public class IndexPageTests
 {
     [Test]
+    public void ShouldDisplaySampleDataNote()
+    {
+        using var ctx = new TestContext();
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+
+        var component = ctx.RenderComponent<IndexPage>();
+
+        var note = component.Find($"[data-testid='{nameof(IndexPage.Elements.SampleDataNote)}']");
+        note.ShouldNotBeNull();
+        note.TextContent.Trim().ShouldBe("Sample data loaded");
+    }
+
+    [Test]
     public void ShouldDisplayGreetingBanner()
     {
         using var ctx = new TestContext();


### PR DESCRIPTION
Closes #7034

Add a small visible note 'Sample data loaded' near the top of the dashboard/home page. New, clearly-absent element. Keep it minimal and add a bUnit test.