### PR TITLE
E2E-1: Add GET /api/ping endpoint returning pong (#7171)

### DIFF
--- a/src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs
+++ b/src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
 
 /// <summary>
-/// UI.Server test host with API key validation enabled for <c>/api/*</c> (except public version/time).
+/// UI.Server test host with API key validation enabled for <c>/api/*</c> (except public version, time, and ping).
 /// </summary>
 public sealed class ApiKeyProtectedWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
 {


### PR DESCRIPTION
## Summary

Implements and verifies the GET `/api/ping` liveness endpoint that returns plain-text `pong` for operators, load balancers, and monitoring systems.

The core implementation was already present on `master` from a prior merge (#5472). This PR walks the technical design checklist, confirms all behavior matches the specification, and applies a minor documentation fix.

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/PingController.cs` | Existing — dual routes (`/api/ping`, `/api/v1.0/ping`), rate limiting, anonymous access, plain-text `pong` response |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Existing — ping paths excluded from API key validation |
| `src/UnitTests/UI.Api/PingControllerTests.cs` | Existing — unit test for controller behavior |
| `src/IntegrationTests/Api/PingEndpointIntegrationTests.cs` | Existing — HTTP integration tests (unversioned, versioned, API-key bypass) |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Existing — parameterized tests for ping public paths |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Existing — web test for ping without API key |
| `src/UnitTests/UI.Server/ApiKeyProtectedWebApplicationFactory.cs` | Updated XML summary to mention ping alongside version/time |

## Testing

- `dotnet test src/UnitTests --filter FullyQualifiedName~Ping` — 2 passed
- `dotnet test src/IntegrationTests --filter FullyQualifiedName~Ping` — 3 passed
- `PrivateBuild.ps1` — full build green (unit + integration tests)

## Checklist Verification

- [x] `PingController` in UI.Api with dual routes and rate limiting
- [x] Controller discovery via `AddApplicationPart` in UI.Server
- [x] API key middleware excludes ping paths
- [x] Unit test: `Get_Should_ReturnPlainTextPong`
- [x] Integration tests: unversioned, versioned, and API-key bypass
- [x] Middleware unit and web tests for ping paths

Closes #7171