### PR TITLE
Ready container v2-2: add footer note

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -20,6 +20,10 @@ public class CopyrightFooterTests : AcceptanceTestBase
         await Expect(footer).ToContainTextAsync(yearText);
         await Expect(footer).ToContainTextAsync("ClearMeasure Labs");
 
+        var footerNote = Page.GetByTestId(nameof(MainLayout.Elements.FooterNote));
+        await Expect(footerNote).ToBeVisibleAsync();
+        await Expect(footerNote).ToContainTextAsync("Ready container v2-2");
+
         var link = footer.Locator("a[href*='clearmeasure.com']").First;
         await Expect(link).ToBeVisibleAsync();
         var href = (await link.GetAttributeAsync("href"))!.ToLowerInvariant();

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -80,6 +80,7 @@
                        target="_blank"
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
+                <span class="site-footer-note" data-testid="@nameof(Elements.FooterNote)">Ready container v2-2</span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -15,7 +15,8 @@ public partial class MainLayout : IAsyncDisposable
     public enum Elements
     {
         NavRailToggle,
-        CopyrightFooter
+        CopyrightFooter,
+        FooterNote
     }
 
     /// <summary>

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -321,6 +321,13 @@
     border-radius: 2px;
 }
 
+.site-footer-note {
+    display: block;
+    font-size: 0.75rem;
+    color: #a0aec0;
+    line-height: 1.5;
+}
+
 /* Responsive Design */
 @media (max-width: 1024px) {
     .modern-sidebar {
@@ -559,6 +566,10 @@
 
 :global(html[data-theme="dark"]) .site-footer-line {
     color: #a0aec0;
+}
+
+:global(html[data-theme="dark"]) .site-footer-note {
+    color: #718096;
 }
 
 :global(html[data-theme="dark"]) .site-footer-link {

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -206,6 +206,18 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderFooterNote_WithReadyContainerVersion()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var footerNote = layout.Find($"[data-testid='{nameof(MainLayout.Elements.FooterNote)}']");
+        footerNote.TextContent.Trim().ShouldBe("Ready container v2-2");
+    }
+
+    [Test]
     public void ShouldRenderCompanyLink_WithAccessibleAttributes_WhenExternalLinkUsesNewTab()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7104

Trivial footer note; keep-alive run, stays open for interactive use.