### PR TITLE
[aidevtest-batch] Add 'Batch note 6' to the footer

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-batch-note" data-testid="@nameof(Elements.BatchNote)">Batch note 6</span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        BatchNote
     }
 
     /// <summary>

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -321,6 +321,12 @@
     border-radius: 2px;
 }
 
+.site-footer-batch-note {
+    display: block;
+    font-size: 0.75rem;
+    color: #a0aec0;
+}
+
 /* Responsive Design */
 @media (max-width: 1024px) {
     .modern-sidebar {

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -206,6 +206,18 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderBatchNote6_InFooter()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var batchNote = layout.Find($"[data-testid='{nameof(MainLayout.Elements.BatchNote)}']");
+        batchNote.TextContent.ShouldBe("Batch note 6");
+    }
+
+    [Test]
     public void ShouldRenderCompanyLink_WithAccessibleAttributes_WhenExternalLinkUsesNewTab()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7045

Add a small visible 'Batch note 6' text element to the site footer. New, clearly-absent UI. Keep it minimal and add a bUnit test asserting the text renders.