### PR TITLE
Test design: /api/status endpoint (#7168)

### DIFF
--- a/src/IntegrationTests/Api/StatusEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/StatusEndpointIntegrationTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class StatusEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJsonWithStatusOk_When_GetStatus()
+    {
+        var response = await _client!.GetAsync("/api/status");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        var payload = await response.Content.ReadFromJsonAsync<StatusResponse>();
+        payload.ShouldNotBeNull();
+        payload!.Status.ShouldBe("ok");
+    }
+
+    [Test]
+    public async Task Should_AllowAnonymousAccess_When_GetStatus()
+    {
+        var response = await _client!.GetAsync("/api/status");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_ReturnConsistentJsonStructure_When_GetStatus()
+    {
+        var response = await _client!.GetAsync("/api/status");
+        var json = await response.Content.ReadAsStringAsync();
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.EnumerateObject().Count().ShouldBe(1);
+        document.RootElement.GetProperty("status").GetString().ShouldBe("ok");
+
+        var payload = JsonSerializer.Deserialize<StatusResponse>(json);
+        payload.ShouldNotBeNull();
+        payload!.Status.ShouldBe("ok");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_StatusAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/status");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<StatusResponse>();
+        payload.ShouldNotBeNull();
+        payload!.Status.ShouldBe("ok");
+    }
+}

--- a/src/IntegrationTests/Api/StatusEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/StatusEndpointIntegrationTests.cs
@@ -59,7 +59,9 @@ public class StatusEndpointIntegrationTests
         document.RootElement.EnumerateObject().Count().ShouldBe(1);
         document.RootElement.GetProperty("status").GetString().ShouldBe("ok");
 
-        var payload = JsonSerializer.Deserialize<StatusResponse>(json);
+        var payload = JsonSerializer.Deserialize<StatusResponse>(
+            json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         payload.ShouldNotBeNull();
         payload!.Status.ShouldBe("ok");
     }

--- a/src/UI/Api/Controllers/StatusController.cs
+++ b/src/UI/Api/Controllers/StatusController.cs
@@ -1,0 +1,35 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal JSON probe for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/status")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class StatusController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON payload with <c>status</c> set to <c>ok</c> for reachability checks.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() => Ok(new StatusResponse { Status = "ok" });
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/status</c>.
+/// </summary>
+public sealed class StatusResponse
+{
+    /// <summary>
+    /// Application status indicator; always <c>ok</c> when the endpoint is reachable.
+    /// </summary>
+    public required string Status { get; init; }
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and status endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("status", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("status", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/StatusControllerTests.cs
+++ b/src/UnitTests/UI.Api/StatusControllerTests.cs
@@ -1,0 +1,26 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class StatusControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJsonWithStatusOk()
+    {
+        var controller = new StatusController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.StatusCode.ShouldBe(200);
+        var payload = ok.Value.ShouldBeOfType<StatusResponse>();
+        payload.Status.ShouldBe("ok");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,7 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/status", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -107,4 +107,16 @@ public class ApiKeyAuthenticationWebTests
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
     }
+
+    [Test]
+    public async Task Should_Return200_When_StatusWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/status");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldContain("\"status\":\"ok\"");
+    }
 }


### PR DESCRIPTION
## Summary

Implements the GET `/api/status` endpoint and integration tests described in issue #7168. The endpoint returns anonymous JSON `{ "status": "ok" }` for simple reachability checks, following the existing `PingController` pattern.

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/StatusController.cs` | New controller exposing unversioned GET `/api/status` returning JSON status payload |
| `src/IntegrationTests/Api/StatusEndpointIntegrationTests.cs` | Four integration tests covering 200/JSON, anonymous access, JSON structure, and API key bypass |
| `src/UnitTests/UI.Api/StatusControllerTests.cs` | Unit test verifying controller returns `{ status: "ok" }` |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Exempts `/api/status` from API key validation (alongside ping, version, time) |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Adds `/api/status` to public path test cases |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Adds web integration test for status without API key |

## Testing Notes

- Unit tests: `StatusControllerTests`, updated `ApiKeyAuthenticationMiddlewareTests`, updated `ApiKeyAuthenticationWebTests`
- Integration tests: all four scenarios in `StatusEndpointIntegrationTests`
  - `Should_Return200AndJsonWithStatusOk_When_GetStatus`
  - `Should_AllowAnonymousAccess_When_GetStatus`
  - `Should_ReturnConsistentJsonStructure_When_GetStatus`
  - `Should_Return200WithoutApiKey_When_StatusAndMiddlewareEnabled`
- Full private build (`PrivateBuild.ps1`) passed locally with all unit and integration tests green

Closes #7168