### PR TITLE
Ready container v2-1: add footer note

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -55,4 +55,16 @@ public class CopyrightFooterTests : AcceptanceTestBase
         await Expect(footer).ToBeVisibleAsync();
         await Expect(Page.GetByRole(AriaRole.Alert)).ToContainTextAsync("Sorry, there's nothing at this address.");
     }
+
+    [Test, Retry(2)]
+    public async Task ShouldShowFooterNote_OnLandingPage_WhenAnonymous()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var footerNote = Page.GetByTestId(nameof(MainLayout.Elements.FooterNote));
+        await footerNote.WaitForAsync();
+        await Expect(footerNote).ToBeVisibleAsync();
+        await Expect(footerNote).ToContainTextAsync("Submit a new work order any time");
+    }
 }

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,9 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-note" data-testid="@nameof(Elements.FooterNote)">
+                    Submit a new work order any time — requests are typically reviewed within one business day.
+                </span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        FooterNote
     }
 
     /// <summary>

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -321,6 +321,15 @@
     border-radius: 2px;
 }
 
+.site-footer-note {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.8125rem;
+    color: #a0aec0;
+    line-height: 1.5;
+    word-wrap: break-word;
+}
+
 /* Responsive Design */
 @media (max-width: 1024px) {
     .modern-sidebar {
@@ -571,6 +580,10 @@
 
 :global(html[data-theme="dark"]) .site-footer-link:focus-visible {
     outline-color: #cbd5e0;
+}
+
+:global(html[data-theme="dark"]) .site-footer-note {
+    color: #718096;
 }
 
 :global(html[data-theme="dark"]) .user-section ::deep a:focus,

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -206,6 +206,21 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderFooterNote_WithinSiteFooter()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var note = layout.Find($"[data-testid='{nameof(MainLayout.Elements.FooterNote)}']");
+        note.TextContent.Trim().ShouldBe("Submit a new work order any time — requests are typically reviewed within one business day.");
+
+        var footer = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}']");
+        footer.QuerySelector($"[data-testid='{nameof(MainLayout.Elements.FooterNote)}']").ShouldNotBeNull();
+    }
+
+    [Test]
     public void ShouldRenderCompanyLink_WithAccessibleAttributes_WhenExternalLinkUsesNewTab()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7103

Trivial footer note; keep-alive run, stays open for interactive use.