### PR TITLE
[aidevtest-batch] Add 'Batch note 7' to the footer

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-batch-note" data-testid="@nameof(Elements.BatchNote7)">Batch note 7</span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        BatchNote7
     }
 
     /// <summary>

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -321,6 +321,12 @@
     border-radius: 2px;
 }
 
+.site-footer-batch-note {
+    display: block;
+    font-size: 0.75rem;
+    color: #a0aec0;
+}
+
 /* Responsive Design */
 @media (max-width: 1024px) {
     .modern-sidebar {

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -223,6 +223,18 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderBatchNote7_InFooter()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var batchNote = layout.Find($"[data-testid='{nameof(MainLayout.Elements.BatchNote7)}']");
+        batchNote.TextContent.ShouldContain("Batch note 7");
+    }
+
+    [Test]
     public async Task ShouldInvokeFocusOnNavRailToggleWhenClosingOverlayOnNarrowViewport()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7046

Add a small visible 'Batch note 7' text element to the site footer. New, clearly-absent UI. Keep it minimal and add a bUnit test asserting the text renders.