### PR TITLE
Show the current year in the site footer (#7151)

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -18,6 +18,7 @@ public class CopyrightFooterTests : AcceptanceTestBase
 
         var yearText = DateTime.UtcNow.Year.ToString(CultureInfo.InvariantCulture);
         await Expect(footer).ToContainTextAsync(yearText);
+        await Expect(footer).ToContainTextAsync("Church Bulletin");
         await Expect(footer).ToContainTextAsync("ClearMeasure Labs");
 
         var link = footer.Locator("a[href*='clearmeasure.com']").First;
@@ -39,6 +40,7 @@ public class CopyrightFooterTests : AcceptanceTestBase
         await Expect(footer).ToBeVisibleAsync();
         var yearText = DateTime.UtcNow.Year.ToString(CultureInfo.InvariantCulture);
         await Expect(footer).ToContainTextAsync(yearText);
+        await Expect(footer).ToContainTextAsync("Church Bulletin");
         await Expect(footer).ToContainTextAsync("ClearMeasure Labs");
     }
 

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -74,7 +74,7 @@
         <footer class="site-footer" data-testid="@nameof(Elements.CopyrightFooter)">
             <div class="site-footer-inner">
                 <span class="site-footer-line">
-                    © @CopyrightYear
+                    © @CopyrightYear Church Bulletin
                     <a class="site-footer-link"
                        href="https://clearmeasure.com/"
                        target="_blank"


### PR DESCRIPTION
## Summary

This PR implements issue #7151 by adding "Church Bulletin" text to the copyright footer.

## Changes Made

- Updated MainLayout.razor footer to display "© YYYY Church Bulletin"
- Updated CopyrightFooterTests.cs with assertions for "Church Bulletin" text

## Testing

- All unit tests pass
- All integration tests pass
- All acceptance tests pass
- Private build completed successfully

Closes #7151