### PR TITLE
Tiny: add app base path to health payload (run B) (#7271)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -197,6 +197,35 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_IncludeAppBasePath_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("appBasePath", out var appBasePath).ShouldBeTrue();
+        var value = appBasePath.GetString();
+        value.ShouldNotBeNull();
+        value!.ShouldNotBeEmpty();
+        value.ShouldBe(AppContext.BaseDirectory);
+    }
+
+    [Test]
+    public async Task Should_DeserializeAppBasePath_ToDetailedHealthReport_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        report!.AppBasePath.ShouldNotBeNull();
+        report.AppBasePath.ShouldNotBeEmpty();
+        report.AppBasePath.ShouldBe(AppContext.BaseDirectory);
+    }
+
+    [Test]
     public async Task Should_ListExpectedComponentEntries_When_AggregatedFromRegisteredChecks()
     {
         var response = await _client!.GetAsync("/api/health/detailed");

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -43,6 +43,9 @@ public sealed class DetailedHealthReport
     /// <summary>Managed heap size from <see cref="GC.GetTotalMemory(bool)"/>, expressed in megabytes and rounded.</summary>
     public required int GcMemoryMb { get; init; }
 
+    /// <summary>Application base directory from <see cref="AppContext.BaseDirectory"/> for operational context.</summary>
+    public string? AppBasePath { get; init; }
+
     /// <summary>Per-logical-component entries (mock or probe-derived).</summary>
     public required IReadOnlyList<ComponentHealthEntry> Components { get; init; }
 }

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -21,6 +21,7 @@ public static class HealthReportBuilder
             ProcessId = Environment.ProcessId,
             OsDescription = RuntimeInformation.OSDescription,
             GcMemoryMb = (int)Math.Round(GC.GetTotalMemory(false) / 1_048_576.0),
+            AppBasePath = AppContext.BaseDirectory,
             Components = components,
             OverallStatus = AggregateWorst(components)
         };

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -34,6 +34,7 @@ public sealed class DetailedHealthReportProvider(
             ProcessId = Environment.ProcessId,
             OsDescription = RuntimeInformation.OSDescription,
             GcMemoryMb = GetGcMemoryMb(),
+            AppBasePath = AppContext.BaseDirectory,
             Components = components,
             OverallStatus = MapOverallStatus(report.Status)
         };
@@ -59,6 +60,7 @@ public sealed class DetailedHealthReportProvider(
             ProcessId = Environment.ProcessId,
             OsDescription = RuntimeInformation.OSDescription,
             GcMemoryMb = GetGcMemoryMb(),
+            AppBasePath = AppContext.BaseDirectory,
             Components = components,
             OverallStatus = MapOverallStatus(aggregateStatus)
         };

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -97,6 +97,16 @@ public class HealthReportBuilderTests
     }
 
     [Test]
+    public void HealthReportBuilder_FromEntries_Should_SetAppBasePath()
+    {
+        var report = HealthReportBuilder.FromEntries(
+            TimeProvider.System,
+            [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
+
+        report.AppBasePath.ShouldBe(AppContext.BaseDirectory);
+    }
+
+    [Test]
     public void HealthReportBuilder_FromEntries_Should_AggregateWorstAcrossComponents()
     {
         var components = new[]

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -102,6 +102,36 @@ public class DetailedHealthReportProviderTests
     }
 
     [Test]
+    public void FromComponentStatuses_Should_SetAppBasePath()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Healthy,
+            TimeProvider.System);
+
+        detailed.AppBasePath.ShouldBe(AppContext.BaseDirectory);
+    }
+
+    [Test]
+    public void FromHealthReport_Should_SetAppBasePath()
+    {
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, new Dictionary<string, object>())
+        };
+        var report = new HealthReport(entries, TimeSpan.Zero);
+
+        var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
+
+        detailed.AppBasePath.ShouldBe(AppContext.BaseDirectory);
+    }
+
+    [Test]
     public void FromHealthReport_Should_SetOsDescription()
     {
         var entries = new Dictionary<string, HealthReportEntry>


### PR DESCRIPTION
## Summary

Adds `appBasePath` (from `AppContext.BaseDirectory`) to the detailed health JSON payload at `/api/health/detailed`.

## Files changed
- `src/UI/Api/DetailedHealthModels.cs` — new `AppBasePath` property
- `src/UI/Server/DetailedHealthReportProvider.cs` — set at both build sites
- `src/UI/Api/HealthReportBuilder.cs` — set in `FromEntries`
- Unit tests: `DetailedHealthReportProviderTests`, `HealthReportBuilderTests`
- Integration tests: `DetailedHealthEndpointIntegrationTests`

## Testing
- `./PrivateBuild.ps1` — green (unit + integration)
- No acceptance tests (no UI change)

Closes #7271