### PR TITLE
AI dev showcase v3-14: add note v3-14 to the footer

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-line">Showcase v3 note 14</span>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
Closes #7082

Add the text "Showcase v3 note 14" to the site footer component so it is visible on every page. Small self-contained UI change for an unattended AI-dev demo run.