### PR TITLE
E2E-2: Add GET /api/version endpoint returning the app version (#7172)

### DIFF
--- a/src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class VersionEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("assemblyVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("informationalVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("environment", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("machineName", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("frameworkDescription", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndSamePayload_When_GetUnversionedAndV1Paths()
+    {
+        var unversioned = await _client!.GetAsync("/api/version");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var unversionedBody = await unversioned.Content.ReadAsStringAsync();
+
+        var versioned = await _client.GetAsync("/api/v1.0/version");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var versionedBody = await versioned.Content.ReadAsStringAsync();
+
+        var unversionedPayload = JsonSerializer.Deserialize<VersionMetadataResponse>(
+            unversionedBody,
+            ConditionalGetEtag.JsonSerializerOptions);
+        var versionedPayload = JsonSerializer.Deserialize<VersionMetadataResponse>(
+            versionedBody,
+            ConditionalGetEtag.JsonSerializerOptions);
+
+        unversionedPayload.ShouldNotBeNull();
+        versionedPayload.ShouldNotBeNull();
+        unversionedPayload!.AssemblyVersion.ShouldBe(versionedPayload!.AssemblyVersion);
+        unversionedPayload.InformationalVersion.ShouldBe(versionedPayload.InformationalVersion);
+        unversionedPayload.Environment.ShouldBe(versionedPayload.Environment);
+        unversionedPayload.MachineName.ShouldBe(versionedPayload.MachineName);
+        unversionedPayload.FrameworkDescription.ShouldBe(versionedPayload.FrameworkDescription);
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_VersionAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/version");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/version");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_Return304NotModified_When_IfNoneMatchMatchesEtag()
+    {
+        var first = await _client!.GetAsync("/api/version");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var etag = first.Headers.ETag;
+        etag.ShouldNotBeNull();
+
+        using var second = new HttpRequestMessage(HttpMethod.Get, "/api/version");
+        second.Headers.IfNoneMatch.Add(etag!);
+        var notModified = await _client.SendAsync(second);
+        notModified.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds integration test coverage for the existing `GET /api/version` and `GET /api/v1.0/version` endpoints. The controller, unit tests, middleware bypass, output-cache policy, and rate-limiting wiring were already present on master; this PR completes the technical design by adding full-host integration tests.

## Files Changed

| File | Description |
|------|-------------|
| `src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs` | New integration test suite covering JSON shape, v1 path parity, API-key bypass, and ETag conditional GET |

## Existing Implementation (verified on master)

- `src/UI/Api/Controllers/VersionController.cs` — returns assembly version, informational version, environment, machine name, framework description
- `src/UI/Server/Program.cs` — output-cache policy and controller assembly discovery
- `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` — public path bypass for `/api/version`
- Unit tests in `src/UnitTests/UI.Api/`, `src/UnitTests/UI.Server/`, and `src/UnitTests/Api/`

## Testing

- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./PrivateBuild.ps1` — passed
- `dotnet test src/UnitTests --filter "FullyQualifiedName~Version"` — 10 passed
- New integration tests: 4 tests in `VersionEndpointIntegrationTests`

Closes #7172
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79b40644-a7ef-4c4e-8526-dbbf52d33455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79b40644-a7ef-4c4e-8526-dbbf52d33455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

