### PR TITLE
Parallel speed A: footer PAR-A

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -67,4 +67,16 @@ public class CopyrightFooterTests : AcceptanceTestBase
         await Expect(footerNote).ToBeVisibleAsync();
         await Expect(footerNote).ToContainTextAsync("Submit a new work order any time");
     }
+
+    [Test, Retry(2)]
+    public async Task ShouldShowParallelSpeedTag_OnLandingPage_WhenAnonymous()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var tag = Page.GetByTestId(nameof(MainLayout.Elements.ParallelSpeedTag));
+        await tag.WaitForAsync();
+        await Expect(tag).ToBeVisibleAsync();
+        await Expect(tag).ToContainTextAsync("PAR-A");
+    }
 }

--- a/src/Database/Console/AbstractDatabaseCommand.cs
+++ b/src/Database/Console/AbstractDatabaseCommand.cs
@@ -39,7 +39,10 @@ public abstract class AbstractDatabaseCommand(string action) : Command<DatabaseO
 
     protected static string GetConnectionString(DatabaseOptions options)
     {
-        // Determine if this is a local server (localhost, 127.0.0.1, or LocalDB)
+        // Determine if this is a local server (localhost, 127.0.0.1, or LocalDB), or an
+        // external/shared test SQL Server provisioned for this build (SQL_EXTERNAL=true,
+        // e.g. a k8s sidecar/shared container with a self-signed certificate). Neither
+        // case is real production Azure SQL, so the self-signed certificate is trusted.
         var serverName = (options.DatabaseServer ?? string.Empty).Trim();
         var isLocalServer = serverName.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
                            serverName.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase) ||
@@ -47,7 +50,8 @@ public abstract class AbstractDatabaseCommand(string action) : Command<DatabaseO
                            serverName.Contains("LocalDb", StringComparison.OrdinalIgnoreCase) ||
                            serverName.Contains("(LocalDb)", StringComparison.OrdinalIgnoreCase) ||
                            serverName.StartsWith("127.0.0.1", StringComparison.OrdinalIgnoreCase) ||
-                           serverName.StartsWith("localhost", StringComparison.OrdinalIgnoreCase);
+                           serverName.StartsWith("localhost", StringComparison.OrdinalIgnoreCase) ||
+                           Environment.GetEnvironmentVariable("SQL_EXTERNAL") == "true";
 
 
 

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -83,6 +83,9 @@
                 <span class="site-footer-note" data-testid="@nameof(Elements.FooterNote)">
                     Submit a new work order any time — requests are typically reviewed within one business day.
                 </span>
+                <span class="site-footer-tag" data-testid="@nameof(Elements.ParallelSpeedTag)">
+                    PAR-A
+                </span>
             </div>
         </footer>
     </div>

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -16,7 +16,8 @@ public partial class MainLayout : IAsyncDisposable
     {
         NavRailToggle,
         CopyrightFooter,
-        FooterNote
+        FooterNote,
+        ParallelSpeedTag
     }
 
     /// <summary>

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -330,6 +330,14 @@
     word-wrap: break-word;
 }
 
+.site-footer-tag {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: #cbd5e0;
+    line-height: 1.5;
+}
+
 /* Responsive Design */
 @media (max-width: 1024px) {
     .modern-sidebar {
@@ -583,6 +591,10 @@
 }
 
 :global(html[data-theme="dark"]) .site-footer-note {
+    color: #718096;
+}
+
+:global(html[data-theme="dark"]) .site-footer-tag {
     color: #718096;
 }
 

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -221,6 +221,21 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderParallelSpeedTag_WithinSiteFooter()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var tag = layout.Find($"[data-testid='{nameof(MainLayout.Elements.ParallelSpeedTag)}']");
+        tag.TextContent.Trim().ShouldBe("PAR-A");
+
+        var footer = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}']");
+        footer.QuerySelector($"[data-testid='{nameof(MainLayout.Elements.ParallelSpeedTag)}']").ShouldNotBeNull();
+    }
+
+    [Test]
     public void ShouldRenderCompanyLink_WithAccessibleAttributes_WhenExternalLinkUsesNewTab()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Closes #7141

Add 'PAR-A' to the footer. Parallel-speed test with warm NuGet PVC + slim image + shared SQL.