### PR TITLE
Interactive container 2: add note to the footer

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -25,6 +25,10 @@ public class CopyrightFooterTests : AcceptanceTestBase
         var href = (await link.GetAttributeAsync("href"))!.ToLowerInvariant();
         href.ShouldStartWith("http");
         href.ShouldContain("clearmeasure.com");
+
+        var note = Page.GetByTestId(nameof(MainLayout.Elements.FooterNote));
+        await Expect(note).ToBeVisibleAsync();
+        await Expect(note).ToContainTextAsync("For internal use only");
     }
 
     [Test, Retry(2)]

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,9 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-note" data-testid="@nameof(Elements.FooterNote)">
+                    For internal use only. Report issues to your church office administrator.
+                </span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        FooterNote
     }
 
     /// <summary>

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -299,6 +299,15 @@
     word-wrap: break-word;
 }
 
+.site-footer-note {
+    display: block;
+    font-size: 0.75rem;
+    color: #a0aec0;
+    font-style: italic;
+    line-height: 1.5;
+    word-wrap: break-word;
+}
+
 .site-footer-link {
     margin-left: 0.35rem;
     color: #4a5568;
@@ -559,6 +568,10 @@
 
 :global(html[data-theme="dark"]) .site-footer-line {
     color: #a0aec0;
+}
+
+:global(html[data-theme="dark"]) .site-footer-note {
+    color: #718096;
 }
 
 :global(html[data-theme="dark"]) .site-footer-link {

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -223,6 +223,21 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderFooterNote_WithinCopyrightFooter()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var note = layout.Find($"[data-testid='{nameof(MainLayout.Elements.FooterNote)}']");
+        note.TextContent.ShouldContain("For internal use only");
+
+        var footer = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}']");
+        footer.QuerySelector($"[data-testid='{nameof(MainLayout.Elements.FooterNote)}']").ShouldNotBeNull();
+    }
+
+    [Test]
     public async Task ShouldInvokeFocusOnNavRailToggleWhenClosingOverlayOnNarrowViewport()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7095

Trivial footer note so the container has a real branch; this run stays open (keep-alive) for interactive use.