### PR TITLE
Display user avatar initials in the top navigation bar (#7323)

### DIFF
--- a/src/AcceptanceTests/Authentication/HeaderAvatarTests.cs
+++ b/src/AcceptanceTests/Authentication/HeaderAvatarTests.cs
@@ -10,11 +10,11 @@ public class HeaderAvatarTests : AcceptanceTestBase
     [Test, Retry(2)]
     public async Task ShouldDisplayAvatarWithInitialsAfterLogin()
     {
-        CurrentUser = CreateNamedEmployee("jdoe", "Jane", "Doe");
+        CurrentUser = CreateNamedEmployee("avatar_jd", "Jane", "Doe");
         await LoginAsCurrentUser();
 
         var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
-        await Expect(avatar).ToBeVisibleAsync();
+        await Expect(avatar).ToBeVisibleAsync(new() { Timeout = 15_000 });
         await Expect(avatar).ToHaveTextAsync("JD");
         await Expect(avatar).ToHaveAttributeAsync("aria-label", "Signed in as Jane Doe");
     }
@@ -22,11 +22,11 @@ public class HeaderAvatarTests : AcceptanceTestBase
     [Test, Retry(2)]
     public async Task ShouldRemoveAvatarAfterLogout()
     {
-        CurrentUser = CreateNamedEmployee("jdoe", "Jane", "Doe");
+        CurrentUser = CreateNamedEmployee("avatar_logout", "Jane", "Doe");
         await LoginAsCurrentUser();
 
         var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
-        await Expect(avatar).ToBeVisibleAsync();
+        await Expect(avatar).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
         await Click(nameof(Logout.Elements.LogoutLink));
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
@@ -38,11 +38,11 @@ public class HeaderAvatarTests : AcceptanceTestBase
     public async Task ShouldMaintainAvatarLegibilityOnNarrowViewport()
     {
         await Page.SetViewportSizeAsync(375, 667);
-        CurrentUser = CreateNamedEmployee("jdoe", "Jane", "Doe");
+        CurrentUser = CreateNamedEmployee("avatar_narrow", "Jane", "Doe");
         await LoginAsCurrentUser();
 
         var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
-        await Expect(avatar).ToBeVisibleAsync();
+        await Expect(avatar).ToBeVisibleAsync(new() { Timeout = 15_000 });
         await Expect(avatar).ToHaveTextAsync("JD");
 
         var box = await avatar.BoundingBoxAsync();
@@ -54,25 +54,27 @@ public class HeaderAvatarTests : AcceptanceTestBase
     [Test, Retry(2)]
     public async Task ShouldShowCorrectInitialsForSingleNameUser()
     {
-        CurrentUser = CreateNamedEmployee("homer", "Homer", "");
+        CurrentUser = CreateNamedEmployee("avatar_single", "Homer", "");
         await LoginAsCurrentUser();
 
         var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
-        await Expect(avatar).ToHaveTextAsync("H");
+        await Expect(avatar).ToHaveTextAsync("H", new() { Timeout = 15_000 });
     }
 
     [Test, Retry(2)]
     public async Task ShouldShowUsernameInitialsFallback()
     {
-        CurrentUser = CreateNamedEmployee("hsimpson", "", "");
+        CurrentUser = CreateNamedEmployee("avatarfb", "", "");
         await LoginAsCurrentUser();
 
         var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
-        await Expect(avatar).ToHaveTextAsync("HS");
+        var expectedInitials = CurrentUser.UserName[..2].ToUpperInvariant();
+        await Expect(avatar).ToHaveTextAsync(expectedInitials, new() { Timeout = 15_000 });
     }
 
-    private static Employee CreateNamedEmployee(string userName, string firstName, string lastName)
+    private Employee CreateNamedEmployee(string userNamePrefix, string firstName, string lastName)
     {
+        var userName = $"{userNamePrefix}_{TestTag}";
         using var context = TestHost.NewDbContext();
         var employee = new Employee(userName, firstName, lastName, $"{userName}@test.com");
         employee.AddRole(new Role("admin", true, true));

--- a/src/AcceptanceTests/Authentication/HeaderAvatarTests.cs
+++ b/src/AcceptanceTests/Authentication/HeaderAvatarTests.cs
@@ -1,0 +1,83 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.UI.Shared.Components;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.Authentication;
+
+[TestFixture]
+public class HeaderAvatarTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldDisplayAvatarWithInitialsAfterLogin()
+    {
+        CurrentUser = CreateNamedEmployee("jdoe", "Jane", "Doe");
+        await LoginAsCurrentUser();
+
+        var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
+        await Expect(avatar).ToBeVisibleAsync();
+        await Expect(avatar).ToHaveTextAsync("JD");
+        await Expect(avatar).ToHaveAttributeAsync("aria-label", "Signed in as Jane Doe");
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldRemoveAvatarAfterLogout()
+    {
+        CurrentUser = CreateNamedEmployee("jdoe", "Jane", "Doe");
+        await LoginAsCurrentUser();
+
+        var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
+        await Expect(avatar).ToBeVisibleAsync();
+
+        await Click(nameof(Logout.Elements.LogoutLink));
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(avatar).ToHaveCountAsync(0);
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldMaintainAvatarLegibilityOnNarrowViewport()
+    {
+        await Page.SetViewportSizeAsync(375, 667);
+        CurrentUser = CreateNamedEmployee("jdoe", "Jane", "Doe");
+        await LoginAsCurrentUser();
+
+        var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
+        await Expect(avatar).ToBeVisibleAsync();
+        await Expect(avatar).ToHaveTextAsync("JD");
+
+        var box = await avatar.BoundingBoxAsync();
+        box.ShouldNotBeNull();
+        box!.Width.ShouldBeGreaterThan(30);
+        box.Height.ShouldBeGreaterThan(30);
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldShowCorrectInitialsForSingleNameUser()
+    {
+        CurrentUser = CreateNamedEmployee("homer", "Homer", "");
+        await LoginAsCurrentUser();
+
+        var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
+        await Expect(avatar).ToHaveTextAsync("H");
+    }
+
+    [Test, Retry(2)]
+    public async Task ShouldShowUsernameInitialsFallback()
+    {
+        CurrentUser = CreateNamedEmployee("hsimpson", "", "");
+        await LoginAsCurrentUser();
+
+        var avatar = Page.GetByTestId(nameof(UserAvatar.Elements.UserAvatar));
+        await Expect(avatar).ToHaveTextAsync("HS");
+    }
+
+    private static Employee CreateNamedEmployee(string userName, string firstName, string lastName)
+    {
+        using var context = TestHost.NewDbContext();
+        var employee = new Employee(userName, firstName, lastName, $"{userName}@test.com");
+        employee.AddRole(new Role("admin", true, true));
+        context.Add(employee);
+        context.SaveChanges();
+        return employee;
+    }
+}

--- a/src/UI.Shared/Components/Logout.razor
+++ b/src/UI.Shared/Components/Logout.razor
@@ -1,6 +1,7 @@
 @inject CustomAuthenticationStateProvider AuthStateProvider
 @inject NavigationManager NavigationManager
 
+<UserAvatar/>
 <span data-testid="@Elements.WelcomeText">
     Welcome
     @{

--- a/src/UI.Shared/Components/UserAvatar.razor
+++ b/src/UI.Shared/Components/UserAvatar.razor
@@ -1,0 +1,37 @@
+@inject CustomAuthenticationStateProvider AuthStateProvider
+@inject IUserSession UserSession
+
+@if (_isAuthenticated && !string.IsNullOrEmpty(_initials))
+{
+    <span class="user-avatar"
+          data-testid="@Elements.UserAvatar"
+          aria-label="@_ariaLabel"
+          style="background-color: @_backgroundColor">
+        @_initials
+    </span>
+}
+
+@code {
+    private string _initials = string.Empty;
+    private string _ariaLabel = string.Empty;
+    private string _backgroundColor = string.Empty;
+    private bool _isAuthenticated;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _isAuthenticated = AuthStateProvider.IsAuthenticated();
+        if (!_isAuthenticated)
+            return;
+
+        var username = AuthStateProvider.GetUsername();
+        var employee = await UserSession.GetCurrentUserAsync();
+        _initials = UserAvatarInitialsHelper.GetInitials(employee, username);
+        _ariaLabel = UserAvatarInitialsHelper.GetDisplayName(employee, username);
+        _backgroundColor = UserAvatarInitialsHelper.GetBackgroundColor(username ?? string.Empty);
+    }
+
+    public enum Elements
+    {
+        UserAvatar
+    }
+}

--- a/src/UI.Shared/MainLayout.razor.css
+++ b/src/UI.Shared/MainLayout.razor.css
@@ -242,6 +242,22 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
+.user-section ::deep .user-avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    font-weight: 700;
+    font-size: 0.875rem;
+    color: #ffffff;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    line-height: 1;
+}
+
 .user-section ::deep span {
     font-weight: 600;
     color: #4a5568;
@@ -549,6 +565,11 @@
 :global(html[data-theme="dark"]) .user-section ::deep a,
 :global(html[data-theme="dark"]) .auth-section ::deep a {
     color: #e2e8f0;
+}
+
+:global(html[data-theme="dark"]) .user-section ::deep .user-avatar {
+    color: #ffffff;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
 }
 
 :global(html[data-theme="dark"]) .user-section ::deep a:hover,

--- a/src/UI.Shared/UserAvatarInitialsHelper.cs
+++ b/src/UI.Shared/UserAvatarInitialsHelper.cs
@@ -1,0 +1,87 @@
+using ClearMeasure.Bootcamp.Core.Model;
+
+namespace ClearMeasure.Bootcamp.UI.Shared;
+
+/// <summary>
+/// Derives avatar initials, display name, and background color for the signed-in user header badge.
+/// </summary>
+public static class UserAvatarInitialsHelper
+{
+    /// <summary>
+    /// Returns uppercase initials from the employee name, or the first two username characters when names are unavailable.
+    /// </summary>
+    public static string GetInitials(Employee? employee, string? username)
+    {
+        var firstInitial = GetNameInitial(employee?.FirstName);
+        var lastInitial = GetNameInitial(employee?.LastName);
+
+        if (!string.IsNullOrEmpty(firstInitial) && !string.IsNullOrEmpty(lastInitial))
+            return firstInitial + lastInitial;
+
+        if (!string.IsNullOrEmpty(firstInitial))
+            return firstInitial;
+
+        if (!string.IsNullOrEmpty(lastInitial))
+            return lastInitial;
+
+        if (string.IsNullOrWhiteSpace(username))
+            return string.Empty;
+
+        var trimmed = username.Trim();
+        if (trimmed.Length >= 2)
+            return trimmed[..2].ToUpperInvariant();
+
+        return trimmed.ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// Returns a deterministic HSL background color for the given username.
+    /// </summary>
+    public static string GetBackgroundColor(string username)
+    {
+        if (string.IsNullOrEmpty(username))
+            return "hsl(0, 0%, 70%)";
+
+        var hash = GetDeterministicHash(username);
+        var hue = Math.Abs(hash) % 360;
+        return $"hsl({hue}, 65%, 45%)";
+    }
+
+    /// <summary>
+    /// Returns the accessible display name for the avatar aria-label.
+    /// </summary>
+    public static string GetDisplayName(Employee? employee, string? username)
+    {
+        if (employee != null)
+        {
+            var fullName = employee.GetFullName().Trim();
+            if (!string.IsNullOrWhiteSpace(fullName))
+                return $"Signed in as {fullName}";
+        }
+
+        if (!string.IsNullOrEmpty(username))
+            return $"Signed in as {username}";
+
+        return "Signed in";
+    }
+
+    private static string GetNameInitial(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return string.Empty;
+
+        return char.ToUpperInvariant(name.Trim()[0]).ToString();
+    }
+
+    private static int GetDeterministicHash(string value)
+    {
+        unchecked
+        {
+            var hash = 23;
+            foreach (var c in value)
+                hash = hash * 31 + c;
+
+            return hash;
+        }
+    }
+}

--- a/src/UnitTests/UI.Shared/Components/LogoutTests.cs
+++ b/src/UnitTests/UI.Shared/Components/LogoutTests.cs
@@ -1,5 +1,7 @@
 ﻿using Bunit;
 using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Services;
 using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UI.Shared.Authentication;
 using ClearMeasure.Bootcamp.UI.Shared.Components;
@@ -16,6 +18,17 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Components;
 [TestFixture]
 public class LogoutTests
 {
+    private static TestContext CreateContext(CustomAuthenticationStateProvider authProvider)
+    {
+        var ctx = new TestContext();
+        ctx.Services.AddSingleton(authProvider);
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new Bus(null!));
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(
+            new Employee("hsimpson", "Homer", "Simpson", "homer@test.com")));
+        return ctx;
+    }
+
     [Test]
     public void ShouldDisplayWelcomeMessageWithUsername()
     {
@@ -27,10 +40,12 @@ public class LogoutTests
         ctx.Services.AddSingleton(authProvider);
         ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
         ctx.Services.AddSingleton<IBus>(new Bus(null!));
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(
+            new Employee("hsimpson", "Homer", "Simpson", "homer@test.com")));
 
         var component = ctx.RenderComponent<Logout>();
 
-        var welcomeSpan = component.Find("span");
+        var welcomeSpan = component.Find($"[data-testid='{nameof(Logout.Elements.WelcomeText)}']");
         welcomeSpan.TextContent.ShouldContain("Welcome");
         welcomeSpan.TextContent.ShouldContain("hsimpson");
     }
@@ -38,14 +53,9 @@ public class LogoutTests
     [Test]
     public void ShouldDisplayLogoutLink()
     {
-        using var ctx = new TestContext();
-
         var authProvider = new CustomAuthenticationStateProvider();
         authProvider.Login("hsimpson");
-
-        ctx.Services.AddSingleton(authProvider);
-        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
-        ctx.Services.AddSingleton<IBus>(new Bus(null!));
+        using var ctx = CreateContext(authProvider);
 
         var component = ctx.RenderComponent<Logout>();
 
@@ -59,15 +69,11 @@ public class LogoutTests
     [Test]
     public void ShouldNotifyEventBusWithUserLoggedOutEventOnClick()
     {
-        using var ctx = new TestContext();
-
         var authProvider = new CustomAuthenticationStateProvider();
         authProvider.Login("hsimpson");
+        using var ctx = CreateContext(authProvider);
         var spyEventBus = new SpyUiBus();
-
-        ctx.Services.AddSingleton(authProvider);
         ctx.Services.AddSingleton<IUiBus>(spyEventBus);
-        ctx.Services.AddSingleton<IBus>(new Bus(null!));
 
         var component = ctx.RenderComponent<Logout>();
         var logoutLink = component.Find("a");
@@ -81,14 +87,9 @@ public class LogoutTests
     [Test]
     public void ShouldNavigateToLoginPageOnClick()
     {
-        using var ctx = new TestContext();
-
         var authProvider = new CustomAuthenticationStateProvider();
         authProvider.Login("hsimpson");
-
-        ctx.Services.AddSingleton(authProvider);
-        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
-        ctx.Services.AddSingleton<IBus>(new Bus(null!));
+        using var ctx = CreateContext(authProvider);
 
         var component = ctx.RenderComponent<Logout>();
         var logoutLink = component.Find("a");
@@ -109,6 +110,7 @@ public class LogoutTests
         ctx.Services.AddSingleton<CustomAuthenticationStateProvider>();
         ctx.Services.AddSingleton<IUiBus>(spyEventBus);
         ctx.Services.AddSingleton<IBus>(new Bus(null!));
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(null));
 
         var component = ctx.RenderComponent<Logout>();
         var logoutLink = component.Find("a");
@@ -117,10 +119,14 @@ public class LogoutTests
 
         var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
 
-        // Verify all actions occurred
         spyEventBus.NotifyWasCalled.ShouldBeTrue();
         spyEventBus.LastNotifiedEvent.ShouldBeOfType<UserLoggedOutEvent>();
         navigationManager.Uri.ShouldEndWith("/login");
+    }
+
+    private sealed class StubUserSession(Employee? employee) : IUserSession
+    {
+        public Task<Employee?> GetCurrentUserAsync() => Task.FromResult(employee);
     }
 }
 

--- a/src/UnitTests/UI.Shared/Components/UserAvatarTests.cs
+++ b/src/UnitTests/UI.Shared/Components/UserAvatarTests.cs
@@ -1,0 +1,115 @@
+using Bunit;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Authentication;
+using ClearMeasure.Bootcamp.UI.Shared.Components;
+using ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
+using Microsoft.Extensions.DependencyInjection;
+using Palermo.BlazorMvc;
+using Shouldly;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Components;
+
+[TestFixture]
+public class UserAvatarTests
+{
+    [Test]
+    public void ShouldRenderAvatarWhenAuthenticated()
+    {
+        using var ctx = CreateContext(
+            "jdoe",
+            new Employee("jdoe", "Jane", "Doe", "jane@example.com"));
+
+        var component = ctx.RenderComponent<UserAvatar>();
+
+        var avatar = component.Find($"[data-testid='{nameof(UserAvatar.Elements.UserAvatar)}']");
+        avatar.TextContent.Trim().ShouldBe("JD");
+        avatar.ClassList.ShouldContain("user-avatar");
+    }
+
+    [Test]
+    public void ShouldSetAriaLabel_ContainsDisplayName()
+    {
+        using var ctx = CreateContext(
+            "jdoe",
+            new Employee("jdoe", "Jane", "Doe", "jane@example.com"));
+
+        var component = ctx.RenderComponent<UserAvatar>();
+
+        var avatar = component.Find($"[data-testid='{nameof(UserAvatar.Elements.UserAvatar)}']");
+        avatar.GetAttribute("aria-label").ShouldBe("Signed in as Jane Doe");
+    }
+
+    [Test]
+    public void ShouldSetDataTestid_MatchesElements()
+    {
+        using var ctx = CreateContext(
+            "jdoe",
+            new Employee("jdoe", "Jane", "Doe", "jane@example.com"));
+
+        var component = ctx.RenderComponent<UserAvatar>();
+
+        component.FindAll($"[data-testid='{nameof(UserAvatar.Elements.UserAvatar)}']").Count.ShouldBe(1);
+    }
+
+    [Test]
+    public void ShouldApplyBackgroundColorStyle_InlineOrCssVariable()
+    {
+        using var ctx = CreateContext(
+            "jdoe",
+            new Employee("jdoe", "Jane", "Doe", "jane@example.com"));
+
+        var component = ctx.RenderComponent<UserAvatar>();
+
+        var avatar = component.Find($"[data-testid='{nameof(UserAvatar.Elements.UserAvatar)}']");
+        var style = avatar.GetAttribute("style");
+        style.ShouldNotBeNull();
+        style.ShouldContain("background-color:");
+        style.ShouldContain(UserAvatarInitialsHelper.GetBackgroundColor("jdoe"));
+    }
+
+    [Test]
+    public void ShouldNotRenderAvatarWhenUnauthenticated()
+    {
+        using var ctx = CreateContext(null, null);
+
+        var component = ctx.RenderComponent<UserAvatar>();
+
+        component.FindAll($"[data-testid='{nameof(UserAvatar.Elements.UserAvatar)}']").Count.ShouldBe(0);
+    }
+
+    [Test]
+    public void ShouldHaveCorrectClassesForCircleStyle()
+    {
+        using var ctx = CreateContext(
+            "jdoe",
+            new Employee("jdoe", "Jane", "Doe", "jane@example.com"));
+
+        var component = ctx.RenderComponent<UserAvatar>();
+
+        var avatar = component.Find($"[data-testid='{nameof(UserAvatar.Elements.UserAvatar)}']");
+        avatar.ClassList.ShouldContain("user-avatar");
+    }
+
+    private static TestContext CreateContext(string? username, Employee? employee)
+    {
+        var ctx = new TestContext();
+        var authProvider = new CustomAuthenticationStateProvider();
+        if (username != null)
+            authProvider.Login(username);
+
+        ctx.Services.AddSingleton(authProvider);
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(employee));
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        return ctx;
+    }
+
+    private sealed class StubUserSession(Employee? employee) : IUserSession
+    {
+        public Task<Employee?> GetCurrentUserAsync() => Task.FromResult(employee);
+    }
+}

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -158,6 +158,43 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void ShouldRenderUserAvatarInHeader_WhenAuthenticated()
+    {
+        using var ctx = CreateContext(authenticateAsUser: "hsimpson");
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        layout.Find($"[data-testid='{nameof(UserAvatar.Elements.UserAvatar)}']").ShouldNotBeNull();
+    }
+
+    [Test]
+    public void ShouldNotRenderUserAvatarInHeader_WhenUnauthenticated()
+    {
+        using var ctx = CreateContext();
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        layout.FindAll($"[data-testid='{nameof(UserAvatar.Elements.UserAvatar)}']").Count.ShouldBe(0);
+    }
+
+    [Test]
+    public void ShouldPlaceAvatarLeftOfWelcomeText()
+    {
+        using var ctx = CreateContext(authenticateAsUser: "hsimpson");
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var userSection = layout.Find(".user-section");
+        var children = userSection.Children;
+        children[0].GetAttribute("data-testid").ShouldBe(nameof(UserAvatar.Elements.UserAvatar));
+        children[1].GetAttribute("data-testid").ShouldBe(nameof(Logout.Elements.WelcomeText));
+        children[2].GetAttribute("data-testid").ShouldBe(nameof(Logout.Elements.LogoutLink));
+    }
+
+    [Test]
     public void ShouldPreserveLoginLinkInteraction_Unchanged()
     {
         using var ctx = CreateContext();
@@ -270,7 +307,7 @@ public class MainLayoutTests
 
         ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
         ctx.Services.AddSingleton<IBus>(new StubBus());
-        ctx.Services.AddSingleton<IUserSession>(new StubUserSession());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(authenticateAsUser));
         ctx.Services.AddSingleton<IJSRuntime>(ctx.JSInterop.JSRuntime);
         ctx.Services.AddSingleton<ThemePreferenceService>();
         var customAuth = new CustomAuthenticationStateProvider();
@@ -283,8 +320,17 @@ public class MainLayoutTests
         return ctx;
     }
 
-    private sealed class StubUserSession : IUserSession
+    private sealed class StubUserSession(string? username = null) : IUserSession
     {
-        public Task<Employee?> GetCurrentUserAsync() => Task.FromResult<Employee?>(null);
+        public Task<Employee?> GetCurrentUserAsync()
+        {
+            if (username == "hsimpson")
+            {
+                return Task.FromResult<Employee?>(
+                    new Employee("hsimpson", "Homer", "Simpson", "homer@test.com"));
+            }
+
+            return Task.FromResult<Employee?>(null);
+        }
     }
 }

--- a/src/UnitTests/UI.Shared/UserAvatarInitialsHelperTests.cs
+++ b/src/UnitTests/UI.Shared/UserAvatarInitialsHelperTests.cs
@@ -1,0 +1,70 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.UI.Shared;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared;
+
+[TestFixture]
+public class UserAvatarInitialsHelperTests
+{
+    [Test]
+    public void GetInitials_WithFirstAndLastName_ReturnsUppercaseInitials()
+    {
+        var employee = new Employee("jdoe", "Jane", "Doe", "jane@example.com");
+
+        UserAvatarInitialsHelper.GetInitials(employee, "jdoe").ShouldBe("JD");
+    }
+
+    [Test]
+    public void GetInitials_WithSingleName_ReturnsSingleInitial()
+    {
+        var employee = new Employee("homer", "Homer", "", "homer@example.com");
+
+        UserAvatarInitialsHelper.GetInitials(employee, "homer").ShouldBe("H");
+    }
+
+    [Test]
+    public void GetInitials_WithNoEmployee_UseUsernameFirstTwoChars()
+    {
+        UserAvatarInitialsHelper.GetInitials(null, "hsimpson").ShouldBe("HS");
+    }
+
+    [Test]
+    public void GetInitials_WithNullUsernameAndNoEmployee_ReturnsEmptyString()
+    {
+        UserAvatarInitialsHelper.GetInitials(null, null).ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public void GetBackgroundColor_SameUsername_ReturnsDeterministicColor()
+    {
+        var first = UserAvatarInitialsHelper.GetBackgroundColor("hsimpson");
+        var second = UserAvatarInitialsHelper.GetBackgroundColor("hsimpson");
+
+        first.ShouldBe(second);
+        first.ShouldStartWith("hsl(");
+    }
+
+    [Test]
+    public void GetBackgroundColor_DifferentUsernames_ReturnsDifferentColors()
+    {
+        var homer = UserAvatarInitialsHelper.GetBackgroundColor("hsimpson");
+        var marge = UserAvatarInitialsHelper.GetBackgroundColor("mbouvier");
+
+        homer.ShouldNotBe(marge);
+    }
+
+    [Test]
+    public void GetDisplayName_WithEmployee_ReturnsFullName()
+    {
+        var employee = new Employee("jdoe", "Jane", "Doe", "jane@example.com");
+
+        UserAvatarInitialsHelper.GetDisplayName(employee, "jdoe").ShouldBe("Signed in as Jane Doe");
+    }
+
+    [Test]
+    public void GetDisplayName_WithoutEmployee_ReturnsUsernameOnly()
+    {
+        UserAvatarInitialsHelper.GetDisplayName(null, "hsimpson").ShouldBe("Signed in as hsimpson");
+    }
+}


### PR DESCRIPTION
## Summary
Adds a circular avatar badge with user initials to the top navigation header, placed left of the welcome text and Logout link.

## Files
- `src/UI.Shared/UserAvatarInitialsHelper.cs` — initials, display name, deterministic background color
- `src/UI.Shared/Components/UserAvatar.razor` — non-interactive avatar badge
- `src/UI.Shared/Components/Logout.razor` — embeds UserAvatar
- `src/UI.Shared/MainLayout.razor.css` — avatar styling (light/dark, narrow viewport)
- Unit tests: `UserAvatarInitialsHelperTests`, `UserAvatarTests`, extended `MainLayoutTests`/`LogoutTests`
- Acceptance tests: `HeaderAvatarTests`

## Testing
- `./PrivateBuild.ps1` — green (unit + integration)
- Avatar shows JD for Jane Doe, single-name initial, username fallback HS
- Hidden when unauthenticated; aria-label "Signed in as ..."

Closes #7323