### PR TITLE
Add dark mode toggle to the settings page (#7325)

### DIFF
--- a/src/AcceptanceTests/App/DarkModeTests.cs
+++ b/src/AcceptanceTests/App/DarkModeTests.cs
@@ -42,6 +42,30 @@ public class DarkModeTests : AcceptanceTestBase
     }
 
     [Test, Retry(2)]
+    public async Task DarkMode_ShouldToggleLightModeFromDark()
+    {
+        await LoginAsCurrentUser();
+        await Click(nameof(NavMenu.Elements.Settings));
+        await Page.WaitForURLAsync("**/settings");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        var darkSwitch = Page.GetByTestId(nameof(Settings.Elements.DarkModeSwitch));
+        await darkSwitch.WaitForAsync();
+
+        if (!await darkSwitch.IsCheckedAsync())
+            await Click(nameof(Settings.Elements.DarkModeSwitch));
+        await Page.WaitForFunctionAsync(
+            "() => document.documentElement.getAttribute('data-theme') === 'dark'");
+
+        await Click(nameof(Settings.Elements.DarkModeSwitch));
+        await Page.WaitForFunctionAsync(
+            "() => document.documentElement.getAttribute('data-theme') === 'light'");
+
+        var bsTheme = await Page.EvaluateAsync<string>(
+            "() => document.documentElement.getAttribute('data-bs-theme')");
+        bsTheme.ShouldBe("light");
+    }
+
+    [Test, Retry(2)]
     public async Task DarkMode_ShouldPersistAcrossReload()
     {
         await LoginAsCurrentUser();

--- a/src/UnitTests/UI.Shared/Pages/SettingsTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/SettingsTests.cs
@@ -4,6 +4,7 @@ using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.UI.Shared.Authentication;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
 using ClearMeasure.Bootcamp.UI.Shared.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
@@ -31,6 +32,13 @@ public class SettingsTests
         sw.GetAttribute("role").ShouldBe("switch");
         component.Markup.ShouldContain("Dark mode");
         component.Markup.ShouldContain("whole app");
+    }
+
+    [Test]
+    public void Settings_ShouldRequireAuthorization()
+    {
+        typeof(Settings).GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .ShouldNotBeEmpty();
     }
 
     [Test]

--- a/src/UnitTests/UI.Shared/Services/ThemePreferenceServiceTests.cs
+++ b/src/UnitTests/UI.Shared/Services/ThemePreferenceServiceTests.cs
@@ -34,6 +34,31 @@ public class ThemePreferenceServiceTests
     }
 
     [Test]
+    public async Task InitializeAsync_WithNoStoredValue_ShouldFallbackToSystemPreference()
+    {
+        var js = new StubThemeJsRuntime { InitialTheme = "light" };
+        var sut = new ThemePreferenceService(js);
+
+        await sut.InitializeAsync();
+
+        sut.IsDarkMode.ShouldBeFalse();
+        js.SyncDomFromThemeCalls.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task SetDarkModeAsync_ShouldCallSyncDomFromTheme()
+    {
+        var js = new StubThemeJsRuntime { InitialTheme = "light" };
+        var sut = new ThemePreferenceService(js);
+        await sut.InitializeAsync();
+        js.SyncDomFromThemeCalls = 0;
+
+        await sut.SetDarkModeAsync(true);
+
+        js.SetThemeCalls.ShouldBe(1);
+    }
+
+    [Test]
     public async Task WhenJsInteropThrowsDisconnected_ShouldNotCrashOnInitialize()
     {
         var js = new StubDisconnectedJsRuntime();
@@ -58,6 +83,7 @@ public class ThemePreferenceServiceTests
     {
         public string InitialTheme { get; init; } = "light";
         public int SetThemeCalls { get; private set; }
+        public int SyncDomFromThemeCalls { get; set; }
         public bool? LastSetThemeArg { get; private set; }
 
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
@@ -93,6 +119,7 @@ public class ThemePreferenceServiceTests
 
                 if (identifier == "syncDomFromTheme")
                 {
+                    _parent.SyncDomFromThemeCalls++;
                     _theme = (string)args![0]!;
                     return ValueTask.FromResult(default(TValue)!);
                 }
@@ -117,6 +144,7 @@ public class ThemePreferenceServiceTests
                 switch (identifier)
                 {
                     case "syncDomFromTheme":
+                        _parent.SyncDomFromThemeCalls++;
                         _theme = (string)args![0]!;
                         return ValueTask.CompletedTask;
                     case "setTheme":


### PR DESCRIPTION
## Summary
Adds client-side dark mode toggle on the Settings page (`/settings`) with app-wide theme persistence via `localStorage`.

## Changes
- `ThemePreferenceService` + `theme.js` — read/apply/persist theme via `data-theme` and `data-bs-theme`
- `Settings.razor` — Appearance section with Bootstrap form-switch
- `NavMenu.razor` — Settings nav link
- `MainLayout.razor.cs` — theme init on first render
- `index.html` — FOUC guard inline script
- Dark theme CSS overrides across shared pages/layout

## Tests
- Unit: `ThemePreferenceServiceTests`, `SettingsTests`, `MainLayoutTests`
- Acceptance: `DarkModeTests` (toggle, persistence, auth redirect)

## Verification
- `PrivateBuild.ps1` passed locally (unit + integration)

Closes #7325