### PR TITLE
E2E-3: Add GET /api/healthz endpoint returning 200 OK (#7173)

### DIFF
--- a/src/IntegrationTests/Api/HealthzEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/HealthzEndpointIntegrationTests.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class HealthzEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/healthz");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task Should_Return200_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/healthz");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldBeEmpty();
+        response.Headers.TryGetValues("api-supported-versions", out var values).ShouldBeTrue();
+        values.ShouldNotBeNull();
+        string.Join(", ", values!).ShouldContain("1.0");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_ApiKeyMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/healthz");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/healthz");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/UI/Api/Controllers/HealthzController.cs
+++ b/src/UI/Api/Controllers/HealthzController.cs
@@ -1,0 +1,25 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal liveness probe for automated callers and load balancers.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/healthz")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/healthz")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HealthzController : ControllerBase
+{
+    /// <summary>
+    /// Returns HTTP 200 OK with an empty body when the API host is accepting requests.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() => Ok();
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and healthz endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("healthz", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("healthz", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/HealthzControllerTests.cs
+++ b/src/UnitTests/UI.Api/HealthzControllerTests.cs
@@ -1,0 +1,24 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HealthzControllerTests
+{
+    [Test]
+    public void Get_Should_Return200WithEmptyBody()
+    {
+        var controller = new HealthzController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var ok = result.ShouldBeOfType<OkResult>();
+        ok.StatusCode.ShouldBe(200);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/healthz", true)]
+    [TestCase("/api/v1.0/healthz", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -107,4 +107,17 @@ public class ApiKeyAuthenticationWebTests
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
     }
+
+    [Test]
+    public async Task Should_Return200_When_HealthzWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/healthz");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/healthz");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -80,4 +80,15 @@ public class ApiVersioningEndpointTests
         values.ShouldNotBeNull();
         string.Join(", ", values!).ShouldContain("1.0");
     }
+
+    [Test]
+    public async Task Should_Return200_When_GetHealthz_V1Path()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/healthz");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues("api-supported-versions", out var values).ShouldBeTrue();
+        values.ShouldNotBeNull();
+        string.Join(", ", values!).ShouldContain("1.0");
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a machine-oriented liveness endpoint `GET /api/healthz` that returns HTTP 200 OK with an empty body when the API host is accepting requests. The endpoint supports both unversioned (`/api/healthz`) and versioned (`/api/v1.0/healthz`) routes, allows anonymous access, and bypasses API key authentication when enabled — matching the existing `/api/ping` probe pattern.

This is separate from readiness endpoints (`/_healthcheck`, `/api/health`) and intentionally performs no dependency checks.

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/HealthzController.cs` | New liveness controller returning `Ok()` |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Exempt `/api/healthz` paths from API key validation |
| `src/UnitTests/UI.Api/HealthzControllerTests.cs` | Unit test for controller action |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Middleware path rule test cases |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Web test for anonymous access under API key protection |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | Versioned route and header coverage |
| `src/IntegrationTests/Api/HealthzEndpointIntegrationTests.cs` | Integration tests for HTTP contract |

## Testing

- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./PrivateBuild.ps1` — passed (compile, unit tests, DB migration, integration tests)
- No acceptance/Playwright tests required (no user-facing changes)

## Checklist

Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied

Closes #7173
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3d38fe2-783f-463b-9de4-eff2b7d97604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3d38fe2-783f-463b-9de4-eff2b7d97604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

