### PR TITLE
Tiny: add time zone id to health payload (run C) (#7281)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthCheckEndpointIntegrationTests.cs
@@ -178,4 +178,16 @@ public class DetailedHealthCheckEndpointIntegrationTests
         doc.RootElement.TryGetProperty("is64BitProcess", out var is64BitProcess).ShouldBeTrue();
         is64BitProcess.GetBoolean().ShouldBe(Environment.Is64BitProcess);
     }
+
+    [Test]
+    public async Task GetHealthCheckDetailedReturnsTimeZoneId()
+    {
+        var response = await _client!.GetAsync("/_healthcheck/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("timeZoneId", out var timeZoneId).ShouldBeTrue();
+        timeZoneId.GetString().ShouldBe(TimeZoneInfo.Local.Id);
+    }
 }

--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -273,6 +273,18 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
+    public async Task GetApiHealthDetailedReturnsTimeZoneId()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("timeZoneId", out var timeZoneId).ShouldBeTrue();
+        timeZoneId.GetString().ShouldBe(TimeZoneInfo.Local.Id);
+    }
+
+    [Test]
     public async Task Should_ListExpectedComponentEntries_When_AggregatedFromRegisteredChecks()
     {
         var response = await _client!.GetAsync("/api/health/detailed");

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -52,6 +52,9 @@ public sealed class DetailedHealthReport
     /// <summary>Whether the host process runs as 64-bit (from <see cref="Environment.Is64BitProcess"/>).</summary>
     public required bool Is64BitProcess { get; init; }
 
+    /// <summary>Host local time zone identifier from <see cref="TimeZoneInfo.Local"/>.</summary>
+    public required string TimeZoneId { get; init; }
+
     /// <summary>Per-logical-component entries (mock or probe-derived).</summary>
     public required IReadOnlyList<ComponentHealthEntry> Components { get; init; }
 }

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -24,6 +24,7 @@ public static class HealthReportBuilder
             WorkingSetMb = (int)Math.Round(Environment.WorkingSet / 1_048_576.0),
             ProcessorCount = Environment.ProcessorCount,
             Is64BitProcess = Environment.Is64BitProcess,
+            TimeZoneId = TimeZoneInfo.Local.Id,
             Components = components,
             OverallStatus = AggregateWorst(components)
         };

--- a/src/UI/Server/DetailedHealthCheckResponseWriter.cs
+++ b/src/UI/Server/DetailedHealthCheckResponseWriter.cs
@@ -31,6 +31,7 @@ public static class DetailedHealthCheckResponseWriter
         {
             ServerUtc = timeProvider.GetUtcNow(),
             Is64BitProcess = Environment.Is64BitProcess,
+            TimeZoneId = TimeZoneInfo.Local.Id,
             OverallStatus = report.Status.ToString(),
             TotalDurationMs = report.TotalDuration.TotalMilliseconds,
             Entries = report.Entries
@@ -63,6 +64,9 @@ public static class DetailedHealthCheckResponseWriter
 
         /// <summary>Whether the host process runs as 64-bit (from <see cref="Environment.Is64BitProcess"/>).</summary>
         public bool Is64BitProcess { get; init; }
+
+        /// <summary>Host local time zone identifier from <see cref="TimeZoneInfo.Local"/>.</summary>
+        public string TimeZoneId { get; init; } = string.Empty;
 
         /// <summary>Overall aggregated status of all health checks.</summary>
         public required string OverallStatus { get; init; }

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -37,6 +37,7 @@ public sealed class DetailedHealthReportProvider(
             WorkingSetMb = GetWorkingSetMb(),
             ProcessorCount = Environment.ProcessorCount,
             Is64BitProcess = Environment.Is64BitProcess,
+            TimeZoneId = TimeZoneInfo.Local.Id,
             Components = components,
             OverallStatus = MapOverallStatus(report.Status)
         };
@@ -65,6 +66,7 @@ public sealed class DetailedHealthReportProvider(
             WorkingSetMb = GetWorkingSetMb(),
             ProcessorCount = Environment.ProcessorCount,
             Is64BitProcess = Environment.Is64BitProcess,
+            TimeZoneId = TimeZoneInfo.Local.Id,
             Components = components,
             OverallStatus = MapOverallStatus(aggregateStatus)
         };

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -127,6 +127,16 @@ public class HealthReportBuilderTests
     }
 
     [Test]
+    public void TimeZoneIdAddedToDetailedHealthReport()
+    {
+        var report = HealthReportBuilder.FromEntries(
+            TimeProvider.System,
+            [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
+
+        report.TimeZoneId.ShouldBe(TimeZoneInfo.Local.Id);
+    }
+
+    [Test]
     public void HealthReportBuilder_FromEntries_Should_AggregateWorstAcrossComponents()
     {
         var components = new[]

--- a/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthCheckResponseWriterTests.cs
@@ -203,4 +203,16 @@ public class DetailedHealthCheckResponseWriterTests
         doc.RootElement.TryGetProperty("is64BitProcess", out var is64BitProcess).ShouldBeTrue();
         is64BitProcess.GetBoolean().ShouldBe(Environment.Is64BitProcess);
     }
+
+    [Test]
+    public async Task TimeZoneIdSerializedAsCamelCase()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        using var doc = await WriteAndParseAsync(context, CreateMinimalReport());
+
+        doc.RootElement.TryGetProperty("timeZoneId", out var timeZoneId).ShouldBeTrue();
+        timeZoneId.GetString().ShouldBe(TimeZoneInfo.Local.Id);
+    }
 }

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -85,6 +85,22 @@ public class DetailedHealthReportProviderTests
     }
 
     [Test]
+    public void TimeZoneIdSetFromComponentStatuses()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Healthy,
+            TimeProvider.System);
+
+        detailed.TimeZoneId.ShouldBe(TimeZoneInfo.Local.Id);
+    }
+
+    [Test]
     public void FromHealthReport_Should_SetProcessId()
     {
         var entries = new Dictionary<string, HealthReportEntry>
@@ -124,6 +140,20 @@ public class DetailedHealthReportProviderTests
         var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
 
         detailed.Is64BitProcess.ShouldBe(Environment.Is64BitProcess);
+    }
+
+    [Test]
+    public void TimeZoneIdSetFromHealthReport()
+    {
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, new Dictionary<string, object>())
+        };
+        var report = new HealthReport(entries, TimeSpan.Zero);
+
+        var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
+
+        detailed.TimeZoneId.ShouldBe(TimeZoneInfo.Local.Id);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Adds `timeZoneId` (`TimeZoneInfo.Local.Id`) to both machine-oriented detailed health JSON payloads.

## Files changed

- `src/UI/Api/DetailedHealthModels.cs` — new `TimeZoneId` property on `DetailedHealthReport`
- `src/UI/Api/HealthReportBuilder.cs` — populate from `TimeZoneInfo.Local.Id`
- `src/UI/Server/DetailedHealthReportProvider.cs` — populate in `FromHealthReport` and `FromComponentStatuses`
- `src/UI/Server/DetailedHealthCheckResponseWriter.cs` — add to `DetailedHealthCheckResponse` and `WriteAsync`
- Unit tests: `HealthReportBuilderTests`, `DetailedHealthReportProviderTests`, `DetailedHealthCheckResponseWriterTests`
- Integration tests: `DetailedHealthEndpointIntegrationTests`, `DetailedHealthCheckEndpointIntegrationTests`

## Testing

- `PrivateBuild.ps1` — green (unit + integration)
- Asserts `timeZoneId` camelCase JSON matches `TimeZoneInfo.Local.Id` on `/api/health/detailed` and `/_healthcheck/detailed`

Closes #7281