### PR TITLE
Tiny: add process priority to health payload (run C) (#7282)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -282,6 +283,36 @@ public class DetailedHealthEndpointIntegrationTests
         using var doc = await JsonDocument.ParseAsync(stream);
         doc.RootElement.TryGetProperty("timeZoneId", out var timeZoneId).ShouldBeTrue();
         timeZoneId.GetString().ShouldBe(TimeZoneInfo.Local.Id);
+    }
+
+    [Test]
+    public async Task Should_IncludeProcessPriority_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("processPriority", out var processPriority).ShouldBeTrue();
+        processPriority.ValueKind.ShouldBe(JsonValueKind.String);
+        var value = processPriority.GetString();
+        value.ShouldNotBeNull();
+        value!.ShouldNotBeEmpty();
+        value.ShouldBe(Process.GetCurrentProcess().PriorityClass.ToString());
+    }
+
+    [Test]
+    public async Task Should_DeserializeProcessPriority_ToDetailedHealthReport_When_GetDetailedHealth()
+    {
+        var response = await _client!.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var report = await response.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        report.ShouldNotBeNull();
+        report!.ProcessPriority.ShouldNotBeNull();
+        report.ProcessPriority.ShouldNotBeEmpty();
+        report.ProcessPriority.ShouldBe(Process.GetCurrentProcess().PriorityClass.ToString());
     }
 
     [Test]

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -55,6 +55,9 @@ public sealed class DetailedHealthReport
     /// <summary>Host local time zone identifier from <see cref="TimeZoneInfo.Local"/>.</summary>
     public required string TimeZoneId { get; init; }
 
+    /// <summary>Process scheduling priority from <see cref="System.Diagnostics.Process.PriorityClass"/>.</summary>
+    public required string ProcessPriority { get; init; }
+
     /// <summary>Per-logical-component entries (mock or probe-derived).</summary>
     public required IReadOnlyList<ComponentHealthEntry> Components { get; init; }
 }

--- a/src/UI/Api/HealthReportBuilder.cs
+++ b/src/UI/Api/HealthReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace ClearMeasure.Bootcamp.UI.Api;
@@ -25,6 +26,7 @@ public static class HealthReportBuilder
             ProcessorCount = Environment.ProcessorCount,
             Is64BitProcess = Environment.Is64BitProcess,
             TimeZoneId = TimeZoneInfo.Local.Id,
+            ProcessPriority = Process.GetCurrentProcess().PriorityClass.ToString(),
             Components = components,
             OverallStatus = AggregateWorst(components)
         };

--- a/src/UI/Server/DetailedHealthReportProvider.cs
+++ b/src/UI/Server/DetailedHealthReportProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using ClearMeasure.Bootcamp.UI.Api;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -38,6 +39,7 @@ public sealed class DetailedHealthReportProvider(
             ProcessorCount = Environment.ProcessorCount,
             Is64BitProcess = Environment.Is64BitProcess,
             TimeZoneId = TimeZoneInfo.Local.Id,
+            ProcessPriority = GetProcessPriority(),
             Components = components,
             OverallStatus = MapOverallStatus(report.Status)
         };
@@ -67,6 +69,7 @@ public sealed class DetailedHealthReportProvider(
             ProcessorCount = Environment.ProcessorCount,
             Is64BitProcess = Environment.Is64BitProcess,
             TimeZoneId = TimeZoneInfo.Local.Id,
+            ProcessPriority = GetProcessPriority(),
             Components = components,
             OverallStatus = MapOverallStatus(aggregateStatus)
         };
@@ -77,6 +80,9 @@ public sealed class DetailedHealthReportProvider(
 
     internal static int GetWorkingSetMb() =>
         (int)Math.Round(Environment.WorkingSet / 1_048_576.0);
+
+    internal static string GetProcessPriority() =>
+        Process.GetCurrentProcess().PriorityClass.ToString();
 
     private static string MapOverallStatus(HealthStatus status) => status switch
     {

--- a/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
+++ b/src/UnitTests/UI/Api/HealthReportBuilderTests.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Server;
 using Shouldly;
 
 namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
@@ -134,6 +136,17 @@ public class HealthReportBuilderTests
             [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
 
         report.TimeZoneId.ShouldBe(TimeZoneInfo.Local.Id);
+    }
+
+    [Test]
+    public void HealthReportBuilder_FromEntries_Should_SetProcessPriority()
+    {
+        var report = HealthReportBuilder.FromEntries(
+            TimeProvider.System,
+            [new ComponentHealthEntry { Name = "X", Status = ComponentHealthStatus.Healthy }]);
+
+        report.ProcessPriority.ShouldBe(DetailedHealthReportProvider.GetProcessPriority());
+        report.ProcessPriority.ShouldBe(Process.GetCurrentProcess().PriorityClass.ToString());
     }
 
     [Test]

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using ClearMeasure.Bootcamp.UI.Api;
 using ClearMeasure.Bootcamp.UI.Server;
@@ -101,6 +102,23 @@ public class DetailedHealthReportProviderTests
     }
 
     [Test]
+    public void FromComponentStatuses_Should_SetProcessPriority()
+    {
+        var entries = new Dictionary<string, HealthStatus>(StringComparer.Ordinal)
+        {
+            ["API"] = HealthStatus.Healthy
+        };
+
+        var detailed = DetailedHealthReportProvider.FromComponentStatuses(
+            entries,
+            HealthStatus.Healthy,
+            TimeProvider.System);
+
+        detailed.ProcessPriority.ShouldBe(DetailedHealthReportProvider.GetProcessPriority());
+        detailed.ProcessPriority.ShouldBe(Process.GetCurrentProcess().PriorityClass.ToString());
+    }
+
+    [Test]
     public void FromHealthReport_Should_SetProcessId()
     {
         var entries = new Dictionary<string, HealthReportEntry>
@@ -154,6 +172,21 @@ public class DetailedHealthReportProviderTests
         var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
 
         detailed.TimeZoneId.ShouldBe(TimeZoneInfo.Local.Id);
+    }
+
+    [Test]
+    public void FromHealthReport_Should_SetProcessPriority()
+    {
+        var entries = new Dictionary<string, HealthReportEntry>
+        {
+            ["API"] = new(HealthStatus.Healthy, null, TimeSpan.Zero, null, new Dictionary<string, object>())
+        };
+        var report = new HealthReport(entries, TimeSpan.Zero);
+
+        var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
+
+        detailed.ProcessPriority.ShouldBe(DetailedHealthReportProvider.GetProcessPriority());
+        detailed.ProcessPriority.ShouldBe(Process.GetCurrentProcess().PriorityClass.ToString());
     }
 
     [Test]


### PR DESCRIPTION
Adds `processPriority` (Process.PriorityClass as string) to the detailed health JSON payload from GET /api/health/detailed.

**Files changed:**
- src/UI/Api/DetailedHealthModels.cs — ProcessPriority property
- src/UI/Server/DetailedHealthReportProvider.cs — GetProcessPriority() + population
- src/UI/Api/HealthReportBuilder.cs — FromEntries sets ProcessPriority
- Unit + integration tests for provider, builder, and endpoint

**Testing:** PrivateBuild.ps1 green (unit + integration).

Closes #7282