### PR TITLE
E2E-5: Add GET /api/color endpoint returning a random color (#7175)

### DIFF
--- a/src/IntegrationTests/Api/ColorEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ColorEndpointIntegrationTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ColorEndpointIntegrationTests
+{
+    private static readonly Regex HexColorPattern = new(@"^#[0-9A-F]{6}$", RegexOptions.CultureInvariant);
+
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndPlainTextHexColor_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/color");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        var body = await response.Content.ReadAsStringAsync();
+        HexColorPattern.IsMatch(body).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndPlainTextHexColor_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/color");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        var body = await response.Content.ReadAsStringAsync();
+        HexColorPattern.IsMatch(body).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_ColorAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/color");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        HexColorPattern.IsMatch(await unversioned.Content.ReadAsStringAsync()).ShouldBeTrue();
+
+        var versioned = await client.GetAsync("/api/v1.0/color");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        HexColorPattern.IsMatch(await versioned.Content.ReadAsStringAsync()).ShouldBeTrue();
+    }
+}

--- a/src/UI/Api/Controllers/ColorController.cs
+++ b/src/UI/Api/Controllers/ColorController.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a random CSS hex color for operators, integrations, and end-to-end tests.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/color")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/color")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class ColorController : ControllerBase
+{
+    /// <summary>
+    /// Returns a random CSS hex color as plain text in the form <c>#RRGGBB</c> (uppercase hex digits).
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    [Produces("text/plain")]
+    public IActionResult Get()
+    {
+        Span<byte> rgb = stackalloc byte[3];
+        RandomNumberGenerator.Fill(rgb);
+        var hex = Convert.ToHexString(rgb);
+        return new ContentResult
+        {
+            Content = "#" + hex,
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = StatusCodes.Status200OK
+        };
+    }
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and color endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("color", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("color", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/ColorControllerTests.cs
+++ b/src/UnitTests/UI.Api/ColorControllerTests.cs
@@ -1,0 +1,47 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ColorControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnUppercaseHexColor()
+    {
+        var controller = new ColorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        content.Content.ShouldNotBeNull();
+        content.Content!.Length.ShouldBe(7);
+        content.Content[0].ShouldBe('#');
+        foreach (var c in content.Content.AsSpan(1))
+        {
+            char.IsAsciiHexDigitUpper(c).ShouldBeTrue();
+        }
+    }
+
+    [Test]
+    public void Get_Should_ReturnDifferentColors_When_CalledTwice()
+    {
+        var controller = new ColorController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var first = (controller.Get() as ContentResult)!.Content;
+        var second = (controller.Get() as ContentResult)!.Content;
+
+        first.ShouldNotBe(second);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/color", true)]
+    [TestCase("/api/v1.0/color", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.RegularExpressions;
 using ClearMeasure.Bootcamp.UI.Shared;
 using Shouldly;
 
@@ -106,5 +107,21 @@ public class ApiKeyAuthenticationWebTests
         var versioned = await client.GetAsync("/api/v1.0/ping");
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
+    }
+
+    [Test]
+    public async Task Should_Return200_When_ColorWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        var hexColorPattern = new Regex(@"^#[0-9A-F]{6}$", RegexOptions.CultureInvariant);
+
+        var unversioned = await client.GetAsync("/api/color");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        hexColorPattern.IsMatch(await unversioned.Content.ReadAsStringAsync()).ShouldBeTrue();
+
+        var versioned = await client.GetAsync("/api/v1.0/color");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        hexColorPattern.IsMatch(await versioned.Content.ReadAsStringAsync()).ShouldBeTrue();
     }
 }


### PR DESCRIPTION
## Summary

Adds an anonymous, rate-limited diagnostic GET endpoint at `/api/color` (and `/api/v1.0/color`) that returns a random CSS hex color as plain text (`#RRGGBB` uppercase).

This follows the same patterns as existing open probes (`PingController`, `TimeController`): dual unversioned/versioned routes, `[AllowAnonymous]`, rate limiting, and API-key middleware bypass.

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/ColorController.cs` | New controller returning random `#RRGGBB` via `RandomNumberGenerator` |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Whitelist `/api/color` and `/api/v1.0/color` from API-key validation |
| `src/UnitTests/UI.Api/ColorControllerTests.cs` | Unit tests for response format and randomness |
| `src/IntegrationTests/Api/ColorEndpointIntegrationTests.cs` | HTTP integration tests for unversioned, versioned, and API-key bypass |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Test cases for color path whitelist |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Web test for color without API key |

## Testing Notes

- `PrivateBuild.ps1` passed locally (unit + integration tests green)
- Unit tests verify 200 response, `text/plain` content type, `#` + 6 uppercase hex digits, and distinct values across calls
- Integration tests verify unversioned/versioned routes and API-key middleware bypass

Closes #7175
