### PR TITLE
Make login button bigger (#7193)

### DIFF
--- a/src/UI.Shared/Pages/Login.razor
+++ b/src/UI.Shared/Pages/Login.razor
@@ -28,8 +28,8 @@
                     <div class="alert alert-danger">@errorMessage</div>
                 }
 
-                <div class="text-center">
-                    <button data-testid="@Elements.LoginButton" type="submit" class="btn btn-primary">Enter Church Portal</button>
+                <div class="login-submit">
+                    <button data-testid="@Elements.LoginButton" type="submit" class="btn btn-primary btn-login-portal">Enter Church Portal</button>
                 </div>
             </EditForm>
 

--- a/src/UI.Shared/Pages/Login.razor.css
+++ b/src/UI.Shared/Pages/Login.razor.css
@@ -149,8 +149,22 @@
     font-weight: 500;
 }
 
-.text-center {
-    text-align: center;
+.login-submit {
+    width: 100%;
+}
+
+.btn-login-portal {
+    width: 100%;
+    font-size: 1.375rem;
+    padding: 1.375rem 2rem;
+    min-height: 44px;
+    min-width: unset;
+}
+
+.btn-login-portal:focus,
+.btn-login-portal:focus-visible {
+    box-shadow: 0 0 0 0.2rem rgba(123, 104, 238, 0.25);
+    outline: none;
 }
 
 .church-blessing {
@@ -203,6 +217,10 @@
     
     .login-body {
         padding: 1.5rem;
+    }
+
+    .btn-login-portal {
+        width: 100%;
     }
 }
 

--- a/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
@@ -109,6 +109,23 @@ public class LoginPageTests
     }
 
     [Test]
+    public void ShouldRenderLoginButtonWithEnlargedPortalClass()
+    {
+        using var ctx = new TestContext();
+
+        var provider = new CustomAuthenticationStateProvider();
+        ctx.Services.AddSingleton(provider);
+        ctx.Services.AddSingleton<AuthenticationStateProvider>(provider);
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+
+        var component = ctx.RenderComponent<Login>();
+
+        var submitButton = component.Find($"[data-testid='{Login.Elements.LoginButton}']");
+        submitButton.ClassList.ShouldContain("btn-login-portal");
+    }
+
+    [Test]
     public void ShouldDisplayFirstChurchOfShelbyvilleSubtitle()
     {
         using var ctx = new TestContext();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enlarges the **Enter Church Portal** submit button on the Login page so it is unmistakably the primary call-to-action. The button now spans the full form width with increased font size and vertical padding to meet WCAG 2.5.5 touch-target guidance (~44px minimum height).

## Files Changed

- `src/UI.Shared/Pages/Login.razor` — Added `btn-login-portal` modifier class and replaced `text-center` wrapper with `login-submit` container for full-width layout
- `src/UI.Shared/Pages/Login.razor.css` — Added enlarged button styles (1.375rem font, 1.375rem vertical padding, 100% width, focus-visible ring) and responsive rules for ≤768px viewports
- `src/UnitTests/UI.Shared/Pages/LoginPageTests.cs` — Added bUnit test asserting the submit button carries `btn-login-portal` class

## Testing

- `PrivateBuild.ps1` — full build, unit tests, DB migration, integration tests: **passed**
- Login page unit tests (`LoginPageTests`) — all green including new `ShouldRenderLoginButtonWithEnlargedPortalClass`
- Existing acceptance tests locate button by `data-testid`; no functional changes required

Closes #7193
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cfb3b4e-390b-45ed-9783-0e648a72553b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cfb3b4e-390b-45ed-9783-0e648a72553b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

