### PR TITLE
Tiny: add server UTC time to health payload (run A2) (#7263)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
@@ -95,4 +95,31 @@ public class DetailedHealthCheckEndpointIntegrationTests
         names.ShouldContain("Jeffrey");
         names.ShouldContain("NeedsReboot");
     }
+
+    [Test]
+    public async Task Should_IncludeServerUtc_When_GetDetailedHealthCheckEndpoint()
+    {
+        var response = await _client!.GetAsync("/_healthcheck/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+
+        doc.RootElement.TryGetProperty("serverUtc", out var serverUtc).ShouldBeTrue();
+        serverUtc.GetDateTimeOffset().ShouldNotBe(default);
+    }
+
+    [Test]
+    public async Task Should_ReturnRecentUtcServerUtc_When_GetDetailedHealthCheckEndpoint()
+    {
+        var response = await _client!.GetAsync("/_healthcheck/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+
+        var serverUtc = doc.RootElement.GetProperty("serverUtc").GetDateTimeOffset();
+        serverUtc.Offset.ShouldBe(TimeSpan.Zero);
+        (DateTimeOffset.UtcNow - serverUtc).Duration().ShouldBeLessThan(TimeSpan.FromMinutes(5));
+    }
 }

--- a/src/UI/Server/DetailedHealthCheckResponseWriter.cs
+++ b/src/UI/Server/DetailedHealthCheckResponseWriter.cs
@@ -25,7 +25,7 @@ public static class DetailedHealthCheckResponseWriter
     {
         context.Response.ContentType = "application/json; charset=utf-8";
 
-        var timeProvider = context.RequestServices.GetService<TimeProvider>() ?? TimeProvider.System;
+        var timeProvider = context.RequestServices?.GetService<TimeProvider>() ?? TimeProvider.System;
 
         var response = new DetailedHealthCheckResponse
         {

--- a/src/UI/Server/DetailedHealthCheckResponseWriter.cs
+++ b/src/UI/Server/DetailedHealthCheckResponseWriter.cs
@@ -25,8 +25,11 @@ public static class DetailedHealthCheckResponseWriter
     {
         context.Response.ContentType = "application/json; charset=utf-8";
 
+        var timeProvider = context.RequestServices.GetService<TimeProvider>() ?? TimeProvider.System;
+
         var response = new DetailedHealthCheckResponse
         {
+            ServerUtc = timeProvider.GetUtcNow(),
             OverallStatus = report.Status.ToString(),
             TotalDurationMs = report.TotalDuration.TotalMilliseconds,
             Entries = report.Entries
@@ -54,6 +57,9 @@ public static class DetailedHealthCheckResponseWriter
 
     internal sealed class DetailedHealthCheckResponse
     {
+        /// <summary>UTC timestamp when the health report was written.</summary>
+        public DateTimeOffset ServerUtc { get; init; }
+
         /// <summary>Overall aggregated status of all health checks.</summary>
         public required string OverallStatus { get; init; }
 

--- a/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Server;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Shouldly;
 
@@ -9,6 +10,31 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
 [TestFixture]
 public class DetailedHealthCheckResponseWriterTests
 {
+    private sealed class FixedUtcTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private static HealthReport CreateMinimalReport()
+    {
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(
+                HealthStatus.Healthy,
+                "API layer is healthy",
+                TimeSpan.FromMilliseconds(5),
+                null,
+                new Dictionary<string, object>())
+        };
+        return new HealthReport(entries, TimeSpan.FromMilliseconds(5));
+    }
+
+    private static async Task<JsonDocument> WriteAndParseAsync(HttpContext context, HealthReport report)
+    {
+        await DetailedHealthCheckResponseWriter.WriteAsync(context, report);
+        context.Response.Body.Position = 0;
+        return await JsonDocument.ParseAsync(context.Response.Body);
+    }
     [Test]
     public async Task WriteAsync_Should_WriteJsonWithOverallStatusAndEntries()
     {
@@ -117,5 +143,52 @@ public class DetailedHealthCheckResponseWriterTests
         entry.TryGetProperty("exceptionDetail", out _).ShouldBeFalse();
         entry.TryGetProperty("description", out _).ShouldBeFalse();
         entry.TryGetProperty("data", out _).ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task WriteAsync_Should_IncludeServerUtcInRootJson_When_ResponseWritten()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
+
+        doc.RootElement.TryGetProperty("serverUtc", out var serverUtc).ShouldBeTrue();
+        var parsed = serverUtc.GetDateTimeOffset();
+        parsed.Offset.ShouldBe(TimeSpan.Zero);
+    }
+
+    [Test]
+    public async Task WriteAsync_Should_SetServerUtcFromTimeProvider_When_RegisteredOnRequestServices()
+    {
+        var fixedNow = new DateTimeOffset(2026, 7, 24, 5, 0, 0, TimeSpan.Zero);
+        var services = new ServiceCollection();
+        services.AddSingleton<TimeProvider>(new FixedUtcTimeProvider(fixedNow));
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        context.Response.Body = new MemoryStream();
+
+        using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
+
+        var serverUtc = doc.RootElement.GetProperty("serverUtc").GetDateTimeOffset();
+        serverUtc.ShouldBe(fixedNow);
+    }
+
+    [Test]
+    public async Task WriteAsync_Should_UseSystemTimeProvider_When_TimeProviderNotRegistered()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
+
+        var after = DateTimeOffset.UtcNow;
+        var serverUtc = doc.RootElement.GetProperty("serverUtc").GetDateTimeOffset();
+        serverUtc.Offset.ShouldBe(TimeSpan.Zero);
+        serverUtc.ShouldBeGreaterThanOrEqualTo(before);
+        serverUtc.ShouldBeLessThanOrEqualTo(after);
     }
 }


### PR DESCRIPTION
## Summary

Adds `serverUtc` (ISO-8601 UTC `DateTimeOffset`) to the root JSON payload of `GET /_healthcheck/detailed`, sourced from `TimeProvider` in `RequestServices` with system-clock fallback.

## Files changed
- `src/UI/Server/DetailedHealthCheckResponseWriter.cs` — `ServerUtc` property and TimeProvider resolution
- `src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs` — unit tests for JSON field, DI injection, and fallback
- `src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs` — integration tests for presence and recent UTC window

## Testing
- `PrivateBuild.ps1` — compile, unit tests, DB migration, integration tests (all green)
- Acceptance tests skipped (no UX change)

Closes #7263