### PR TITLE
AI dev showcase v2-7: add note v2-7 to the footer

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -55,4 +55,16 @@ public class CopyrightFooterTests : AcceptanceTestBase
         await Expect(footer).ToBeVisibleAsync();
         await Expect(Page.GetByRole(AriaRole.Alert)).ToContainTextAsync("Sorry, there's nothing at this address.");
     }
+
+    [Test, Retry(2)]
+    public async Task ShouldShowShowcaseNote_OnLandingPage_WhenAnonymous()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var note = Page.GetByTestId(nameof(MainLayout.Elements.ShowcaseNote));
+        await note.WaitForAsync();
+        await Expect(note).ToBeVisibleAsync();
+        await Expect(note).ToContainTextAsync("Showcase v2 note 7");
+    }
 }

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,9 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-line" data-testid="@nameof(Elements.ShowcaseNote)">
+                    Showcase v2 note 7
+                </span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        ShowcaseNote
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #7072

Add the text "Showcase v2 note 7" to the site footer component so it is visible on every page. Small self-contained UI change for an unattended AI-dev demo run.