### PR TITLE
Tiny: add thread count to health payload (run A2) (#7262)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Text.Json;
 using Shouldly;
@@ -94,5 +95,48 @@ public class DetailedHealthCheckEndpointIntegrationTests
         names.ShouldContain("API");
         names.ShouldContain("Jeffrey");
         names.ShouldContain("NeedsReboot");
+        names.ShouldContain("ProcessThreadCount");
+    }
+
+    [Test]
+    public async Task Should_IncludeThreadCountInDetailedHealthCheckJson_When_GetDetailedHealthCheckEndpoint()
+    {
+        var response = await _client!.GetAsync("/_healthcheck/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var entries = doc.RootElement.GetProperty("entries");
+
+        var processThreadEntry = entries.EnumerateArray()
+            .First(e => e.GetProperty("name").GetString() == "ProcessThreadCount");
+
+        processThreadEntry.TryGetProperty("data", out var data).ShouldBeTrue();
+        data.TryGetProperty("threadCount", out var threadCount).ShouldBeTrue();
+        var threadCountValue = threadCount.ValueKind == JsonValueKind.Number
+            ? threadCount.GetInt32()
+            : int.Parse(threadCount.GetString()!);
+        threadCountValue.ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Should_ReportThreadCountMatchingCurrentProcess_When_GetDetailedHealthCheckEndpoint()
+    {
+        var response = await _client!.GetAsync("/_healthcheck/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        var entries = doc.RootElement.GetProperty("entries");
+
+        var processThreadEntry = entries.EnumerateArray()
+            .First(e => e.GetProperty("name").GetString() == "ProcessThreadCount");
+
+        var threadCount = processThreadEntry.GetProperty("data").GetProperty("threadCount");
+        var threadCountValue = threadCount.ValueKind == JsonValueKind.Number
+            ? threadCount.GetInt32()
+            : int.Parse(threadCount.GetString()!);
+
+        threadCountValue.ShouldBe(Process.GetCurrentProcess().Threads.Count);
     }
 }

--- a/src/UI/Server/ProcessThreadCountHealthCheck.cs
+++ b/src/UI/Server/ProcessThreadCountHealthCheck.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ClearMeasure.Bootcamp.UI.Server;
+
+/// <summary>
+/// Health check that reports the current process thread count as diagnostic data.
+/// </summary>
+public class ProcessThreadCountHealthCheck(ILogger<ProcessThreadCountHealthCheck> logger) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
+        CancellationToken cancellationToken = new())
+    {
+        var threadCount = Process.GetCurrentProcess().Threads.Count;
+        logger.LogDebug("Process thread count: {ThreadCount}", threadCount);
+
+        var data = new Dictionary<string, object> { ["threadCount"] = threadCount };
+        return Task.FromResult(HealthCheckResult.Healthy(
+            $"Process has {threadCount} threads",
+            data: data));
+    }
+}

--- a/src/UI/Server/UIServiceRegistry.cs
+++ b/src/UI/Server/UIServiceRegistry.cs
@@ -70,7 +70,8 @@ public class UiServiceRegistry : ServiceRegistry
             .AddCheck<Is64BitProcessHealthCheck>("Server")
             .AddCheck<HealthCheck>("API")
             .AddCheck<FunJeffreyCustomEventHealthCheck>("Jeffrey")
-            .AddCheck<NeedsRebootHealthCheck>("NeedsReboot");
+            .AddCheck<NeedsRebootHealthCheck>("NeedsReboot")
+            .AddCheck<ProcessThreadCountHealthCheck>("ProcessThreadCount");
 
         this.AddSingleton<IDetailedHealthReportProvider, DetailedHealthReportProvider>();
     }

--- a/src/UnitTests/UI/Server/ProcessThreadCountHealthCheckTests.cs
+++ b/src/UnitTests/UI/Server/ProcessThreadCountHealthCheckTests.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class ProcessThreadCountHealthCheckTests
+{
+    private ProcessThreadCountHealthCheck _healthCheck = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _healthCheck = new ProcessThreadCountHealthCheck(NullLogger<ProcessThreadCountHealthCheck>.Instance);
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_Should_ReturnHealthyAndIncludeThreadCountInData()
+    {
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration("ProcessThreadCount", _healthCheck, null, null)
+        };
+
+        var result = await _healthCheck.CheckHealthAsync(context);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        result.Data.ContainsKey("threadCount").ShouldBeTrue();
+        result.Data["threadCount"].ShouldBe(Process.GetCurrentProcess().Threads.Count);
+        ((int)result.Data["threadCount"]).ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task CheckHealthAsync_Should_ReportThreadCountAsInteger()
+    {
+        var context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration("ProcessThreadCount", _healthCheck, null, null)
+        };
+
+        var result = await _healthCheck.CheckHealthAsync(context);
+
+        result.Data["threadCount"].ShouldBeOfType<int>();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ProcessThreadCountHealthCheck` that reports the current process thread count in the detailed health check JSON payload at `/_healthcheck/detailed`.

## Files changed
- `src/UI/Server/ProcessThreadCountHealthCheck.cs` — new health check with `threadCount` in data
- `src/UI/Server/UIServiceRegistry.cs` — register as `ProcessThreadCount`
- `src/UnitTests/UI/Server/ProcessThreadCountHealthCheckTests.cs` — unit tests
- `src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs` — integration tests

## Testing
- `./PrivateBuild.ps1` — green (unit + integration)
- No acceptance tests (UX unchanged; diagnostic table auto-renders new data row)

Closes #7262