### PR TITLE
Tiny: add OS description to health payload (run A2) (#7260)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -145,6 +145,33 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_IncludeOsDescription_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("osDescription", out var osDescription).ShouldBeTrue();
+        var value = osDescription.GetString();
+        value.ShouldNotBeNull();
+        value!.ShouldNotBeEmpty();
+    }
+
+    [Test]
+    public async Task Should_DeserializeOsDescription_ToDetailedHealthReport_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        report!.OsDescription.ShouldNotBeNull();
+        report.OsDescription.ShouldNotBeEmpty();
+    }
+
+    [Test]
     public async Task Should_ListExpectedComponentEntries_When_AggregatedFromRegisteredChecks()
     {
         var response = await _client!.GetAsync("/api/health/detailed");

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -37,6 +37,9 @@ public sealed class DetailedHealthReport
     /// <summary>Host OS process identifier for observability correlation across instances.</summary>
     public required int ProcessId { get; init; }
 
+    /// <summary>Operating system description from <see cref="System.Runtime.InteropServices.RuntimeInformation.OSDescription"/>.</summary>
+    public required string OsDescription { get; init; }
+
     /// <summary>Per-logical-component entries (mock or probe-derived).</summary>
     public required IReadOnlyList<ComponentHealthEntry> Components { get; init; }
 }

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace ClearMeasure.Bootcamp.UI.Api;
 
 /// <summary>
@@ -17,6 +19,7 @@ public static class HealthReportBuilder
         {
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             ProcessId = Environment.ProcessId,
+            OsDescription = RuntimeInformation.OSDescription,
             Components = components,
             OverallStatus = AggregateWorst(components)
         };

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using ClearMeasure.Bootcamp.UI.Api;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -31,6 +32,7 @@ public sealed class DetailedHealthReportProvider(
         {
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             ProcessId = Environment.ProcessId,
+            OsDescription = RuntimeInformation.OSDescription,
             Components = components,
             OverallStatus = MapOverallStatus(report.Status)
         };
@@ -54,6 +56,7 @@ public sealed class DetailedHealthReportProvider(
         {
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             ProcessId = Environment.ProcessId,
+            OsDescription = RuntimeInformation.OSDescription,
             Components = components,
             OverallStatus = MapOverallStatus(aggregateStatus)
         };

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using ClearMeasure.Bootcamp.UI.Api;
 using Shouldly;
 
@@ -71,6 +72,18 @@ public class HealthReportBuilderTests
             [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
 
         report.ProcessId.ShouldBe(Environment.ProcessId);
+    }
+
+    [Test]
+    public void HealthReportBuilder_FromEntries_Should_SetOsDescription()
+    {
+        var report = HealthReportBuilder.FromEntries(
+            TimeProvider.System,
+            [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
+
+        report.OsDescription.ShouldNotBeNull();
+        report.OsDescription.ShouldNotBeEmpty();
+        report.OsDescription.ShouldBe(RuntimeInformation.OSDescription);
     }
 
     [Test]

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using ClearMeasure.Bootcamp.UI.Api;
 using ClearMeasure.Bootcamp.UI.Server;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -63,6 +64,40 @@ public class DetailedHealthReportProviderTests
         var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
 
         detailed.ProcessId.ShouldBe(Environment.ProcessId);
+    }
+
+    [Test]
+    public void FromComponentStatuses_Should_SetOsDescription()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Healthy,
+            TimeProvider.System);
+
+        detailed.OsDescription.ShouldNotBeNull();
+        detailed.OsDescription.ShouldNotBeEmpty();
+        detailed.OsDescription.ShouldBe(RuntimeInformation.OSDescription);
+    }
+
+    [Test]
+    public void FromHealthReport_Should_SetOsDescription()
+    {
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, new Dictionary<string, object>())
+        };
+        var report = new HealthReport(entries, TimeSpan.Zero);
+
+        var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
+
+        detailed.OsDescription.ShouldNotBeNull();
+        detailed.OsDescription.ShouldNotBeEmpty();
+        detailed.OsDescription.ShouldBe(RuntimeInformation.OSDescription);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Adds `osDescription` (from `RuntimeInformation.OSDescription`) to the `GET /api/health/detailed` JSON payload.

## Files changed
- `src/UI/Api/DetailedHealthModels.cs` — new `OsDescription` property
- `src/UI/Server/DetailedHealthReportProvider.cs` — populate in both report paths
- `src/UI/Api/HealthReportBuilder.cs` — populate in `FromEntries`
- Unit tests: `DetailedHealthReportProviderTests`, `HealthReportBuilderTests`
- Integration tests: `DetailedHealthEndpointIntegrationTests`

## Testing
- `./PrivateBuild.ps1` — green (unit + integration)
- New tests assert non-null/non-empty `osDescription` in unit and integration coverage

Closes #7260