### PR TITLE
E2E-8: Add GET /api/dice endpoint returning a d6 roll (#7179)

### DIFF
--- a/src/IntegrationTests/Api/DiceEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DiceEndpointIntegrationTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class DiceEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndPlainTextRoll_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/dice");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        var body = await response.Content.ReadAsStringAsync();
+        int.TryParse(body, out var value).ShouldBeTrue();
+        value.ShouldBeInRange(1, 6);
+    }
+
+    [Test]
+    public async Task Should_Return200AndPlainTextRoll_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/dice");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        var body = await response.Content.ReadAsStringAsync();
+        int.TryParse(body, out var value).ShouldBeTrue();
+        value.ShouldBeInRange(1, 6);
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_DiceAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/dice");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        int.TryParse(await unversioned.Content.ReadAsStringAsync(), out var unversionedValue).ShouldBeTrue();
+        unversionedValue.ShouldBeInRange(1, 6);
+
+        var versioned = await client.GetAsync("/api/v1.0/dice");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        int.TryParse(await versioned.Content.ReadAsStringAsync(), out var versionedValue).ShouldBeTrue();
+        versionedValue.ShouldBeInRange(1, 6);
+    }
+}

--- a/src/UI/Api/Controllers/DiceController.cs
+++ b/src/UI/Api/Controllers/DiceController.cs
@@ -1,0 +1,46 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a plain-text six-sided die roll for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/dice")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/dice")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class DiceController : ControllerBase
+{
+    private readonly Random _random;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiceController"/> class.
+    /// </summary>
+    /// <param name="random">Optional random source; defaults to <see cref="Random.Shared"/>.</param>
+    public DiceController(Random? random = null)
+    {
+        _random = random ?? Random.Shared;
+    }
+
+    /// <summary>
+    /// Returns a random integer from 1 through 6 as plain text.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var roll = _random.Next(1, 7);
+        return new ContentResult
+        {
+            Content = roll.ToString(),
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = StatusCodes.Status200OK
+        };
+    }
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and dice endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("dice", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("dice", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/DiceControllerTests.cs
+++ b/src/UnitTests/UI.Api/DiceControllerTests.cs
@@ -1,0 +1,47 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class DiceControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnPlainTextInteger_When_SeededRandom()
+    {
+        var controller = new DiceController(new Random(42))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        content.Content.ShouldNotBeNull();
+        int.TryParse(content.Content, out var value).ShouldBeTrue();
+        value.ShouldBeInRange(1, 6);
+    }
+
+    [TestCase(1)]
+    [TestCase(42)]
+    [TestCase(100)]
+    [TestCase(999)]
+    public void Get_Should_ReturnValueInRange1Through6_When_SeededRandom(int seed)
+    {
+        var controller = new DiceController(new Random(seed))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        int.TryParse(content.Content, out var value).ShouldBeTrue();
+        value.ShouldBeInRange(1, 6);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/dice", true)]
+    [TestCase("/api/v1.0/dice", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -107,4 +107,21 @@ public class ApiKeyAuthenticationWebTests
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
     }
+
+    [Test]
+    public async Task Should_Return200_When_DiceWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/dice");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        int.TryParse(await unversioned.Content.ReadAsStringAsync(), out var unversionedValue).ShouldBeTrue();
+        unversionedValue.ShouldBeInRange(1, 6);
+
+        var versioned = await client.GetAsync("/api/v1.0/dice");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        int.TryParse(await versioned.Content.ReadAsStringAsync(), out var versionedValue).ShouldBeTrue();
+        versionedValue.ShouldBeInRange(1, 6);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new anonymous probe endpoint `GET /api/dice` (and versioned `GET /api/v1.0/dice`) that returns a random six-sided die roll as plain text (`"1"`–`"6"`). This follows the same patterns as existing probe endpoints (`/api/ping`, `/api/time`, `/api/version`).

Closes #7179

## Files Changed

| File | Description |
|------|-------------|
| `src/UI/Api/Controllers/DiceController.cs` | New controller with dual routes, rate limiting, and optional seeded `Random` for testability |
| `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` | Exempts `/api/dice` and `/api/v1.0/dice` from API-key validation |
| `src/UnitTests/UI.Api/DiceControllerTests.cs` | Unit tests for controller behavior and value range |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` | Added test cases for dice path exemption |
| `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` | Web test verifying dice accessible without API key |
| `src/IntegrationTests/Api/DiceEndpointIntegrationTests.cs` | Integration tests for unversioned, versioned, and API-key-exempt routes |

## Testing Notes

- **Private build:** Passed (`PrivateBuild.ps1`) — all unit and integration tests green (121 integration tests passed)
- **Unit tests:** Controller returns 200, `text/plain`, integer in [1, 6]; middleware path rules; API-key web behavior
- **Integration tests:** Full HTTP pipeline for unversioned and versioned routes; API-key middleware exemption verified
- **Acceptance tests:** Not required — no UI changes

## Submitter checklist
- [x] Issue is clearly tagged
- [x] Narrate status of the branch (feature complete, incremental build, etc)
- [x] You expect the approval checklist to be satisfied