### PR TITLE
Tiny: add GC memory MB to health payload (run A2) (#7261)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -172,6 +172,31 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_IncludeGcMemoryMb_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("gcMemoryMb", out var gcMemoryMb).ShouldBeTrue();
+        gcMemoryMb.ValueKind.ShouldBe(JsonValueKind.Number);
+        gcMemoryMb.GetInt32().ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_DeserializeGcMemoryMb_ToDetailedHealthReport_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        report!.GcMemoryMb.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
     public async Task Should_ListExpectedComponentEntries_When_AggregatedFromRegisteredChecks()
     {
         var response = await _client!.GetAsync("/api/health/detailed");

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -40,6 +40,9 @@ public sealed class DetailedHealthReport
     /// <summary>Operating system description from <see cref="System.Runtime.InteropServices.RuntimeInformation.OSDescription"/>.</summary>
     public required string OsDescription { get; init; }
 
+    /// <summary>Managed heap size from <see cref="GC.GetTotalMemory(bool)"/>, expressed in megabytes and rounded.</summary>
+    public required int GcMemoryMb { get; init; }
+
     /// <summary>Per-logical-component entries (mock or probe-derived).</summary>
     public required IReadOnlyList<ComponentHealthEntry> Components { get; init; }
 }

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -20,6 +20,7 @@ public static class HealthReportBuilder
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             ProcessId = Environment.ProcessId,
             OsDescription = RuntimeInformation.OSDescription,
+            GcMemoryMb = (int)Math.Round(GC.GetTotalMemory(false) / 1_048_576.0),
             Components = components,
             OverallStatus = AggregateWorst(components)
         };

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -33,6 +33,7 @@ public sealed class DetailedHealthReportProvider(
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             ProcessId = Environment.ProcessId,
             OsDescription = RuntimeInformation.OSDescription,
+            GcMemoryMb = GetGcMemoryMb(),
             Components = components,
             OverallStatus = MapOverallStatus(report.Status)
         };
@@ -57,10 +58,14 @@ public sealed class DetailedHealthReportProvider(
             CheckedAtUtc = clock.GetUtcNow().UtcDateTime,
             ProcessId = Environment.ProcessId,
             OsDescription = RuntimeInformation.OSDescription,
+            GcMemoryMb = GetGcMemoryMb(),
             Components = components,
             OverallStatus = MapOverallStatus(aggregateStatus)
         };
     }
+
+    internal static int GetGcMemoryMb() =>
+        (int)Math.Round(GC.GetTotalMemory(false) / 1_048_576.0);
 
     private static string MapOverallStatus(HealthStatus status) => status switch
     {

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -87,6 +87,16 @@ public class HealthReportBuilderTests
     }
 
     [Test]
+    public void HealthReportBuilder_FromEntries_Should_SetGcMemoryMb()
+    {
+        var report = HealthReportBuilder.FromEntries(
+            TimeProvider.System,
+            [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
+
+        report.GcMemoryMb.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
     public void HealthReportBuilder_FromEntries_Should_AggregateWorstAcrossComponents()
     {
         var components = new[]

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -85,6 +85,23 @@ public class DetailedHealthReportProviderTests
     }
 
     [Test]
+    public void FromComponentStatuses_Should_SetGcMemoryMb()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Healthy,
+            TimeProvider.System);
+
+        detailed.GcMemoryMb.ShouldBeGreaterThanOrEqualTo(0);
+        detailed.GcMemoryMb.ShouldBe(DetailedHealthReportProvider.GetGcMemoryMb());
+    }
+
+    [Test]
     public void FromHealthReport_Should_SetOsDescription()
     {
         var entries = new Dictionary<string, HealthReportEntry>
@@ -98,6 +115,21 @@ public class DetailedHealthReportProviderTests
         detailed.OsDescription.ShouldNotBeNull();
         detailed.OsDescription.ShouldNotBeEmpty();
         detailed.OsDescription.ShouldBe(RuntimeInformation.OSDescription);
+    }
+
+    [Test]
+    public void FromHealthReport_Should_SetGcMemoryMb()
+    {
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, new Dictionary<string, object>())
+        };
+        var report = new HealthReport(entries, TimeSpan.Zero);
+
+        var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
+
+        detailed.GcMemoryMb.ShouldBeGreaterThanOrEqualTo(0);
+        detailed.GcMemoryMb.ShouldBe(DetailedHealthReportProvider.GetGcMemoryMb());
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Adds `gcMemoryMb` (managed heap size from `GC.GetTotalMemory`, rounded to MB) to the `GET /api/health/detailed` JSON payload.

## Files changed

- `src/UI/Api/DetailedHealthModels.cs` — new `GcMemoryMb` property
- `src/UI/Server/DetailedHealthReportProvider.cs` — populate via `GetGcMemoryMb()` helper
- `src/UI/Api/HealthReportBuilder.cs` — populate in `FromEntries`
- Unit tests: `DetailedHealthReportProviderTests`, `HealthReportBuilderTests`
- Integration test: `DetailedHealthEndpointIntegrationTests`

## Testing

- `PrivateBuild.ps1` passed locally (unit + integration tests)
- No UI change; `/_healthcheck/detailed` unchanged

Closes #7261