### PR TITLE
AI dev showcase 1: add showcase note 1 to the footer

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-line" data-testid="@nameof(Elements.ShowcaseNote)">Showcase note 1</span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        ShowcaseNote
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #7060

Add the text "Showcase note 1" to the site footer component so it is visible on every page. Small, self-contained UI change for an unattended AI-dev demo run.