### PR TITLE
Tiny: add is64bit flag to health payload (run B) (#7272)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
@@ -176,7 +176,6 @@ public class DetailedHealthCheckEndpointIntegrationTests
         await using var stream = await response.Content.ReadAsStreamAsync();
         using var doc = await JsonDocument.ParseAsync(stream);
         doc.RootElement.TryGetProperty("is64BitProcess", out var is64BitProcess).ShouldBeTrue();
-        is64BitProcess.ValueKind.ShouldBe(JsonValueKind.True or JsonValueKind.False);
         is64BitProcess.GetBoolean().ShouldBe(Environment.Is64BitProcess);
     }
 }

--- a/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
@@ -166,4 +166,17 @@ public class DetailedHealthCheckEndpointIntegrationTests
         serverUtc.Offset.ShouldBe(TimeSpan.Zero);
         (DateTimeOffset.UtcNow - serverUtc).Duration().ShouldBeLessThan(TimeSpan.FromMinutes(5));
     }
+
+    [Test]
+    public async Task Should_IncludeIs64BitProcess_When_GetDetailedHealthCheckEndpoint()
+    {
+        var response = await _client!.GetAsync("/_healthcheck/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("is64BitProcess", out var is64BitProcess).ShouldBeTrue();
+        is64BitProcess.ValueKind.ShouldBe(JsonValueKind.True or JsonValueKind.False);
+        is64BitProcess.GetBoolean().ShouldBe(Environment.Is64BitProcess);
+    }
 }

--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -232,7 +232,6 @@ public class DetailedHealthEndpointIntegrationTests
         await using var stream = await response.Content.ReadAsStreamAsync();
         using var doc = await JsonDocument.ParseAsync(stream);
         doc.RootElement.TryGetProperty("is64BitProcess", out var is64BitProcess).ShouldBeTrue();
-        is64BitProcess.ValueKind.ShouldBe(JsonValueKind.True or JsonValueKind.False);
         is64BitProcess.GetBoolean().ShouldBe(Environment.Is64BitProcess);
     }
 

--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -224,6 +224,31 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
+    public async Task Should_IncludeIs64BitProcess_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("is64BitProcess", out var is64BitProcess).ShouldBeTrue();
+        is64BitProcess.ValueKind.ShouldBe(JsonValueKind.True or JsonValueKind.False);
+        is64BitProcess.GetBoolean().ShouldBe(Environment.Is64BitProcess);
+    }
+
+    [Test]
+    public async Task Should_DeserializeIs64BitProcess_ToDetailedHealthReport_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        report!.Is64BitProcess.ShouldBe(Environment.Is64BitProcess);
+    }
+
+    [Test]
     public async Task Should_ListExpectedComponentEntries_When_AggregatedFromRegisteredChecks()
     {
         var response = await _client!.GetAsync("/api/health/detailed");

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -46,6 +46,9 @@ public sealed class DetailedHealthReport
     /// <summary>Logical processor count from <see cref="Environment.ProcessorCount"/> for load-balancing hints.</summary>
     public required int ProcessorCount { get; init; }
 
+    /// <summary>Whether the host process runs as 64-bit (from <see cref="Environment.Is64BitProcess"/>).</summary>
+    public required bool Is64BitProcess { get; init; }
+
     /// <summary>Per-logical-component entries (mock or probe-derived).</summary>
     public required IReadOnlyList<ComponentHealthEntry> Components { get; init; }
 }

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -22,6 +22,7 @@ public static class HealthReportBuilder
             OsDescription = RuntimeInformation.OSDescription,
             GcMemoryMb = (int)Math.Round(GC.GetTotalMemory(false) / 1_048_576.0),
             ProcessorCount = Environment.ProcessorCount,
+            Is64BitProcess = Environment.Is64BitProcess,
             Components = components,
             OverallStatus = AggregateWorst(components)
         };

--- a/src/UI/Server/DetailedHealthCheckResponseWriter.cs
+++ b/src/UI/Server/DetailedHealthCheckResponseWriter.cs
@@ -30,6 +30,7 @@ public static class DetailedHealthCheckResponseWriter
         var response = new DetailedHealthCheckResponse
         {
             ServerUtc = timeProvider.GetUtcNow(),
+            Is64BitProcess = Environment.Is64BitProcess,
             OverallStatus = report.Status.ToString(),
             TotalDurationMs = report.TotalDuration.TotalMilliseconds,
             Entries = report.Entries
@@ -59,6 +60,9 @@ public static class DetailedHealthCheckResponseWriter
     {
         /// <summary>UTC timestamp when the health report was written.</summary>
         public DateTimeOffset ServerUtc { get; init; }
+
+        /// <summary>Whether the host process runs as 64-bit (from <see cref="Environment.Is64BitProcess"/>).</summary>
+        public bool Is64BitProcess { get; init; }
 
         /// <summary>Overall aggregated status of all health checks.</summary>
         public required string OverallStatus { get; init; }

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -35,6 +35,7 @@ public sealed class DetailedHealthReportProvider(
             OsDescription = RuntimeInformation.OSDescription,
             GcMemoryMb = GetGcMemoryMb(),
             ProcessorCount = Environment.ProcessorCount,
+            Is64BitProcess = Environment.Is64BitProcess,
             Components = components,
             OverallStatus = MapOverallStatus(report.Status)
         };
@@ -61,6 +62,7 @@ public sealed class DetailedHealthReportProvider(
             OsDescription = RuntimeInformation.OSDescription,
             GcMemoryMb = GetGcMemoryMb(),
             ProcessorCount = Environment.ProcessorCount,
+            Is64BitProcess = Environment.Is64BitProcess,
             Components = components,
             OverallStatus = MapOverallStatus(aggregateStatus)
         };

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -107,6 +107,16 @@ public class HealthReportBuilderTests
     }
 
     [Test]
+    public void HealthReportBuilder_FromEntries_Should_SetIs64BitProcess()
+    {
+        var report = HealthReportBuilder.FromEntries(
+            TimeProvider.System,
+            [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
+
+        report.Is64BitProcess.ShouldBe(Environment.Is64BitProcess);
+    }
+
+    [Test]
     public void HealthReportBuilder_FromEntries_Should_AggregateWorstAcrossComponents()
     {
         var components = new[]

--- a/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
@@ -191,4 +191,17 @@ public class DetailedHealthCheckResponseWriterTests
         serverUtc.ShouldBeGreaterThanOrEqualTo(before);
         serverUtc.ShouldBeLessThanOrEqualTo(after);
     }
+
+    [Test]
+    public async Task WriteAsync_Should_IncludeIs64BitProcessInRootJson_When_ResponseWritten()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
+
+        doc.RootElement.TryGetProperty("is64BitProcess", out var is64BitProcess).ShouldBeTrue();
+        is64BitProcess.ValueKind.ShouldBe(JsonValueKind.True or JsonValueKind.False);
+        is64BitProcess.GetBoolean().ShouldBe(Environment.Is64BitProcess);
+    }
 }

--- a/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
@@ -201,7 +201,6 @@ public class DetailedHealthCheckResponseWriterTests
         using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
 
         doc.RootElement.TryGetProperty("is64BitProcess", out var is64BitProcess).ShouldBeTrue();
-        is64BitProcess.ValueKind.ShouldBe(JsonValueKind.True or JsonValueKind.False);
         is64BitProcess.GetBoolean().ShouldBe(Environment.Is64BitProcess);
     }
 }

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -69,6 +69,22 @@ public class DetailedHealthReportProviderTests
     }
 
     [Test]
+    public void FromComponentStatuses_Should_SetIs64BitProcess()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Healthy,
+            TimeProvider.System);
+
+        detailed.Is64BitProcess.ShouldBe(Environment.Is64BitProcess);
+    }
+
+    [Test]
     public void FromHealthReport_Should_SetProcessId()
     {
         var entries = new Dictionary<string, HealthReportEntry>
@@ -94,6 +110,20 @@ public class DetailedHealthReportProviderTests
         var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
 
         detailed.ProcessorCount.ShouldBe(Environment.ProcessorCount);
+    }
+
+    [Test]
+    public void FromHealthReport_Should_SetIs64BitProcess()
+    {
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, new Dictionary<string, object>())
+        };
+        var report = new HealthReport(entries, TimeSpan.Zero);
+
+        var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
+
+        detailed.Is64BitProcess.ShouldBe(Environment.Is64BitProcess);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Adds `is64BitProcess` (`Environment.Is64BitProcess`) to detailed health JSON payloads.

## Files
- `src/UI/Api/DetailedHealthModels.cs` — new property on `DetailedHealthReport`
- `src/UI/Api/HealthReportBuilder.cs` — populate in `FromEntries()`
- `src/UI/Server/DetailedHealthReportProvider.cs` — populate in both factory methods
- `src/UI/Server/DetailedHealthCheckResponseWriter.cs` — expose on `/_healthcheck/detailed`
- Unit/integration tests mirroring existing `ProcessId`/`ProcessorCount` coverage

## Testing
- `./PrivateBuild.ps1` — green (compile, unit tests, DB migration, integration tests)

Closes #7272