### PR TITLE
Fix flaky client health check acceptance test

### DIFF
--- a/src/AcceptanceTests/App/ClientHealthCheckTests.cs
+++ b/src/AcceptanceTests/App/ClientHealthCheckTests.cs
@@ -18,8 +18,8 @@ public class ClientHealthCheckTests : AcceptanceTestBase
     public async Task FirstStartShouldValidateClientHealthChecks()
     {
         await Page.GotoAsync("/_clienthealthcheck");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         var statusSpan = Page.GetByTestId(nameof(ClientHealthCheck.Elements.Status));
+        await statusSpan.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 90_000 });
         var innerTextAsync = await statusSpan.InnerTextAsync();
         innerTextAsync.ShouldBeOneOf(AcceptableHealthStatuses);
         AcceptableHealthStatuses.ShouldContain(innerTextAsync);
@@ -36,8 +36,8 @@ public class ClientHealthCheckTests : AcceptanceTestBase
         await Page.WaitForURLAsync("**/_clienthealthcheck");
         Page.Url.ShouldContain("/_clienthealthcheck");
 
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         var statusSpan = Page.GetByTestId(nameof(ClientHealthCheck.Elements.Status));
+        await statusSpan.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 90_000 });
         var innerTextAsync = await statusSpan.InnerTextAsync();
         AcceptableHealthStatuses.ShouldContain(innerTextAsync);
     }

--- a/src/UI/Client/Pages/ClientHealthCheck.razor
+++ b/src/UI/Client/Pages/ClientHealthCheck.razor
@@ -59,7 +59,21 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        _report = await Service.CheckHealthAsync();
+        // Bound the health probe so a slow or hanging check cannot leave the page
+        // stuck on "Loading..." forever. On timeout, surface an Unhealthy report
+        // instead of never rendering the status.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        try
+        {
+            _report = await Service.CheckHealthAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            _report = new HealthReport(
+                new Dictionary<string, HealthReportEntry>(),
+                HealthStatus.Unhealthy,
+                TimeSpan.Zero);
+        }
     }
 
     private string GetStatusCssClass(HealthStatus status)


### PR DESCRIPTION
## Problem

Master build 1.4.1582 failed on a single acceptance test: `ClientHealthCheckTests.Should_NavigateToHealthCheck_WhenGearIconClicked` — a 60s Playwright `TimeoutException` waiting for `GetByTestId("Status")`.

Diagnosis: not a code regression. The failing commit's tree is byte-for-byte identical to the last-good commit (the intervening commits were a revert), and the immediately prior run passed the same suite. The ARM acceptance job passed in the very same run; only x64 timed out. This is a flaky/timing failure: the WASM client health page renders `Status` only after `HealthCheckService.CheckHealthAsync()` resolves, and a slow probe on a loaded runner could exceed Playwright's wait.

## Fix (roll-forward)

- **Page** (`ClientHealthCheck.razor`): bound the probe with a 30s `CancellationToken`; on timeout render an `Unhealthy` report so `Status` always renders instead of hanging on "Loading...".
- **Tests** (`ClientHealthCheckTests.cs`): replace fragile `NetworkIdle` waits with an explicit `Status`-visible wait (90s) before reading text, on both client health tests.

## Verification

All 4 `ClientHealthCheckTests` pass locally (Release, LocalDB, Playwright/Chromium), including the previously-failing navigation test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)