### PR TITLE
AI dev showcase 5: add showcase note 5 to the footer

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -28,6 +28,18 @@ public class CopyrightFooterTests : AcceptanceTestBase
     }
 
     [Test, Retry(2)]
+    public async Task ShouldShowShowcaseNote_InFooter_OnLandingPage()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var showcaseNote = Page.GetByTestId(nameof(MainLayout.Elements.ShowcaseNote));
+        await showcaseNote.WaitForAsync();
+        await Expect(showcaseNote).ToBeVisibleAsync();
+        await Expect(showcaseNote).ToContainTextAsync("Showcase note 5");
+    }
+
+    [Test, Retry(2)]
     public async Task ShouldShowCopyrightFooter_OnAuthenticatedRoute_AfterLogin()
     {
         await LoginAsCurrentUser();

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-line" data-testid="@nameof(Elements.ShowcaseNote)">Showcase note 5</span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        ShowcaseNote
     }
 
     /// <summary>

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -206,6 +206,18 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderShowcaseNote_InFooter_OnEveryPage()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var showcaseNote = layout.Find($"[data-testid='{nameof(MainLayout.Elements.ShowcaseNote)}']");
+        showcaseNote.TextContent.Trim().ShouldBe("Showcase note 5");
+    }
+
+    [Test]
     public void ShouldRenderCompanyLink_WithAccessibleAttributes_WhenExternalLinkUsesNewTab()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7064

Add the text "Showcase note 5" to the site footer component so it is visible on every page. Small, self-contained UI change for an unattended AI-dev demo run.