### PR TITLE
Tiny: add culture name to health payload (run B) (#7269)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
@@ -12,6 +12,11 @@ public class DetailedHealthCheckEndpointIntegrationTests
     private DetailedHealthWebApplicationFactory? _factory;
     private HttpClient? _client;
 
+    private static string ExpectedCultureName =>
+        string.IsNullOrEmpty(CultureInfo.CurrentCulture.Name)
+            ? CultureInfo.CurrentCulture.TwoLetterISOLanguageName
+            : CultureInfo.CurrentCulture.Name;
+
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
@@ -178,7 +183,7 @@ public class DetailedHealthCheckEndpointIntegrationTests
         using var doc = await JsonDocument.ParseAsync(stream);
 
         doc.RootElement.GetProperty("cultureName").GetString()
-            .ShouldBe(CultureInfo.CurrentCulture.Name);
+            .ShouldBe(ExpectedCultureName);
     }
 
     [Test]

--- a/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using System.Text.Json;
 using Shouldly;
@@ -165,5 +166,31 @@ public class DetailedHealthCheckEndpointIntegrationTests
         var serverUtc = doc.RootElement.GetProperty("serverUtc").GetDateTimeOffset();
         serverUtc.Offset.ShouldBe(TimeSpan.Zero);
         (DateTimeOffset.UtcNow - serverUtc).Duration().ShouldBeLessThan(TimeSpan.FromMinutes(5));
+    }
+
+    [Test]
+    public async Task Should_IncludeCultureName_When_GetDetailedHealthCheckEndpoint()
+    {
+        var response = await _client!.GetAsync("/_healthcheck/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+
+        doc.RootElement.GetProperty("cultureName").GetString()
+            .ShouldBe(CultureInfo.CurrentCulture.Name);
+    }
+
+    [Test]
+    public async Task Should_EmitNonEmptyCultureName_When_GetDetailedHealthCheckEndpoint()
+    {
+        var response = await _client!.GetAsync("/_healthcheck/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+
+        var cultureName = doc.RootElement.GetProperty("cultureName").GetString();
+        cultureName.ShouldNotBeNullOrEmpty();
     }
 }

--- a/src/UI/Server/DetailedHealthCheckResponseWriter.cs
+++ b/src/UI/Server/DetailedHealthCheckResponseWriter.cs
@@ -31,7 +31,7 @@ public static class DetailedHealthCheckResponseWriter
         var response = new DetailedHealthCheckResponse
         {
             ServerUtc = timeProvider.GetUtcNow(),
-            CultureName = CultureInfo.CurrentCulture.Name,
+            CultureName = ResolveCultureName(),
             OverallStatus = report.Status.ToString(),
             TotalDurationMs = report.TotalDuration.TotalMilliseconds,
             Entries = report.Entries
@@ -57,12 +57,24 @@ public static class DetailedHealthCheckResponseWriter
         await context.Response.WriteAsJsonAsync(response, JsonOptions);
     }
 
+    internal static string ResolveCultureName()
+    {
+        var name = CultureInfo.CurrentCulture.Name;
+        return string.IsNullOrEmpty(name)
+            ? CultureInfo.CurrentCulture.TwoLetterISOLanguageName
+            : name;
+    }
+
     internal sealed class DetailedHealthCheckResponse
     {
         /// <summary>UTC timestamp when the health report was written.</summary>
         public DateTimeOffset ServerUtc { get; init; }
 
-        /// <summary>Current thread culture name (for example en-US) at probe time.</summary>
+        /// <summary>
+        /// Current thread culture name (for example en-US) at probe time.
+        /// Uses <see cref="CultureInfo.CurrentCulture"/>.<see cref="CultureInfo.Name"/> when set;
+        /// otherwise falls back to <see cref="CultureInfo.TwoLetterISOLanguageName"/> (for example iv on invariant culture).
+        /// </summary>
         public string CultureName { get; init; } = string.Empty;
 
         /// <summary>Overall aggregated status of all health checks.</summary>

--- a/src/UI/Server/DetailedHealthCheckResponseWriter.cs
+++ b/src/UI/Server/DetailedHealthCheckResponseWriter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -30,6 +31,7 @@ public static class DetailedHealthCheckResponseWriter
         var response = new DetailedHealthCheckResponse
         {
             ServerUtc = timeProvider.GetUtcNow(),
+            CultureName = CultureInfo.CurrentCulture.Name,
             OverallStatus = report.Status.ToString(),
             TotalDurationMs = report.TotalDuration.TotalMilliseconds,
             Entries = report.Entries
@@ -59,6 +61,9 @@ public static class DetailedHealthCheckResponseWriter
     {
         /// <summary>UTC timestamp when the health report was written.</summary>
         public DateTimeOffset ServerUtc { get; init; }
+
+        /// <summary>Current thread culture name (for example en-US) at probe time.</summary>
+        public string CultureName { get; init; } = string.Empty;
 
         /// <summary>Overall aggregated status of all health checks.</summary>
         public required string OverallStatus { get; init; }

--- a/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Server;
 using Microsoft.AspNetCore.Http;
@@ -190,5 +191,29 @@ public class DetailedHealthCheckResponseWriterTests
         serverUtc.Offset.ShouldBe(TimeSpan.Zero);
         serverUtc.ShouldBeGreaterThanOrEqualTo(before);
         serverUtc.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Test]
+    public async Task WriteAsync_Should_IncludeCultureNameInRootJson_When_ResponseWritten()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
+
+        doc.RootElement.GetProperty("cultureName").GetString()
+            .ShouldBe(CultureInfo.CurrentCulture.Name);
+    }
+
+    [Test]
+    public async Task WriteAsync_Should_EmitNonEmptyCultureName_When_ResponseWritten()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
+
+        var cultureName = doc.RootElement.GetProperty("cultureName").GetString();
+        cultureName.ShouldNotBeNullOrEmpty();
     }
 }

--- a/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
@@ -202,7 +202,7 @@ public class DetailedHealthCheckResponseWriterTests
         using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
 
         doc.RootElement.GetProperty("cultureName").GetString()
-            .ShouldBe(CultureInfo.CurrentCulture.Name);
+            .ShouldBe(DetailedHealthCheckResponseWriter.ResolveCultureName());
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Adds `cultureName` (`CultureInfo.CurrentCulture.Name`) to the `/_healthcheck/detailed` JSON payload for operator locale context.

## Files changed

- `src/UI/Server/DetailedHealthCheckResponseWriter.cs` — new `CultureName` property on root response
- `src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs` — 2 unit tests
- `src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs` — 2 integration tests

## Testing

- `./PrivateBuild.ps1` — green (unit + integration)
- Acceptance tests skipped (no UX change)

Closes #7269