### PR TITLE
Tiny: include app version in detailed health check payload (#7249)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -140,4 +140,45 @@ public class DetailedHealthEndpointIntegrationTests
                 || c.Status == ComponentHealthStatus.Unhealthy).ShouldBeTrue();
         }
     }
+
+    [Test]
+    public async Task Should_IncludeVersion_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        report!.Version.ShouldNotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task Should_HaveConsistentVersion_AcrossMultipleRequests()
+    {
+        var response1 = await _client!.GetAsync("/api/health/detailed");
+        var report1 = await response1.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var response2 = await _client!.GetAsync("/api/health/detailed");
+        var report2 = await response2.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        report1.ShouldNotBeNull();
+        report2.ShouldNotBeNull();
+        report1!.Version.ShouldBe(report2!.Version);
+    }
+
+    [Test]
+    public async Task Should_SerializeVersionToJson_WithCorrectPropertyName()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("version", out var version).ShouldBeTrue();
+        version.ValueKind.ShouldBe(JsonValueKind.String);
+        version.GetString().ShouldNotBeNullOrEmpty();
+    }
 }

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -36,6 +36,9 @@ public sealed class DetailedHealthReport
 
     /// <summary>Per-logical-component entries (mock or probe-derived).</summary>
     public required IReadOnlyList<ComponentHealthEntry> Components { get; init; }
+
+    /// <summary>Informational version of the executing assembly (optional).</summary>
+    public string? Version { get; init; }
 }
 
 /// <summary>

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using ClearMeasure.Bootcamp.UI.Api;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -31,7 +32,8 @@ public sealed class DetailedHealthReportProvider(
         {
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             Components = components,
-            OverallStatus = MapOverallStatus(report.Status)
+            OverallStatus = MapOverallStatus(report.Status),
+            Version = GetAssemblyInformationalVersion()
         };
     }
 
@@ -53,8 +55,19 @@ public sealed class DetailedHealthReportProvider(
         {
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             Components = components,
-            OverallStatus = MapOverallStatus(aggregateStatus)
+            OverallStatus = MapOverallStatus(aggregateStatus),
+            Version = GetAssemblyInformationalVersion()
         };
+    }
+
+    /// <summary>
+    /// Retrieves the executing assembly's informational version.
+    /// </summary>
+    /// <returns>The informational version string, or null if not found.</returns>
+    internal static string? GetAssemblyInformationalVersion()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
     }
 
     private static string MapOverallStatus(HealthStatus status) => status switch

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -165,4 +165,65 @@ public class DetailedHealthReportProviderTests
         component.Data.ShouldNotBeNull();
         component.Data!["endpoint"].ShouldBe("https://api.example.com");
     }
+
+    [Test]
+    public void GetAssemblyInformationalVersion_Should_ReturnNonNullVersion()
+    {
+        var version = DetailedHealthReportProvider.GetAssemblyInformationalVersion();
+
+        version.ShouldNotBeNullOrEmpty();
+    }
+
+    [Test]
+    public void FromHealthReport_Should_PopulateVersion_WhenBuilding()
+    {
+        var fixedTime = new DateTime(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(
+                HealthStatus.Healthy,
+                "All systems operational",
+                TimeSpan.FromMilliseconds(10),
+                null,
+                new Dictionary<string, object>())
+        };
+        var report = new HealthReport(entries, TimeSpan.FromMilliseconds(10));
+
+        var detailed = DetailedHealthReportProvider.FromHealthReport(
+            report, new FixedUtcTimeProvider(fixedTime));
+
+        detailed.Version.ShouldNotBeNullOrEmpty();
+    }
+
+    [Test]
+    public void FromComponentStatuses_Should_PopulateVersion_WhenBuilding()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Healthy,
+            TimeProvider.System);
+
+        detailed.Version.ShouldNotBeNullOrEmpty();
+    }
+
+    [Test]
+    public void DetailedHealthReport_Should_AllowNullVersion_ForOptionalProperty()
+    {
+        var fixedTime = new DateTime(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+        
+        var detailed = new DetailedHealthReport
+        {
+            CheckedAtUtc = fixedTime,
+            Components = new List<ComponentHealthEntry>(),
+            OverallStatus = ComponentHealthStatus.Healthy,
+            Version = null
+        };
+
+        detailed.Version.ShouldBeNull();
+    }
 }


### PR DESCRIPTION
## Summary
Added optional `version` property to the detailed health check JSON response to include the executing assembly's informational version. This allows monitoring systems, deployment pipelines, and observability platforms to correlate health reports with deployed application versions.

## Key Files Changed
- `src/UI/Api/DetailedHealthModels.cs` — Added `Version` property to `DetailedHealthReport` model
- `src/UI/Server/DetailedHealthReportProvider.cs` — Added `GetAssemblyInformationalVersion()` method and updated `FromHealthReport()` and `FromComponentStatuses()` to populate version
- `src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs` — Added 4 unit tests
- `src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs` — Added 3 integration tests

## Testing Notes
- Unit tests verify version retrieval and population in both `FromHealthReport()` and `FromComponentStatuses()`
- Integration tests verify the HTTP `/api/health/detailed` endpoint includes the version property with a non-empty string value
- Tests verify version is consistent across multiple requests and serializes with correct JSON property name
- All tests follow existing patterns: NUnit + Shouldly assertions, AAA pattern

## Backward Compatibility
The `Version` property is optional (nullable `string?`), so existing clients that ignore unknown properties will continue to function normally.


Closes #7249