### PR TITLE
AI dev showcase v3-17: add note v3-17 to the footer

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-line">Showcase v3 note 17</span>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
Closes #7085

Add the text "Showcase v3 note 17" to the site footer component so it is visible on every page. Small self-contained UI change for an unattended AI-dev demo run.