### PR TITLE
build: env-gated external SQL Server support

### DIFF
--- a/BuildFunctions.ps1
+++ b/BuildFunctions.ps1
@@ -460,7 +460,16 @@ Function Get-SqlServerPassword {
         [Parameter(Mandatory = $true)]
         [string]$ContainerName
     )
-    
+
+    # When connecting to an EXTERNAL/shared SQL Server (not a per-build Docker
+    # container), the SA password is fixed for that server and supplied via
+    # SQL_SA_PASSWORD. Use it for every password lookup so New-SqlServerDatabase,
+    # the connection string, and migrations all authenticate against the shared
+    # server. Falls back to the per-container derived password for local/CI.
+    if ($env:SQL_SA_PASSWORD) {
+        return $env:SQL_SA_PASSWORD
+    }
+
     return "${ContainerName}#1A"
 }
 
@@ -570,7 +579,13 @@ Function Get-DefaultDatabaseServer {
 
     switch ($engine) {
         "LocalDB"       { return "(LocalDb)\MSSQLLocalDB" }
-        "SQL-Container" { return "localhost" }
+        "SQL-Container" {
+            # For an external/shared SQL Server, the host (and optional ,port) is
+            # supplied via SQL_SERVER_HOST (e.g. "sql-shared,1433"). Otherwise the
+            # server is a local Docker container on localhost.
+            if ($env:SQL_SERVER_HOST) { return $env:SQL_SERVER_HOST }
+            return "localhost"
+        }
         default         { return "" }
     }
 }
@@ -603,6 +618,14 @@ Function Get-ResolvedDatabaseName {
 
     if (-not [string]::IsNullOrEmpty($explicitName)) {
         return $explicitName
+    }
+
+    # Allow the database name to be parameterized via DATABASE_NAME. Used when many
+    # builds share ONE SQL Server and each needs its own isolated database (e.g.
+    # ChurchBulletin_7123), so per-build drop/recreate does not collide. An explicit
+    # -explicitName argument still takes precedence.
+    if ($env:DATABASE_NAME) {
+        return $env:DATABASE_NAME
     }
 
     if ($onLinux -or $localBuild) {

--- a/build.ps1
+++ b/build.ps1
@@ -64,7 +64,10 @@ Function Init {
 
 	switch ($script:databaseEngine) {
 		"SQL-Container" {
-			if (-not (Test-IsDockerRunning)) {
+			# SQL_EXTERNAL=true => connect to an already-running SQL Server (a k8s
+			# sidecar or a shared server) instead of starting a local Docker
+			# container, so no Docker daemon is required in the build environment.
+			if ($env:SQL_EXTERNAL -ne "true" -and -not (Test-IsDockerRunning)) {
 				throw "Docker is not running. Start Docker (for example, Docker Desktop) so the container-based SQL Server required for 'SQL-Container' builds can run, then rerun this build script."
 			}
 		}
@@ -120,7 +123,13 @@ Function UnitTests {
 
 Function Setup-DatabaseForBuild {
 	if ($script:databaseEngine -eq "SQL-Container") {
-		New-DockerContainerForSqlServer -containerName $(Get-ContainerName $script:databaseName)
+		# With an external/shared SQL Server (SQL_EXTERNAL=true) the server already
+		# exists, so skip creating a per-build Docker container. New-SqlServerDatabase
+		# still runs, dropping and recreating THIS build's database on that server -
+		# so every PrivateBuild starts from a clean, freshly-migrated database.
+		if ($env:SQL_EXTERNAL -ne "true") {
+			New-DockerContainerForSqlServer -containerName $(Get-ContainerName $script:databaseName)
+		}
 		New-SqlServerDatabase -serverName $script:databaseServer -databaseName $script:databaseName
 		$containerName = Get-ContainerName -DatabaseName $script:databaseName
 		$sqlPassword = Get-SqlServerPassword -ContainerName $containerName


### PR DESCRIPTION
Env-gated (SQL_EXTERNAL/SQL_SERVER_HOST/SQL_SA_PASSWORD/DATABASE_NAME) external SQL Server support in build.ps1. No-op for local dev/CI. Enables the AI-dev factory's DinD-free SQL sidecar. 🤖 Generated with [Claude Code](https://claude.com/claude-code)