### PR TITLE
Change footer to copyright 2027 (#7210)

### DIFF
--- a/src/AcceptanceTests/App/CopyrightFooterTests.cs
+++ b/src/AcceptanceTests/App/CopyrightFooterTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using ClearMeasure.Bootcamp.UI.Shared;
 
 namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
@@ -16,8 +15,7 @@ public class CopyrightFooterTests : AcceptanceTestBase
         await footer.WaitForAsync();
         await Expect(footer).ToBeVisibleAsync();
 
-        var yearText = DateTime.UtcNow.Year.ToString(CultureInfo.InvariantCulture);
-        await Expect(footer).ToContainTextAsync(yearText);
+        await Expect(footer).ToContainTextAsync("© 2027");
         await Expect(footer).ToContainTextAsync("ClearMeasure Labs");
 
         var link = footer.Locator("a[href*='clearmeasure.com']").First;
@@ -37,8 +35,7 @@ public class CopyrightFooterTests : AcceptanceTestBase
 
         var footer = Page.GetByTestId(nameof(MainLayout.Elements.CopyrightFooter));
         await Expect(footer).ToBeVisibleAsync();
-        var yearText = DateTime.UtcNow.Year.ToString(CultureInfo.InvariantCulture);
-        await Expect(footer).ToContainTextAsync(yearText);
+        await Expect(footer).ToContainTextAsync("© 2027");
         await Expect(footer).ToContainTextAsync("ClearMeasure Labs");
     }
 

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -20,9 +20,9 @@ public partial class MainLayout : IAsyncDisposable
     }
 
     /// <summary>
-    /// Calendar year shown in the site copyright line (UTC, matches acceptance tests).
+    /// Calendar year shown in the site copyright line.
     /// </summary>
-    protected int CopyrightYear => DateTime.UtcNow.Year;
+    protected int CopyrightYear => 2027;
 
     [Inject]
     private IJSRuntime Js { get; set; } = default!;

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+using System.Reflection;
 using Bunit;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Model;
@@ -170,7 +170,19 @@ public class MainLayoutTests
     }
 
     [Test]
-    public void ShouldRenderCopyrightFooter_WithCurrentYear_OrganizationAndLink_WhenNotAuthenticated()
+    public void CopyrightYear_ShouldReturn2027_InMainLayout()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        layout.Instance.GetType().GetProperty("CopyrightYear", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(layout.Instance).ShouldBe(2027);
+    }
+
+    [Test]
+    public void ShouldRenderCopyrightFooter_With2027Year_OrganizationAndLink_WhenNotAuthenticated()
     {
         using var ctx = CreateContext();
 
@@ -181,8 +193,7 @@ public class MainLayoutTests
         footer.TagName.ShouldBe("FOOTER");
         layout.FindAll("#app-navigation-rail footer").Count.ShouldBe(0);
 
-        var yearText = DateTime.UtcNow.Year.ToString(CultureInfo.InvariantCulture);
-        footer.TextContent.ShouldContain(yearText);
+        footer.TextContent.ShouldContain("2027");
         footer.TextContent.ShouldContain("ClearMeasure Labs");
 
         var link = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}'] .site-footer-link");
@@ -191,7 +202,7 @@ public class MainLayoutTests
     }
 
     [Test]
-    public void ShouldRenderCopyrightFooter_WhenAuthenticated()
+    public void ShouldRenderCopyrightFooter_With2027Year_WhenAuthenticated()
     {
         using var ctx = CreateContext(authenticateAsUser: "hsimpson");
 
@@ -199,8 +210,7 @@ public class MainLayoutTests
         var layout = component.FindComponent<MainLayout>();
 
         var footer = layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}']");
-        var yearText = DateTime.UtcNow.Year.ToString(CultureInfo.InvariantCulture);
-        footer.TextContent.ShouldContain(yearText);
+        footer.TextContent.ShouldContain("2027");
         footer.TextContent.ShouldContain("ClearMeasure Labs");
         layout.Find($"[data-testid='{nameof(MainLayout.Elements.CopyrightFooter)}'] .site-footer-link").GetAttribute("href")!.TrimEnd('/').ShouldBe("https://clearmeasure.com");
     }


### PR DESCRIPTION
Updates the site copyright footer year from the dynamic UTC year to **2027**.

**Files changed:**
- `src/UI.Shared/MainLayout.razor.cs` — `CopyrightYear` returns 2027
- `src/UnitTests/UI.Shared/MainLayoutTests.cs` — updated copyright footer unit tests + new property test
- `src/AcceptanceTests/App/CopyrightFooterTests.cs` — updated year assertions to 2027

**Testing:**
- Private build passed (unit + integration tests)
- Acceptance test year assertions updated; footer link, note, and layout unchanged

Closes #7210