### PR TITLE
Sidecar-SQL E2E: add footer note SIDECAR-OK

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -67,4 +67,16 @@ public class CopyrightFooterTests : AcceptanceTestBase
         await Expect(footerNote).ToBeVisibleAsync();
         await Expect(footerNote).ToContainTextAsync("Submit a new work order any time");
     }
+
+    [Test, Retry(2)]
+    public async Task ShouldShowSidecarStatus_OnLandingPage_WhenAnonymous()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var sidecarStatus = Page.GetByTestId(nameof(MainLayout.Elements.SidecarStatus));
+        await sidecarStatus.WaitForAsync();
+        await Expect(sidecarStatus).ToBeVisibleAsync();
+        await Expect(sidecarStatus).ToContainTextAsync("SIDECAR-OK");
+    }
 }

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -83,6 +83,9 @@
                 <span class="site-footer-note" data-testid="@nameof(Elements.FooterNote)">
                     Submit a new work order any time — requests are typically reviewed within one business day.
                 </span>
+                <span class="site-footer-note" data-testid="@nameof(Elements.SidecarStatus)">
+                    SIDECAR-OK
+                </span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -16,7 +16,8 @@ public partial class MainLayout : IAsyncDisposable
     {
         NavRailToggle,
         CopyrightFooter,
-        FooterNote
+        FooterNote,
+        SidecarStatus
     }
 
     /// <summary>

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -221,6 +221,21 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderSidecarStatus_WithinSiteFooter()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var sidecarStatus = layout.Find($"[data-testid='{nameof(MainLayout.Elements.SidecarStatus)}']");
+        sidecarStatus.TextContent.Trim().ShouldBe("SIDECAR-OK");
+
+        var footer = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}']");
+        footer.QuerySelector($"[data-testid='{nameof(MainLayout.Elements.SidecarStatus)}']").ShouldNotBeNull();
+    }
+
+    [Test]
     public void ShouldRenderCompanyLink_WithAccessibleAttributes_WhenExternalLinkUsesNewTab()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7125

Add the text 'SIDECAR-OK' to the site footer component. Validates the DinD-free SQL-sidecar pipeline (build+tests+drop/recreate) and serve mode.