### PR TITLE
Make login button bigger (#7193)

### DIFF
--- a/src/UI.Shared/Pages/Login.razor
+++ b/src/UI.Shared/Pages/Login.razor
@@ -28,8 +28,8 @@
                     <div class="alert alert-danger">@errorMessage</div>
                 }
 
-                <div class="text-center">
-                    <button data-testid="@Elements.LoginButton" type="submit" class="btn btn-primary">Enter Church Portal</button>
+                <div class="login-submit">
+                    <button data-testid="@Elements.LoginButton" type="submit" class="btn btn-primary btn-login-portal">Enter Church Portal</button>
                 </div>
             </EditForm>
 

--- a/src/UI.Shared/Pages/Login.razor.css
+++ b/src/UI.Shared/Pages/Login.razor.css
@@ -131,6 +131,24 @@
     box-shadow: 0 2px 10px rgba(123, 104, 238, 0.3);
 }
 
+.login-submit {
+    width: 100%;
+}
+
+.btn-login-portal {
+    width: 100%;
+    font-size: 1.375rem;
+    padding: 1.375rem 2rem;
+    min-height: 44px;
+    min-width: unset;
+}
+
+.btn-login-portal:focus,
+.btn-login-portal:focus-visible {
+    box-shadow: 0 0 0 0.2rem rgba(123, 104, 238, 0.25);
+    outline: none;
+}
+
 .alert-danger {
     background: linear-gradient(135deg, #fed7d7 0%, #feb2b2 100%);
     border: 1px solid #fc8181;
@@ -203,6 +221,10 @@
     
     .login-body {
         padding: 1.5rem;
+    }
+
+    .btn-login-portal {
+        width: 100%;
     }
 }
 

--- a/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/LoginPageTests.cs
@@ -109,6 +109,23 @@ public class LoginPageTests
     }
 
     [Test]
+    public void ShouldRenderLoginButtonWithEnlargedPortalClass()
+    {
+        using var ctx = new TestContext();
+
+        var provider = new CustomAuthenticationStateProvider();
+        ctx.Services.AddSingleton(provider);
+        ctx.Services.AddSingleton<AuthenticationStateProvider>(provider);
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+
+        var component = ctx.RenderComponent<Login>();
+
+        var submitButton = component.Find($"[data-testid='{Login.Elements.LoginButton}']");
+        submitButton.ClassList.ShouldContain("btn-login-portal");
+    }
+
+    [Test]
     public void ShouldDisplayFirstChurchOfShelbyvilleSubtitle()
     {
         using var ctx = new TestContext();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enlarges the **Enter Church Portal** submit button on the Login page so it is unmistakably the primary action. The button now spans the full form width with increased font size, padding, and a 44px minimum touch target while preserving the existing gradient, hover lift, and shadow styling.

## Files Changed

| File | Description |
|------|-------------|
| `src/UI.Shared/Pages/Login.razor` | Added `btn-login-portal` class and replaced `text-center` wrapper with `login-submit` container |
| `src/UI.Shared/Pages/Login.razor.css` | Added enlarged button styles, focus ring, and responsive rules for narrow viewports |
| `src/UnitTests/UI.Shared/Pages/LoginPageTests.cs` | Added bUnit test asserting `btn-login-portal` class is present on submit button |

## Testing

- ✅ `PrivateBuild.ps1` — compile, unit tests, DB migration, integration tests all green
- ✅ `LoginPageTests` — existing login flow tests pass; new class assertion added
- ✅ No backend, auth, or routing changes; `data-testid="LoginButton"` unchanged

Closes #7193
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95b5ad93-656c-4e26-9068-07715377458f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95b5ad93-656c-4e26-9068-07715377458f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

