### PR TITLE
Tiny: add process id to health payload (run A2) (#7259)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -119,6 +119,32 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_IncludeProcessId_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("processId", out var processId).ShouldBeTrue();
+        processId.GetInt32().ShouldBeGreaterThan(0);
+        processId.GetInt32().ShouldBe(Environment.ProcessId);
+    }
+
+    [Test]
+    public async Task Should_DeserializeProcessId_ToDetailedHealthReport_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        report!.ProcessId.ShouldBeGreaterThan(0);
+        report.ProcessId.ShouldBe(Environment.ProcessId);
+    }
+
+    [Test]
     public async Task Should_ListExpectedComponentEntries_When_AggregatedFromRegisteredChecks()
     {
         var response = await _client!.GetAsync("/api/health/detailed");

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -34,6 +34,9 @@ public sealed class DetailedHealthReport
     /// <summary>UTC instant when the report was built (ISO-8601 when serialized).</summary>
     public required DateTime CheckedAtUtc { get; init; }
 
+    /// <summary>Host OS process identifier for observability correlation across instances.</summary>
+    public required int ProcessId { get; init; }
+
     /// <summary>Per-logical-component entries (mock or probe-derived).</summary>
     public required IReadOnlyList<ComponentHealthEntry> Components { get; init; }
 }

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -16,6 +16,7 @@ public static class HealthReportBuilder
         return new DetailedHealthReport
         {
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
+            ProcessId = Environment.ProcessId,
             Components = components,
             OverallStatus = AggregateWorst(components)
         };

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -30,6 +30,7 @@ public sealed class DetailedHealthReportProvider(
         return new DetailedHealthReport
         {
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
+            ProcessId = Environment.ProcessId,
             Components = components,
             OverallStatus = MapOverallStatus(report.Status)
         };
@@ -52,6 +53,7 @@ public sealed class DetailedHealthReportProvider(
         return new DetailedHealthReport
         {
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
+            ProcessId = Environment.ProcessId,
             Components = components,
             OverallStatus = MapOverallStatus(aggregateStatus)
         };

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -64,6 +64,16 @@ public class HealthReportBuilderTests
     }
 
     [Test]
+    public void HealthReportBuilder_FromEntries_Should_SetProcessId()
+    {
+        var report = HealthReportBuilder.FromEntries(
+            TimeProvider.System,
+            [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
+
+        report.ProcessId.ShouldBe(Environment.ProcessId);
+    }
+
+    [Test]
     public void HealthReportBuilder_FromEntries_Should_AggregateWorstAcrossComponents()
     {
         var components = new[]

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -36,6 +36,36 @@ public class DetailedHealthReportProviderTests
     }
 
     [Test]
+    public void FromComponentStatuses_Should_SetProcessId()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Healthy,
+            TimeProvider.System);
+
+        detailed.ProcessId.ShouldBe(Environment.ProcessId);
+    }
+
+    [Test]
+    public void FromHealthReport_Should_SetProcessId()
+    {
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, new Dictionary<string, object>())
+        };
+        var report = new HealthReport(entries, TimeSpan.Zero);
+
+        var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
+
+        detailed.ProcessId.ShouldBe(Environment.ProcessId);
+    }
+
+    [Test]
     public void FromComponentStatuses_Should_OrderComponentsByName()
     {
         var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)


### PR DESCRIPTION
## Summary

Adds `processId` (`Environment.ProcessId`) to the `GET /api/health/detailed` JSON payload for observability correlation.

## Files changed

- `src/UI/Api/DetailedHealthModels.cs` — new `ProcessId` property on `DetailedHealthReport`
- `src/UI/Api/HealthReportBuilder.cs` — populate `ProcessId` in `FromEntries`
- `src/UI/Server/DetailedHealthReportProvider.cs` — populate `ProcessId` in `FromHealthReport` and `FromComponentStatuses`
- Unit tests: `HealthReportBuilderTests`, `DetailedHealthReportProviderTests`
- Integration tests: `DetailedHealthEndpointIntegrationTests`

## Testing

- `PrivateBuild.ps1` — all unit + integration tests pass
- New tests assert camelCase `processId` in JSON and match `Environment.ProcessId`

Closes #7259