### PR TITLE
E2E-4: Add GET /api/whoami endpoint returning the current user (#7174)

### DIFF
--- a/src/Core/Services/IEmployeeSignInService.cs
+++ b/src/Core/Services/IEmployeeSignInService.cs
@@ -1,0 +1,17 @@
+namespace ClearMeasure.Bootcamp.Core.Services;
+
+/// <summary>
+/// Signs the current HTTP request in or out as an employee using server-side authentication.
+/// </summary>
+public interface IEmployeeSignInService
+{
+    /// <summary>
+    /// Establishes an authenticated session for the given employee username.
+    /// </summary>
+    Task SignInAsync(string userName);
+
+    /// <summary>
+    /// Clears the authenticated employee session for the current request.
+    /// </summary>
+    Task SignOutAsync();
+}

--- a/src/IntegrationTests/Api/WhoAmIApiKeyProtectedWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/WhoAmIApiKeyProtectedWebApplicationFactory.cs
@@ -1,0 +1,36 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server with API key middleware enabled for whoami integration tests.
+/// </summary>
+public sealed class WhoAmIApiKeyProtectedWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    internal const string SqliteConnectionString = "Data Source=whoami-apikey-integration;Mode=Memory;Cache=Shared";
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", SqliteConnectionString);
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = SqliteConnectionString,
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "true",
+                ["ApiKeyAuthentication:ValidationKey"] = ApiKeyProtectedWebApplicationFactory.TestApiKey,
+                ["FeatureFlags:SampleFeatureA"] = "false",
+                ["FeatureFlags:SampleFeatureB"] = "false"
+            });
+        });
+    }
+}

--- a/src/IntegrationTests/Api/WhoAmIEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/WhoAmIEndpointIntegrationTests.cs
@@ -1,0 +1,267 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.DataAccess.Mappings;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UI.Server;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.Api;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class WhoAmIEndpointIntegrationTests
+{
+    private SqliteConnection? _sharedMemoryHold;
+    private WhoAmIWebApplicationFactory? _factory;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _sharedMemoryHold = new SqliteConnection(WhoAmIWebApplicationFactory.SqliteConnectionString);
+        _sharedMemoryHold.Open();
+        _factory = new WhoAmIWebApplicationFactory();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _factory?.Dispose();
+        _sharedMemoryHold?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return401_When_GetWhoAmIWithoutAuthentication()
+    {
+        using var client = _factory!.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/whoami");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        var versioned = await client.GetAsync("/api/v1.0/whoami");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return200AndEmployeeJson_When_AuthenticatedViaAuthLogin()
+    {
+        var testTag = Guid.NewGuid().ToString("N")[..8];
+        var employee = SeedTestEmployee(testTag);
+        using var client = _factory!.CreateClient();
+
+        var login = await client.PostAsJsonAsync("/api/auth/login", new { userName = employee.UserName });
+        login.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        var response = await client.GetAsync("/api/whoami");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<WhoAmIResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.UserName.ShouldBe(employee.UserName);
+        payload.FirstName.ShouldBe("Test");
+        payload.LastName.ShouldBe("User");
+        payload.EmailAddress.ShouldBe($"testuser-{testTag}@example.com");
+        payload.PreferredLanguage.ShouldBe("en-US");
+        payload.Roles.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Should_Return200AndEmployeeJson_When_GetVersionedWhoAmI()
+    {
+        var testTag = Guid.NewGuid().ToString("N")[..8];
+        var employee = SeedTestEmployee(testTag);
+        using var client = _factory!.CreateClient();
+
+        var login = await client.PostAsJsonAsync("/api/auth/login", new { userName = employee.UserName });
+        login.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/api/v1.0/whoami");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<WhoAmIResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.UserName.ShouldBe(employee.UserName);
+    }
+
+    [Test]
+    public async Task Should_Return401AfterLogout_When_SessionCleared()
+    {
+        var testTag = Guid.NewGuid().ToString("N")[..8];
+        var employee = SeedTestEmployee(testTag);
+        using var client = _factory!.CreateClient();
+
+        var login = await client.PostAsJsonAsync("/api/auth/login", new { userName = employee.UserName });
+        login.EnsureSuccessStatusCode();
+
+        var logout = await client.PostAsync("/api/auth/logout", null);
+        logout.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        var whoami = await client.GetAsync("/api/whoami");
+        whoami.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_LoginWithUnknownUsername()
+    {
+        using var client = _factory!.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new { userName = "nonexistent-user" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.ShouldContain("Invalid login");
+    }
+
+    [Test]
+    public async Task Should_Return204_When_LogoutWithoutAuthentication()
+    {
+        using var client = _factory!.CreateClient();
+
+        var response = await client.PostAsync("/api/auth/logout", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    [Test]
+    public async Task Should_EnforceApiKey_When_MiddlewareEnabledAndWhoAmIProtected()
+    {
+        var testTag = Guid.NewGuid().ToString("N")[..8];
+        await using var connection = new SqliteConnection(WhoAmIApiKeyProtectedWebApplicationFactory.SqliteConnectionString);
+        await connection.OpenAsync();
+        await using var factory = new WhoAmIApiKeyProtectedWebApplicationFactory();
+        SeedTestEmployee(testTag, factory);
+        using var client = factory.CreateClient();
+
+        var unauth = await client.GetAsync("/api/whoami");
+        unauth.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+        using var withKey = factory.CreateClient();
+        withKey.DefaultRequestHeaders.Add(
+            ApiKeyConstants.HeaderName,
+            ApiKeyProtectedWebApplicationFactory.TestApiKey);
+
+        var login = await withKey.PostAsJsonAsync("/api/auth/login", new { userName = $"testuser-{testTag}" });
+        login.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        var whoami = await withKey.GetAsync("/api/whoami");
+        whoami.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_RespectRateLimiting_When_WhoAmICalledRepeatedly()
+    {
+        var testTag = Guid.NewGuid().ToString("N")[..8];
+        await using var connection = new SqliteConnection(WhoAmIWebApplicationFactory.SqliteConnectionString);
+        await connection.OpenAsync();
+        await using var factory = new RateLimitedApiWebApplicationFactory(WhoAmIWebApplicationFactory.SqliteConnectionString);
+        SeedTestEmployee(testTag, factory);
+        using var client = factory.CreateClient();
+
+        var login = await client.PostAsJsonAsync("/api/auth/login", new { userName = $"testuser-{testTag}" });
+        login.EnsureSuccessStatusCode();
+
+        var first = await client.GetAsync("/api/whoami");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var second = await client.GetAsync("/api/whoami");
+        second.StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    [Test]
+    public async Task Should_Return401_When_EmployeeDeletedAfterLogin()
+    {
+        var testTag = Guid.NewGuid().ToString("N")[..8];
+        var employee = SeedTestEmployee(testTag);
+        using var client = _factory!.CreateClient();
+
+        var login = await client.PostAsJsonAsync("/api/auth/login", new { userName = employee.UserName });
+        login.EnsureSuccessStatusCode();
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DataContext>();
+            var tracked = await db.Set<Employee>().SingleAsync(e => e.UserName == employee.UserName);
+            db.Remove(tracked);
+            await db.SaveChangesAsync();
+        }
+
+        var whoami = await client.GetAsync("/api/whoami");
+        whoami.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_IncludeMultipleRoles_When_EmployeeHasMultipleRoles()
+    {
+        var testTag = Guid.NewGuid().ToString("N")[..8];
+        var employee = SeedTestEmployeeWithMultipleRoles(testTag);
+        using var client = _factory!.CreateClient();
+
+        var login = await client.PostAsJsonAsync("/api/auth/login", new { userName = employee.UserName });
+        login.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/api/whoami");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<WhoAmIResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        payload.ShouldNotBeNull();
+        payload!.Roles.Count.ShouldBe(2);
+        payload.Roles.ShouldContain(r => r.Name == $"Maintenance-{testTag}" && r.CanFulfillWorkOrder);
+        payload.Roles.ShouldContain(r => r.Name == $"Manager-{testTag}" && r.CanCreateWorkOrder);
+    }
+
+    private Employee SeedTestEmployee(string testTag, WebApplicationFactory<UiServerWebApplicationMarker>? factory = null)
+    {
+        var targetFactory = factory ?? _factory!;
+        using var scope = targetFactory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DataContext>();
+        db.Database.EnsureCreated();
+        var role = new Role($"TestRole-{testTag}", true, true);
+        var employee = new Employee(
+            $"testuser-{testTag}",
+            "Test",
+            "User",
+            $"testuser-{testTag}@example.com")
+        {
+            PreferredLanguage = "en-US"
+        };
+        employee.AddRole(role);
+        db.Add(role);
+        db.Add(employee);
+        db.SaveChanges();
+        return employee;
+    }
+
+    private Employee SeedTestEmployeeWithMultipleRoles(string testTag)
+    {
+        using var scope = _factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<DataContext>();
+        db.Database.EnsureCreated();
+        var maintenance = new Role($"Maintenance-{testTag}", false, true);
+        var manager = new Role($"Manager-{testTag}", true, false);
+        var employee = new Employee(
+            $"multirole-{testTag}",
+            "Test",
+            "User",
+            $"multirole-{testTag}@example.com")
+        {
+            PreferredLanguage = "en-US"
+        };
+        employee.AddRole(maintenance);
+        employee.AddRole(manager);
+        db.Add(maintenance);
+        db.Add(manager);
+        db.Add(employee);
+        db.SaveChanges();
+        return employee;
+    }
+}

--- a/src/IntegrationTests/Api/WhoAmIWebApplicationFactory.cs
+++ b/src/IntegrationTests/Api/WhoAmIWebApplicationFactory.cs
@@ -1,0 +1,35 @@
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+/// <summary>
+/// Hosts UI.Server for <c>/api/whoami</c> integration tests with shared SQLite in-memory database.
+/// </summary>
+public sealed class WhoAmIWebApplicationFactory : WebApplicationFactory<UiServerWebApplicationMarker>
+{
+    internal const string SqliteConnectionString = "Data Source=whoami-integration;Mode=Memory;Cache=Shared";
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:SqlConnectionString", SqliteConnectionString);
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:SqlConnectionString"] = SqliteConnectionString,
+                ["AI_OpenAI_ApiKey"] = "",
+                ["AI_OpenAI_Url"] = "",
+                ["AI_OpenAI_Model"] = "",
+                ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = "",
+                ["ApiKeyAuthentication:Enabled"] = "false",
+                ["ApiKeyAuthentication:ValidationKey"] = "",
+                ["FeatureFlags:SampleFeatureA"] = "false",
+                ["FeatureFlags:SampleFeatureB"] = "false"
+            });
+        });
+    }
+}

--- a/src/UI.Shared/Components/Logout.razor
+++ b/src/UI.Shared/Components/Logout.razor
@@ -1,5 +1,6 @@
 @inject CustomAuthenticationStateProvider AuthStateProvider
 @inject NavigationManager NavigationManager
+@inject HttpClient Http
 
 <span data-testid="@Elements.WelcomeText">
     Welcome
@@ -12,8 +13,9 @@
 
 @code {
 
-    private void HandleLogout()
+    private async Task HandleLogout()
     {
+        await Http.PostAsync("/api/auth/logout", null);
         AuthStateProvider.Logout();
         EventBus.Notify(new UserLoggedOutEvent(AuthStateProvider.GetUsername()));
         NavigationManager.NavigateTo("/login");

--- a/src/UI.Shared/Pages/Login.razor.cs
+++ b/src/UI.Shared/Pages/Login.razor.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text;
+using System.Text.Json;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.UI.Shared.Authentication;
@@ -12,6 +14,7 @@ public partial class Login : AppComponentBase
 {
     [Inject] public CustomAuthenticationStateProvider? AuthStateProvider { get; set; }
     [Inject] public NavigationManager? NavigationManager { get; set; }
+    [Inject] public HttpClient? Http { get; set; }
 
     public readonly LoginModel loginModel = new();
     public string? errorMessage;
@@ -54,8 +57,10 @@ public partial class Login : AppComponentBase
         var selectedEmployee = employees.FirstOrDefault(e => e.UserName == loginModel.Username);
         if (selectedEmployee != null)
         {
-            // Successful login
             AuthStateProvider!.Login(loginModel.Username);
+            var loginBody = JsonSerializer.Serialize(new { userName = loginModel.Username });
+            using var content = new StringContent(loginBody, Encoding.UTF8, "application/json");
+            await Http!.PostAsync("/api/auth/login", content);
             EventBus.Notify(new UserLoggedInEvent(loginModel.Username));
             await Bus.Publish(new Core.Model.Events.UserLoggedInEvent(loginModel.Username));
             NavigationManager!.NavigateTo("/");

--- a/src/UI/Api/Controllers/AuthController.cs
+++ b/src/UI/Api/Controllers/AuthController.cs
@@ -1,0 +1,72 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Programmatic employee login and logout for API consumers and test harnesses.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/auth")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/auth")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class AuthController(IBus bus, IEmployeeSignInService signInService) : ControllerBase
+{
+    /// <summary>
+    /// Establishes an authenticated employee session for the given username.
+    /// </summary>
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.UserName))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid login",
+                Detail = "Username is required.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        try
+        {
+            await bus.Send(new EmployeeByUserNameQuery(request.UserName));
+        }
+        catch (InvalidOperationException)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid login",
+                Detail = $"No employee found with username '{request.UserName}'.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        await signInService.SignInAsync(request.UserName);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Clears the authenticated employee session.
+    /// </summary>
+    [HttpPost("logout")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Logout()
+    {
+        await signInService.SignOutAsync();
+        return NoContent();
+    }
+}
+
+/// <summary>
+/// Request body for <c>POST /api/auth/login</c>.
+/// </summary>
+public record LoginRequest(string UserName);

--- a/src/UI/Api/Controllers/WhoAmIController.cs
+++ b/src/UI/Api/Controllers/WhoAmIController.cs
@@ -1,0 +1,70 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes the authenticated employee identity for programmatic API consumers.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/whoami")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/whoami")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+[Authorize]
+public class WhoAmIController(IUserSession userSession) : ControllerBase
+{
+    /// <summary>
+    /// Returns the current authenticated employee as JSON.
+    /// </summary>
+    [HttpGet]
+    public async Task<IActionResult> Get(CancellationToken cancellationToken)
+    {
+        var employee = await userSession.GetCurrentUserAsync();
+        if (employee is null)
+        {
+            return Unauthorized();
+        }
+
+        var payload = MapToResponse(employee);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+
+    private static WhoAmIResponse MapToResponse(Employee employee) =>
+        new(
+            UserName: employee.UserName,
+            FirstName: employee.FirstName,
+            LastName: employee.LastName,
+            EmailAddress: employee.EmailAddress,
+            PreferredLanguage: employee.PreferredLanguage,
+            Roles: employee.Roles
+                .Select(role => new WhoAmIRoleResponse(
+                    role.Name,
+                    role.CanCreateWorkOrder,
+                    role.CanFulfillWorkOrder))
+                .ToArray());
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/whoami</c> and <c>GET /api/v1.0/whoami</c>.
+/// </summary>
+public record WhoAmIResponse(
+    string UserName,
+    string FirstName,
+    string LastName,
+    string EmailAddress,
+    string PreferredLanguage,
+    IReadOnlyList<WhoAmIRoleResponse> Roles);
+
+/// <summary>
+/// Role projection included in <see cref="WhoAmIResponse"/>.
+/// </summary>
+public record WhoAmIRoleResponse(
+    string Name,
+    bool CanCreateWorkOrder,
+    bool CanFulfillWorkOrder);

--- a/src/UI/Server/Authentication/EmployeeAuthenticationDefaults.cs
+++ b/src/UI/Server/Authentication/EmployeeAuthenticationDefaults.cs
@@ -1,0 +1,12 @@
+namespace ClearMeasure.Bootcamp.UI.Server.Authentication;
+
+/// <summary>
+/// Constants for the employee cookie authentication scheme.
+/// </summary>
+public static class EmployeeAuthenticationDefaults
+{
+    /// <summary>
+    /// Authentication scheme name for employee cookie sessions.
+    /// </summary>
+    public const string Scheme = "EmployeeCookie";
+}

--- a/src/UI/Server/Authentication/EmployeeSignInService.cs
+++ b/src/UI/Server/Authentication/EmployeeSignInService.cs
@@ -1,0 +1,39 @@
+using System.Security.Claims;
+using ClearMeasure.Bootcamp.Core.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Authentication;
+
+/// <summary>
+/// Signs employees in and out using the employee cookie authentication scheme.
+/// </summary>
+public sealed class EmployeeSignInService(IHttpContextAccessor httpContextAccessor) : IEmployeeSignInService
+{
+    /// <inheritdoc />
+    public Task SignInAsync(string userName)
+    {
+        var httpContext = httpContextAccessor.HttpContext
+            ?? throw new InvalidOperationException("No active HTTP context.");
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, userName)],
+            EmployeeAuthenticationDefaults.Scheme);
+        var principal = new ClaimsPrincipal(identity);
+        return httpContext.SignInAsync(
+            EmployeeAuthenticationDefaults.Scheme,
+            principal,
+            new AuthenticationProperties { IsPersistent = true });
+    }
+
+    /// <inheritdoc />
+    public Task SignOutAsync()
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return httpContext.SignOutAsync(EmployeeAuthenticationDefaults.Scheme);
+    }
+}

--- a/src/UI/Server/Authentication/ServerUserSession.cs
+++ b/src/UI/Server/Authentication/ServerUserSession.cs
@@ -1,0 +1,38 @@
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.Core.Services;
+using Microsoft.AspNetCore.Http;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Authentication;
+
+/// <summary>
+/// Resolves the authenticated employee from the server-side cookie session.
+/// </summary>
+public sealed class ServerUserSession(IHttpContextAccessor httpContextAccessor, IBus bus) : IUserSession
+{
+    /// <inheritdoc />
+    public async Task<Employee?> GetCurrentUserAsync()
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        if (httpContext?.User?.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        var userName = httpContext.User.Identity.Name;
+        if (string.IsNullOrEmpty(userName))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await bus.Send(new EmployeeByUserNameQuery(userName));
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/UI/Server/Program.cs
+++ b/src/UI/Server/Program.cs
@@ -13,6 +13,7 @@ using ClearMeasure.Bootcamp.McpServer.Tools;
 using ClearMeasure.Bootcamp.McpServer.Resources;
 using ClearMeasure.Bootcamp.UI.Api;
 using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UI.Server.Authentication;
 using ClearMeasure.Bootcamp.UI.Server.Grpc;
 using ClearMeasure.Bootcamp.UI.Server.Middleware;
 using ClearMeasure.Bootcamp.UI.Server.Notifications;
@@ -52,6 +53,25 @@ builder.Services.Configure<IdempotencyOptions>(
 builder.Services.AddSingleton<IdempotencyProbeState>();
 builder.Services.AddApiRateLimiting(builder.Configuration);
 builder.Services.AddApiRequestTimeouts(builder.Configuration);
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthentication(EmployeeAuthenticationDefaults.Scheme)
+    .AddCookie(EmployeeAuthenticationDefaults.Scheme, options =>
+    {
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SameSite = SameSiteMode.Lax;
+        options.Cookie.Path = "/";
+        options.Events.OnRedirectToLogin = context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return Task.CompletedTask;
+        };
+        options.Events.OnRedirectToAccessDenied = context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return Task.CompletedTask;
+        };
+    });
+builder.Services.AddAuthorization();
 builder.Services.Configure<ApiKeyAuthenticationOptions>(
     builder.Configuration.GetSection(ApiKeyAuthenticationOptions.SectionName));
 builder.Services.Configure<DiagnosticsFeatureFlagsOptions>(
@@ -161,6 +181,9 @@ app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.UseWhen(
     context => ApiRateLimitingExtensions.ShouldApplyToPath(context.Request.Path),

--- a/src/UI/Server/UIServiceRegistry.cs
+++ b/src/UI/Server/UIServiceRegistry.cs
@@ -9,6 +9,7 @@ using ClearMeasure.Bootcamp.LlmGateway;
 using ClearMeasure.Bootcamp.McpServer;
 using ClearMeasure.Bootcamp.McpServer.Tools;
 using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Server.Authentication;
 using ClearMeasure.Bootcamp.UI.Server.Notifications;
 using ClearMeasure.Bootcamp.UI.Shared;
 using FluentValidation;
@@ -73,5 +74,8 @@ public class UiServiceRegistry : ServiceRegistry
             .AddCheck<NeedsRebootHealthCheck>("NeedsReboot");
 
         this.AddSingleton<IDetailedHealthReportProvider, DetailedHealthReportProvider>();
+
+        this.AddScoped<IUserSession, ServerUserSession>();
+        this.AddScoped<IEmployeeSignInService, EmployeeSignInService>();
     }
 }

--- a/src/UnitTests/UI.Api/AuthControllerTests.cs
+++ b/src/UnitTests/UI.Api/AuthControllerTests.cs
@@ -1,0 +1,101 @@
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class AuthControllerTests
+{
+    [Test]
+    public async Task Login_Should_Return204_When_ValidUsername()
+    {
+        var employee = new Employee("validuser", "Valid", "User", "valid@example.com");
+        var signInService = new StubEmployeeSignInService();
+        var controller = new AuthController(new StubBus(employee), signInService)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = await controller.Login(new LoginRequest("validuser"));
+
+        result.ShouldBeOfType<NoContentResult>();
+        signInService.LastSignedInUserName.ShouldBe("validuser");
+    }
+
+    [Test]
+    public async Task Login_Should_Return400_When_UnknownUsername()
+    {
+        var controller = new AuthController(new StubBus(null), new StubEmployeeSignInService())
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = await controller.Login(new LoginRequest("unknown"));
+
+        var badRequest = result.ShouldBeOfType<BadRequestObjectResult>();
+        badRequest.Value.ShouldBeOfType<ProblemDetails>();
+    }
+
+    [Test]
+    public async Task Logout_Should_Return204_When_Called()
+    {
+        var signInService = new StubEmployeeSignInService();
+        var controller = new AuthController(new StubBus(null), signInService)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = await controller.Logout();
+
+        result.ShouldBeOfType<NoContentResult>();
+        signInService.SignOutCalled.ShouldBeTrue();
+    }
+
+    private sealed class StubBus(Employee? employee) : IBus
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request)
+        {
+            if (request is EmployeeByUserNameQuery)
+            {
+                if (employee is null)
+                {
+                    throw new InvalidOperationException("Employee not found.");
+                }
+
+                return Task.FromResult((TResponse)(object)employee);
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public Task<object?> Send(object request) => throw new NotImplementedException();
+
+        public Task Publish(INotification notification) => Task.CompletedTask;
+    }
+
+    private sealed class StubEmployeeSignInService : IEmployeeSignInService
+    {
+        public string? LastSignedInUserName { get; private set; }
+
+        public bool SignOutCalled { get; private set; }
+
+        public Task SignInAsync(string userName)
+        {
+            LastSignedInUserName = userName;
+            return Task.CompletedTask;
+        }
+
+        public Task SignOutAsync()
+        {
+            SignOutCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/UnitTests/UI.Api/WhoAmIControllerTests.cs
+++ b/src/UnitTests/UI.Api/WhoAmIControllerTests.cs
@@ -1,0 +1,72 @@
+using System.Security.Claims;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class WhoAmIControllerTests
+{
+    [Test]
+    public async Task Get_Should_ReturnJsonWithEmployeeFields_When_UserAuthenticated()
+    {
+        var role = new Role("Maintenance", false, true);
+        var employee = new Employee("testuser", "Test", "User", "test@example.com")
+        {
+            PreferredLanguage = "en-US"
+        };
+        employee.AddRole(role);
+        var controller = new WhoAmIController(new StubUserSession(employee))
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity("test"))
+                }
+            }
+        };
+
+        var result = await controller.Get(CancellationToken.None);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = System.Text.Json.JsonSerializer.Deserialize<WhoAmIResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.UserName.ShouldBe("testuser");
+        payload.FirstName.ShouldBe("Test");
+        payload.LastName.ShouldBe("User");
+        payload.EmailAddress.ShouldBe("test@example.com");
+        payload.PreferredLanguage.ShouldBe("en-US");
+        payload.Roles.Count.ShouldBe(1);
+        payload.Roles[0].Name.ShouldBe("Maintenance");
+        payload.Roles[0].CanCreateWorkOrder.ShouldBeFalse();
+        payload.Roles[0].CanFulfillWorkOrder.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Get_Should_Return401_When_UserNotAuthenticated()
+    {
+        var controller = new WhoAmIController(new StubUserSession(null))
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = await controller.Get(CancellationToken.None);
+
+        result.ShouldBeOfType<UnauthorizedResult>();
+    }
+
+    private sealed class StubUserSession(Employee? currentUser) : IUserSession
+    {
+        public Task<Employee?> GetCurrentUserAsync() => Task.FromResult(currentUser);
+    }
+}

--- a/src/UnitTests/UI.Server/ServerUserSessionTests.cs
+++ b/src/UnitTests/UI.Server/ServerUserSessionTests.cs
@@ -1,0 +1,82 @@
+using System.Security.Claims;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Server.Authentication;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class ServerUserSessionTests
+{
+    [Test]
+    public async Task GetCurrentUserAsync_Should_LoadEmployee_When_ClaimPresent()
+    {
+        var employee = new Employee("testuser", "Test", "User", "test@example.com");
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, "testuser")],
+                EmployeeAuthenticationDefaults.Scheme))
+        };
+        var accessor = new StubHttpContextAccessor(httpContext);
+        var session = new ServerUserSession(accessor, new StubBus(employee));
+
+        var result = await session.GetCurrentUserAsync();
+
+        result.ShouldNotBeNull();
+        result!.UserName.ShouldBe("testuser");
+    }
+
+    [Test]
+    public async Task GetCurrentUserAsync_Should_ReturnNull_When_NoClaim()
+    {
+        var accessor = new StubHttpContextAccessor(new DefaultHttpContext());
+        var session = new ServerUserSession(accessor, new StubBus(null));
+
+        var result = await session.GetCurrentUserAsync();
+
+        result.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task GetCurrentUserAsync_Should_ReturnNull_When_NoHttpContext()
+    {
+        var accessor = new StubHttpContextAccessor(null);
+        var session = new ServerUserSession(accessor, new StubBus(null));
+
+        var result = await session.GetCurrentUserAsync();
+
+        result.ShouldBeNull();
+    }
+
+    private sealed class StubHttpContextAccessor(HttpContext? httpContext) : IHttpContextAccessor
+    {
+        public HttpContext? HttpContext { get; set; } = httpContext;
+    }
+
+    private sealed class StubBus(Employee? employee) : IBus
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request)
+        {
+            if (request is EmployeeByUserNameQuery)
+            {
+                if (employee is null)
+                {
+                    throw new InvalidOperationException("Employee not found.");
+                }
+
+                return Task.FromResult((TResponse)(object)employee);
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public Task<object?> Send(object request) => throw new NotImplementedException();
+
+        public Task Publish(INotification notification) => Task.CompletedTask;
+    }
+}

--- a/src/UnitTests/UI.Shared/AuthHttpClientTestSupport.cs
+++ b/src/UnitTests/UI.Shared/AuthHttpClientTestSupport.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using System.Net.Http;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared;
+
+/// <summary>
+/// Returns <see cref="HttpStatusCode.NoContent"/> for auth API calls in bUnit component tests.
+/// </summary>
+internal sealed class StubAuthHttpMessageHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+}
+
+/// <summary>
+/// Registers an <see cref="HttpClient"/> suitable for login/logout component tests.
+/// </summary>
+internal static class AuthHttpClientTestSupport
+{
+    internal static HttpClient CreateClient() =>
+        new(new StubAuthHttpMessageHandler())
+        {
+            BaseAddress = new Uri("http://localhost/")
+        };
+}

--- a/src/UnitTests/UI.Shared/Components/LogoutTests.cs
+++ b/src/UnitTests/UI.Shared/Components/LogoutTests.cs
@@ -4,6 +4,7 @@ using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UI.Shared.Authentication;
 using ClearMeasure.Bootcamp.UI.Shared.Components;
 using ClearMeasure.Bootcamp.UI.Shared.Models;
+using ClearMeasure.Bootcamp.UnitTests.UI.Shared;
 using ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
@@ -68,6 +69,7 @@ public class LogoutTests
         ctx.Services.AddSingleton(authProvider);
         ctx.Services.AddSingleton<IUiBus>(spyEventBus);
         ctx.Services.AddSingleton<IBus>(new Bus(null!));
+        ctx.Services.AddSingleton(AuthHttpClientTestSupport.CreateClient());
 
         var component = ctx.RenderComponent<Logout>();
         var logoutLink = component.Find("a");
@@ -89,6 +91,7 @@ public class LogoutTests
         ctx.Services.AddSingleton(authProvider);
         ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
         ctx.Services.AddSingleton<IBus>(new Bus(null!));
+        ctx.Services.AddSingleton(AuthHttpClientTestSupport.CreateClient());
 
         var component = ctx.RenderComponent<Logout>();
         var logoutLink = component.Find("a");
@@ -109,6 +112,7 @@ public class LogoutTests
         ctx.Services.AddSingleton<CustomAuthenticationStateProvider>();
         ctx.Services.AddSingleton<IUiBus>(spyEventBus);
         ctx.Services.AddSingleton<IBus>(new Bus(null!));
+        ctx.Services.AddSingleton(AuthHttpClientTestSupport.CreateClient());
 
         var component = ctx.RenderComponent<Logout>();
         var logoutLink = component.Find("a");

--- a/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
@@ -4,6 +4,7 @@ using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.UI.Shared.Authentication;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
 using Microsoft.AspNetCore.Components.Authorization;
+using ClearMeasure.Bootcamp.UnitTests.UI.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Palermo.BlazorMvc;
 using Shouldly;
@@ -95,6 +96,7 @@ public class LoginPageTests
         ctx.Services.AddSingleton<AuthenticationStateProvider>(provider);
         ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
         ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton(AuthHttpClientTestSupport.CreateClient());
 
         var component = ctx.RenderComponent<Login>();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `GET /api/whoami` and supporting server-side employee authentication so programmatic clients (integration tests, E2E helpers, MCP/API tooling) can discover the authenticated employee without driving the Blazor login UI.

### What changed

- **Server-side cookie auth**: Added `EmployeeCookie` authentication scheme with `ServerUserSession`, `EmployeeSignInService`, and `IEmployeeSignInService`.
- **`GET /api/whoami`** (+ versioned route): Returns authenticated employee JSON (`userName`, `firstName`, `lastName`, `emailAddress`, `preferredLanguage`, `roles`). Requires employee auth; returns 401 when unauthenticated.
- **`POST /api/auth/login` / `POST /api/auth/logout`**: Programmatic login/logout for test harnesses and API clients.
- **Blazor bridge**: Login and Logout components now call the server auth endpoints to keep the cookie session in sync with client-side auth state.

## Files changed

| File | Description |
|------|-------------|
| `src/Core/Services/IEmployeeSignInService.cs` | Sign-in service interface |
| `src/UI/Server/Authentication/*` | Cookie auth defaults, sign-in service, server user session |
| `src/UI/Server/Program.cs` | `AddAuthentication`/`UseAuthentication` wiring |
| `src/UI/Server/UIServiceRegistry.cs` | DI registration for server auth services |
| `src/UI/Api/Controllers/WhoAmIController.cs` | WhoAmI endpoint + response DTOs |
| `src/UI/Api/Controllers/AuthController.cs` | Login/logout endpoints |
| `src/UI.Shared/Pages/Login.razor.cs` | Calls `POST /api/auth/login` after Blazor login |
| `src/UI.Shared/Components/Logout.razor` | Calls `POST /api/auth/logout` on logout |
| `src/UnitTests/UI.Api/*` | WhoAmI and Auth controller unit tests |
| `src/UnitTests/UI.Server/ServerUserSessionTests.cs` | Server user session unit tests |
| `src/UnitTests/UI.Shared/AuthHttpClientTestSupport.cs` | bUnit HttpClient stub for login/logout tests |
| `src/IntegrationTests/Api/WhoAmI*` | 10 integration test scenarios |

## Testing

- Unit tests: 8 new tests (WhoAmIController, AuthController, ServerUserSession) + updated login/logout bUnit tests
- Integration tests: 10 scenarios covering auth, versioned routes, API key layering, rate limiting, logout, deleted employee
- Private build: passed (281 unit + 128 integration tests)

Closes #7174
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1b1ff1b-d419-4d53-8621-a87157a7ec8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1b1ff1b-d419-4d53-8621-a87157a7ec8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

