### PR TITLE
AI dev showcase v2-8: add note v2-8 to the footer

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-line">Showcase v2 note 8</span>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
Closes #7073

Add the text "Showcase v2 note 8" to the site footer component so it is visible on every page. Small self-contained UI change for an unattended AI-dev demo run.