### PR TITLE
Fix flaky NavRailToggle anonymous-landing acceptance test

### DIFF
--- a/src/AcceptanceTests/App/NavRailToggleTests.cs
+++ b/src/AcceptanceTests/App/NavRailToggleTests.cs
@@ -112,8 +112,11 @@ public class NavRailToggleTests : AcceptanceTestBase
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         await Task.Delay(GetInputDelayMs());
 
+        // First interactive element after a cold anonymous WASM boot: allow generous warmup.
+        // browserContext.SetDefaultTimeout does not apply to web-first assertions (they default to
+        // 5s), so this must be explicit - matching the pattern used elsewhere in this suite.
         var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
-        await Expect(toggle).ToBeVisibleAsync();
+        await Expect(toggle).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
 
         await Click(nameof(MainLayout.Elements.NavRailToggle));
         await Task.Delay(GetInputDelayMs());


### PR DESCRIPTION
## Problem

`ShouldShowNavRailToggle_OnAnonymousLandingPage` intermittently failed on the x64 Acceptance Tests job with a visibility timeout. It is the only test that asserts against a cold-boot anonymous Blazor WASM page with no prior login warmup.

## Root cause

`browserContext.SetDefaultTimeout(60_000)` does **not** apply to Playwright web-first assertions. `Expect(...).ToBeVisibleAsync()` uses its own default of 5s. On a slow cold WASM boot the page took longer than 5s to render the toggle, so the assertion timed out even though the default action/navigation timeout was 60s.

## Fix

Give the first visibility assertion an explicit `Timeout = 30_000`, matching the convention already used elsewhere in the suite. One-line change plus explanatory comment; the project already compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)