### PR TITLE
Sidecar-SQL E2E v3: footer note SIDECAR3-OK

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -67,4 +67,16 @@ public class CopyrightFooterTests : AcceptanceTestBase
         await Expect(footerNote).ToBeVisibleAsync();
         await Expect(footerNote).ToContainTextAsync("Submit a new work order any time");
     }
+
+    [Test, Retry(2)]
+    public async Task ShouldShowSidecarValidationNote_OnLandingPage_WhenAnonymous()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var sidecarNote = Page.GetByTestId(nameof(MainLayout.Elements.SidecarValidationNote));
+        await sidecarNote.WaitForAsync();
+        await Expect(sidecarNote).ToBeVisibleAsync();
+        await Expect(sidecarNote).ToContainTextAsync("SIDECAR3-OK");
+    }
 }

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -83,6 +83,9 @@
                 <span class="site-footer-note" data-testid="@nameof(Elements.FooterNote)">
                     Submit a new work order any time — requests are typically reviewed within one business day.
                 </span>
+                <span class="site-footer-note" data-testid="@nameof(Elements.SidecarValidationNote)">
+                    SIDECAR3-OK
+                </span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -16,7 +16,8 @@ public partial class MainLayout : IAsyncDisposable
     {
         NavRailToggle,
         CopyrightFooter,
-        FooterNote
+        FooterNote,
+        SidecarValidationNote
     }
 
     /// <summary>

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -221,6 +221,21 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderSidecarValidationNote_WithinSiteFooter()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var note = layout.Find($"[data-testid='{nameof(MainLayout.Elements.SidecarValidationNote)}']");
+        note.TextContent.Trim().ShouldBe("SIDECAR3-OK");
+
+        var footer = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}']");
+        footer.QuerySelector($"[data-testid='{nameof(MainLayout.Elements.SidecarValidationNote)}']").ShouldNotBeNull();
+    }
+
+    [Test]
     public void ShouldRenderCompanyLink_WithAccessibleAttributes_WhenExternalLinkUsesNewTab()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7130

Add 'SIDECAR3-OK' to the site footer. Validates entrypoint-owned serve-DB create+migrate on the SQL sidecar.