### PR TITLE
E2E-9: Add GET /api/hello endpoint returning a greeting (#7180)

### DIFF
--- a/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class HelloEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndPlainTextHello_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("Hello");
+    }
+
+    [Test]
+    public async Task Should_Return200AndPlainTextHello_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("Hello");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_HelloAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/hello");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await unversioned.Content.ReadAsStringAsync()).ShouldBe("Hello");
+
+        var versioned = await client.GetAsync("/api/v1.0/hello");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await versioned.Content.ReadAsStringAsync()).ShouldBe("Hello");
+    }
+}

--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,32 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal plain-text greeting probe for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns the literal response body <c>Hello</c> for reachability checks.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        new ContentResult
+        {
+            Content = "Hello",
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = StatusCodes.Status200OK
+        };
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and hello endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,27 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnPlainTextHello()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        content.Content.ShouldBe("Hello");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/hello", true)]
+    [TestCase("/api/v1.0/hello", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -107,4 +107,19 @@ public class ApiKeyAuthenticationWebTests
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
     }
+
+    [Test]
+    public async Task Should_Return200_When_HelloWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/hello");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await unversioned.Content.ReadAsStringAsync()).ShouldBe("Hello");
+
+        var versioned = await client.GetAsync("/api/v1.0/hello");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await versioned.Content.ReadAsStringAsync()).ShouldBe("Hello");
+    }
 }

--- a/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
+++ b/src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs
@@ -71,6 +71,18 @@ public class ApiVersioningEndpointTests
     }
 
     [Test]
+    public async Task Should_Return200_When_GetHello_V1Path()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("Hello");
+    }
+
+    [Test]
     public async Task Should_IncludeSupportedVersionsHeader_When_GetVersionedEndpoint()
     {
         var response = await _client!.GetAsync("/api/v1.0/health");


### PR DESCRIPTION
## Summary

Adds a new GET `/api/hello` endpoint that returns a plain-text greeting (`Hello`) for E2E and CI reachability checks. The endpoint follows the same pattern as existing diagnostic probes (`/api/ping`, `/api/time`, `/api/version`).

## Changes

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/HelloController.cs` | New controller with unversioned and versioned routes |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Exempt `/api/hello` and `/api/v1.0/hello` from API-key validation |
| `src/UnitTests/UI.Api/HelloControllerTests.cs` | Unit test for controller response |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Path rule test cases for hello routes |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Web test for hello without API key |
| `src/UnitTests/UI.Server/ApiVersioningEndpointTests.cs` | Versioned hello route smoke test |
| `src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs` | Integration tests for unversioned, versioned, and API-key-exempt paths |

## Testing

- Unit tests: `HelloControllerTests`, middleware path rules, middleware web tests, API versioning smoke test
- Integration tests: unversioned/versioned routes, API-key-exempt access
- Full build: `PrivateBuild.ps1` passed (all unit + integration tests green)

Closes #7180