### PR TITLE
Sidecar-SQL E2E v2: footer note SIDECAR2-OK

### DIFF
--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -81,7 +81,7 @@
                        rel="noopener noreferrer">ClearMeasure Labs</a>
                 </span>
                 <span class="site-footer-note" data-testid="@nameof(Elements.FooterNote)">
-                    Submit a new work order any time — requests are typically reviewed within one business day.
+                    Submit a new work order any time — requests are typically reviewed within one business day. SIDECAR2-OK
                 </span>
             </div>
         </footer>

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -214,7 +214,7 @@ public class MainLayoutTests
         var layout = component.FindComponent<MainLayout>();
 
         var note = layout.Find($"[data-testid='{nameof(MainLayout.Elements.FooterNote)}']");
-        note.TextContent.Trim().ShouldBe("Submit a new work order any time — requests are typically reviewed within one business day.");
+        note.TextContent.Trim().ShouldBe("Submit a new work order any time — requests are typically reviewed within one business day. SIDECAR2-OK");
 
         var footer = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}']");
         footer.QuerySelector($"[data-testid='{nameof(MainLayout.Elements.FooterNote)}']").ShouldNotBeNull();


### PR DESCRIPTION
Closes #7128

Add 'SIDECAR2-OK' to the site footer. Validates DinD-free SQL-sidecar pipeline now that master has the external-SQL build scripts.