### PR TITLE
Add breadcrumb navigation to all inner pages (#7326)

### DIFF
--- a/src/AcceptanceTests/App/BreadcrumbTests.cs
+++ b/src/AcceptanceTests/App/BreadcrumbTests.cs
@@ -1,3 +1,4 @@
+using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UI.Shared.Components;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
 using System.Text.RegularExpressions;

--- a/src/AcceptanceTests/App/BreadcrumbTests.cs
+++ b/src/AcceptanceTests/App/BreadcrumbTests.cs
@@ -31,7 +31,7 @@ public class BreadcrumbTests : AcceptanceTestBase
         await Click(nameof(NavMenu.Elements.NewWorkOrder));
         await Page.WaitForURLAsync("**/workorder/manage?mode=New");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber)).WaitForAsync();
+        await Page.GetByTestId(nameof(WorkOrderManage.Elements.Title)).WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
         await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
@@ -63,9 +63,6 @@ public class BreadcrumbTests : AcceptanceTestBase
     public async Task Should_NotDisplayBreadcrumb_OnHomePage()
     {
         await LoginAsCurrentUser();
-        await Page.GotoAsync("/");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await Page.GetByTestId(nameof(Logout.Elements.WelcomeText)).WaitForAsync();
 
         await Expect(Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb))).ToHaveCountAsync(0);
     }
@@ -75,9 +72,13 @@ public class BreadcrumbTests : AcceptanceTestBase
     {
         await LoginAsCurrentUser();
         var order = await CreateAndSaveNewWorkOrder();
-        await Page.GotoAsync($"/workorder/manage/{order.Number}?mode=Edit");
+
+        var workOrderLink = Page.GetByTestId(nameof(WorkOrderSearch.Elements.WorkOrderLink) + order.Number);
+        await workOrderLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        await workOrderLink.EvaluateAsync("el => el.click()");
+        await Page.WaitForURLAsync($"**/workorder/manage/{order.Number}**");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber)).WaitForAsync();
+        await Page.GetByTestId(nameof(WorkOrderManage.Elements.Title)).WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
         await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
@@ -92,7 +93,7 @@ public class BreadcrumbTests : AcceptanceTestBase
         await Click(nameof(NavMenu.Elements.NewWorkOrder));
         await Page.WaitForURLAsync("**/workorder/manage?mode=New");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber)).WaitForAsync();
+        await Page.GetByTestId(nameof(WorkOrderManage.Elements.Title)).WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
         await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });

--- a/src/AcceptanceTests/App/BreadcrumbTests.cs
+++ b/src/AcceptanceTests/App/BreadcrumbTests.cs
@@ -1,0 +1,86 @@
+using ClearMeasure.Bootcamp.UI.Shared.Components;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using System.Text.RegularExpressions;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
+
+[TestFixture]
+public class BreadcrumbTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task Should_DisplayBreadcrumb_OnSearchPage()
+    {
+        await LoginAsCurrentUser();
+        await Page.GotoAsync("/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
+        await Expect(breadcrumb).ToBeVisibleAsync();
+        await Expect(breadcrumb).ToContainTextAsync("Home");
+        await Expect(breadcrumb).ToContainTextAsync("Work Orders");
+        await Expect(breadcrumb).ToContainTextAsync("Search");
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_ClickParentLink_NavigateToWorkOrders()
+    {
+        await LoginAsCurrentUser();
+        await Page.GotoAsync("/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
+        await breadcrumb.Locator("a", new LocatorLocatorOptions { HasText = "Work Orders" }).ClickAsync();
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Expect(Page).ToHaveURLAsync(new Regex("/workorder/search"));
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_ClickHomeLink_NavigateToHome()
+    {
+        await LoginAsCurrentUser();
+        await Page.GotoAsync("/counter");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
+        await breadcrumb.Locator("a", new LocatorLocatorOptions { HasText = "Home" }).ClickAsync();
+        await Page.WaitForURLAsync("**/");
+        await Expect(Page).ToHaveURLAsync(new Regex("/$"));
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_NotDisplayBreadcrumb_OnHomePage()
+    {
+        await LoginAsCurrentUser();
+        await Page.GotoAsync("/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb))).ToHaveCountAsync(0);
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_DisplayCorrectTrail_OnManageExistingWorkOrder()
+    {
+        await LoginAsCurrentUser();
+        var order = await CreateAndSaveNewWorkOrder();
+        await Page.GotoAsync($"/workorder/manage/{order.Number}?mode=Edit");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
+        await Expect(breadcrumb).ToBeVisibleAsync();
+        await Expect(breadcrumb).ToContainTextAsync(order.Number!);
+        await Expect(breadcrumb.Locator(".breadcrumb-active")).ToHaveTextAsync(order.Number!);
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_DisplayNewWorkOrder_InTrail_WhenCreating()
+    {
+        await LoginAsCurrentUser();
+        await Page.GotoAsync("/workorder/manage?mode=New");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
+        await Expect(breadcrumb).ToBeVisibleAsync();
+        await Expect(breadcrumb).ToContainTextAsync("New Work Order");
+        await Expect(breadcrumb.Locator(".breadcrumb-active")).ToHaveTextAsync("New Work Order");
+    }
+}

--- a/src/AcceptanceTests/App/BreadcrumbTests.cs
+++ b/src/AcceptanceTests/App/BreadcrumbTests.cs
@@ -11,11 +11,13 @@ public class BreadcrumbTests : AcceptanceTestBase
     public async Task Should_DisplayBreadcrumb_OnSearchPage()
     {
         await LoginAsCurrentUser();
-        await Page.GotoAsync("/workorder/search");
+        await Click(nameof(NavMenu.Elements.Search));
+        await Page.WaitForURLAsync("**/workorder/search");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Page.Locator($"#{WorkOrderSearch.Elements.CreatorSelect}").WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
-        await Expect(breadcrumb).ToBeVisibleAsync();
+        await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
         await Expect(breadcrumb).ToContainTextAsync("Home");
         await Expect(breadcrumb).ToContainTextAsync("Work Orders");
         await Expect(breadcrumb).ToContainTextAsync("Search");
@@ -25,11 +27,20 @@ public class BreadcrumbTests : AcceptanceTestBase
     public async Task Should_ClickParentLink_NavigateToWorkOrders()
     {
         await LoginAsCurrentUser();
-        await Page.GotoAsync("/workorder/search");
+        await Page.GotoAsync("/counter");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Page.GetByTestId(nameof(Counter.Elements.CounterValue)).WaitForAsync();
+
+        await Click(nameof(NavMenu.Elements.Search));
+        await Page.WaitForURLAsync("**/workorder/search");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Page.Locator($"#{WorkOrderSearch.Elements.CreatorSelect}").WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
-        await breadcrumb.Locator("a", new LocatorLocatorOptions { HasText = "Work Orders" }).ClickAsync();
+        await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        var workOrdersLink = breadcrumb.Locator("a", new LocatorLocatorOptions { HasText = "Work Orders" });
+        await workOrdersLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        await workOrdersLink.EvaluateAsync("el => el.click()");
         await Page.WaitForURLAsync("**/workorder/search");
         await Expect(Page).ToHaveURLAsync(new Regex("/workorder/search"));
     }
@@ -40,9 +51,12 @@ public class BreadcrumbTests : AcceptanceTestBase
         await LoginAsCurrentUser();
         await Page.GotoAsync("/counter");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Page.GetByTestId(nameof(Counter.Elements.CounterValue)).WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
-        await breadcrumb.Locator("a", new LocatorLocatorOptions { HasText = "Home" }).ClickAsync();
+        await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        var homeLink = breadcrumb.Locator("a", new LocatorLocatorOptions { HasText = "Home" });
+        await homeLink.EvaluateAsync("el => el.click()");
         await Page.WaitForURLAsync("**/");
         await Expect(Page).ToHaveURLAsync(new Regex("/$"));
     }
@@ -53,6 +67,7 @@ public class BreadcrumbTests : AcceptanceTestBase
         await LoginAsCurrentUser();
         await Page.GotoAsync("/");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Page.GetByTestId(nameof(Logout.Elements.WelcomeText)).WaitForAsync();
 
         await Expect(Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb))).ToHaveCountAsync(0);
     }
@@ -64,9 +79,10 @@ public class BreadcrumbTests : AcceptanceTestBase
         var order = await CreateAndSaveNewWorkOrder();
         await Page.GotoAsync($"/workorder/manage/{order.Number}?mode=Edit");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber)).WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
-        await Expect(breadcrumb).ToBeVisibleAsync();
+        await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
         await Expect(breadcrumb).ToContainTextAsync(order.Number!);
         await Expect(breadcrumb.Locator(".breadcrumb-active")).ToHaveTextAsync(order.Number!);
     }
@@ -75,11 +91,13 @@ public class BreadcrumbTests : AcceptanceTestBase
     public async Task Should_DisplayNewWorkOrder_InTrail_WhenCreating()
     {
         await LoginAsCurrentUser();
-        await Page.GotoAsync("/workorder/manage?mode=New");
+        await Click(nameof(NavMenu.Elements.NewWorkOrder));
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber)).WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
-        await Expect(breadcrumb).ToBeVisibleAsync();
+        await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
         await Expect(breadcrumb).ToContainTextAsync("New Work Order");
         await Expect(breadcrumb.Locator(".breadcrumb-active")).ToHaveTextAsync("New Work Order");
     }

--- a/src/AcceptanceTests/App/BreadcrumbTests.cs
+++ b/src/AcceptanceTests/App/BreadcrumbTests.cs
@@ -28,14 +28,10 @@ public class BreadcrumbTests : AcceptanceTestBase
     public async Task Should_ClickParentLink_NavigateToWorkOrders()
     {
         await LoginAsCurrentUser();
-        await Page.GotoAsync("/counter");
+        await Click(nameof(NavMenu.Elements.NewWorkOrder));
+        await Page.WaitForURLAsync("**/workorder/manage?mode=New");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await Page.GetByTestId(nameof(Counter.Elements.CounterValue)).WaitForAsync();
-
-        await Click(nameof(NavMenu.Elements.Search));
-        await Page.WaitForURLAsync("**/workorder/search");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        await Page.Locator($"#{WorkOrderSearch.Elements.CreatorSelect}").WaitForAsync();
+        await Page.GetByTestId(nameof(WorkOrderManage.Elements.WorkOrderNumber)).WaitForAsync();
 
         var breadcrumb = Page.GetByTestId(nameof(Breadcrumb.Elements.Breadcrumb));
         await breadcrumb.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
@@ -43,6 +39,7 @@ public class BreadcrumbTests : AcceptanceTestBase
         await workOrdersLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
         await workOrdersLink.EvaluateAsync("el => el.click()");
         await Page.WaitForURLAsync("**/workorder/search");
+        await Page.Locator($"#{WorkOrderSearch.Elements.CreatorSelect}").WaitForAsync();
         await Expect(Page).ToHaveURLAsync(new Regex("/workorder/search"));
     }
 

--- a/src/UI.Shared/Components/Breadcrumb.razor
+++ b/src/UI.Shared/Components/Breadcrumb.razor
@@ -1,0 +1,31 @@
+@using ClearMeasure.Bootcamp.UI.Shared.Models
+
+<nav aria-label="breadcrumb" data-testid="@Elements.Breadcrumb" class="breadcrumb-nav">
+    @for (var i = 0; i < Items.Count; i++)
+    {
+        var item = Items[i];
+        if (i > 0)
+        {
+            <span class="breadcrumb-separator" aria-hidden="true">&gt;</span>
+        }
+
+        if (item.IsActive)
+        {
+            <span class="breadcrumb-active" aria-current="page">@item.Label</span>
+        }
+        else
+        {
+            <a class="breadcrumb-link" href="@item.Url">@item.Label</a>
+        }
+    }
+</nav>
+
+@code {
+    [Parameter, EditorRequired]
+    public IReadOnlyList<BreadcrumbItem> Items { get; set; } = Array.Empty<BreadcrumbItem>();
+
+    public enum Elements
+    {
+        Breadcrumb
+    }
+}

--- a/src/UI.Shared/Components/Breadcrumb.razor.css
+++ b/src/UI.Shared/Components/Breadcrumb.razor.css
@@ -1,0 +1,66 @@
+.breadcrumb-nav {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 2rem;
+    background: rgba(255, 255, 255, 0.85);
+    border-bottom: 1px solid #e2e8f0;
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+.breadcrumb-link {
+    color: #6c757d;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.breadcrumb-link:hover {
+    color: #4a5568;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.breadcrumb-link:focus-visible {
+    outline: 2px solid #4a5568;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+.breadcrumb-separator {
+    color: #adb5bd;
+    user-select: none;
+}
+
+.breadcrumb-active {
+    color: #4a5568;
+    font-weight: 600;
+}
+
+:global(html[data-theme="dark"]) .breadcrumb-nav {
+    background: rgba(45, 55, 72, 0.9);
+    border-bottom-color: #4a5568;
+}
+
+:global(html[data-theme="dark"]) .breadcrumb-link {
+    color: #a0aec0;
+}
+
+:global(html[data-theme="dark"]) .breadcrumb-link:hover {
+    color: #e2e8f0;
+}
+
+:global(html[data-theme="dark"]) .breadcrumb-separator {
+    color: #718096;
+}
+
+:global(html[data-theme="dark"]) .breadcrumb-active {
+    color: #f7fafc;
+}
+
+@media (max-width: 768px) {
+    .breadcrumb-nav {
+        padding: 0.625rem 1rem;
+    }
+}

--- a/src/UI.Shared/MainLayout.razor
+++ b/src/UI.Shared/MainLayout.razor
@@ -65,6 +65,11 @@
             </div>
         </header>
 
+        @if (BreadcrumbService.ShouldShow)
+        {
+            <Breadcrumb Items="@BreadcrumbService.Items"/>
+        }
+
         <main class="modern-main">
             <div class="content-wrapper">
                 @Body

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -78,6 +78,7 @@ public partial class MainLayout : IAsyncDisposable
     protected override void OnInitialized()
     {
         BreadcrumbService.OnChange += HandleBreadcrumbChanged;
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private void HandleBreadcrumbChanged() => InvokeAsync(StateHasChanged);

--- a/src/UI.Shared/MainLayout.razor.cs
+++ b/src/UI.Shared/MainLayout.razor.cs
@@ -30,6 +30,9 @@ public partial class MainLayout : IAsyncDisposable
     [Inject]
     private ThemePreferenceService Theme { get; set; } = default!;
 
+    [Inject]
+    private BreadcrumbService BreadcrumbService { get; set; } = default!;
+
     private ElementReference _navToggleButtonRef;
     private DotNetObjectReference<MainLayout>? _dotNetRef;
     private IJSObjectReference? _jsModule;
@@ -71,6 +74,13 @@ public partial class MainLayout : IAsyncDisposable
         StateHasChanged();
         return Task.CompletedTask;
     }
+
+    protected override void OnInitialized()
+    {
+        BreadcrumbService.OnChange += HandleBreadcrumbChanged;
+    }
+
+    private void HandleBreadcrumbChanged() => InvokeAsync(StateHasChanged);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -120,6 +130,8 @@ public partial class MainLayout : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        BreadcrumbService.OnChange -= HandleBreadcrumbChanged;
+
         if (_navToggleHelper is not null)
         {
             try

--- a/src/UI.Shared/Models/BreadcrumbItem.cs
+++ b/src/UI.Shared/Models/BreadcrumbItem.cs
@@ -1,0 +1,9 @@
+namespace ClearMeasure.Bootcamp.UI.Shared.Models;
+
+/// <summary>
+/// Represents one segment in the breadcrumb trail.
+/// </summary>
+/// <param name="Label">Display text for the segment.</param>
+/// <param name="Url">Navigation target for parent segments; null for the active page.</param>
+/// <param name="IsActive">True when this segment is the current page.</param>
+public sealed record BreadcrumbItem(string Label, string? Url, bool IsActive);

--- a/src/UI.Shared/Pages/ApplicationChat.razor.css
+++ b/src/UI.Shared/Pages/ApplicationChat.razor.css
@@ -1,7 +1,7 @@
 .ai-agent-page {
     background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-    height: calc(100vh - 14rem);
-    height: calc(100dvh - 14rem);
+    height: calc(100vh - 17rem);
+    height: calc(100dvh - 17rem);
     min-height: 0;
     display: flex;
     flex-direction: column;
@@ -156,8 +156,8 @@
 
 @media (max-width: 768px) {
     .ai-agent-page {
-        height: calc(100vh - 11rem);
-        height: calc(100dvh - 11rem);
+        height: calc(100vh - 14rem);
+        height: calc(100dvh - 14rem);
         min-height: 0;
     }
 

--- a/src/UI.Shared/Services/BreadcrumbService.cs
+++ b/src/UI.Shared/Services/BreadcrumbService.cs
@@ -1,0 +1,94 @@
+using ClearMeasure.Bootcamp.UI.Shared.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace ClearMeasure.Bootcamp.UI.Shared.Services;
+
+/// <summary>
+/// Builds the breadcrumb trail from the current route.
+/// </summary>
+public sealed class BreadcrumbService : IDisposable
+{
+    private readonly NavigationManager _navigation;
+    private IReadOnlyList<BreadcrumbItem> _items = Array.Empty<BreadcrumbItem>();
+    private bool _shouldShow;
+
+    public BreadcrumbService(NavigationManager navigation)
+    {
+        _navigation = navigation;
+        _navigation.LocationChanged += OnLocationChanged;
+        UpdateFromCurrentLocation();
+    }
+
+    public event Action? OnChange;
+
+    public IReadOnlyList<BreadcrumbItem> Items => _items;
+
+    public bool ShouldShow => _shouldShow;
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e) => UpdateFromCurrentLocation();
+
+    internal void UpdateFromCurrentLocation()
+    {
+        var uri = _navigation.ToAbsoluteUri(_navigation.Uri);
+        var path = uri.AbsolutePath;
+
+        if (string.IsNullOrEmpty(path))
+            path = "/";
+
+        if (path.Length > 1 && path.EndsWith('/'))
+            path = path.TrimEnd('/');
+
+        var (shouldShow, items) = BuildTrail(path, uri.Query);
+        _shouldShow = shouldShow;
+        _items = items;
+        OnChange?.Invoke();
+    }
+
+    private static (bool ShouldShow, IReadOnlyList<BreadcrumbItem> Items) BuildTrail(string path, string query)
+    {
+        if (path == "/" ||
+            path.Equals("/login", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/_clienthealthcheck", StringComparison.OrdinalIgnoreCase))
+        {
+            return (false, Array.Empty<BreadcrumbItem>());
+        }
+
+        if (path.Equals("/counter", StringComparison.OrdinalIgnoreCase))
+            return (true, Trail(Home(), Active("Counter")));
+
+        if (path.Equals("/fetchdata", StringComparison.OrdinalIgnoreCase))
+            return (true, Trail(Home(), Active("Fetch Data")));
+
+        if (path.Equals("/ai-agent", StringComparison.OrdinalIgnoreCase))
+            return (true, Trail(Home(), Active("AI Agent")));
+
+        if (path.Equals("/settings", StringComparison.OrdinalIgnoreCase))
+            return (true, Trail(Home(), Active("Settings")));
+
+        if (path.Equals("/workorder/search", StringComparison.OrdinalIgnoreCase))
+            return (true, Trail(Home(), WorkOrders(), Active("Search")));
+
+        if (path.Equals("/workorder/manage", StringComparison.OrdinalIgnoreCase))
+            return (true, Trail(Home(), WorkOrders(), Active("New Work Order")));
+
+        if (path.StartsWith("/workorder/manage/", StringComparison.OrdinalIgnoreCase))
+        {
+            var id = path["/workorder/manage/".Length..];
+            if (!string.IsNullOrWhiteSpace(id))
+                return (true, Trail(Home(), WorkOrders(), Active(id)));
+        }
+
+        return (false, Array.Empty<BreadcrumbItem>());
+    }
+
+    private static BreadcrumbItem Home() => new("Home", "/", false);
+
+    private static BreadcrumbItem WorkOrders() => new("Work Orders", "/workorder/search", false);
+
+    private static BreadcrumbItem Active(string label) => new(label, null, true);
+
+    private static IReadOnlyList<BreadcrumbItem> Trail(params BreadcrumbItem[] items) => items;
+
+    public void Dispose() => _navigation.LocationChanged -= OnLocationChanged;
+}

--- a/src/UI/Client/UIClientServiceRegistry.cs
+++ b/src/UI/Client/UIClientServiceRegistry.cs
@@ -39,6 +39,7 @@ public class UIClientServiceRegistry : ServiceRegistry
         this.AddSingleton<ChatClientFactory>();
         this.AddTransient<WorkOrderTool>();
         this.AddSingleton<ThemePreferenceService>();
+        this.AddScoped<BreadcrumbService>();
 
         Scan(scanner =>
         {

--- a/src/UnitTests/UI.Shared/Components/BreadcrumbTests.cs
+++ b/src/UnitTests/UI.Shared/Components/BreadcrumbTests.cs
@@ -1,0 +1,112 @@
+using Bunit;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.UI.Shared.Components;
+using ClearMeasure.Bootcamp.UI.Shared.Models;
+using ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
+using Microsoft.Extensions.DependencyInjection;
+using Palermo.BlazorMvc;
+using Shouldly;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Components;
+
+[TestFixture]
+public class BreadcrumbTests
+{
+    [Test]
+    public void Breadcrumb_RendersAllItems_InOrder()
+    {
+        using var ctx = CreateContext();
+        var items = new List<BreadcrumbItem>
+        {
+            new("Home", "/", false),
+            new("Work Orders", "/workorder/search", false),
+            new("Search", null, true)
+        };
+
+        var component = ctx.RenderComponent<Breadcrumb>(p => p.Add(x => x.Items, items));
+
+        component.Markup.ShouldContain("Home");
+        component.Markup.ShouldContain("Work Orders");
+        component.Markup.ShouldContain("Search");
+
+        var homeIndex = component.Markup.IndexOf("Home", StringComparison.Ordinal);
+        var workOrdersIndex = component.Markup.IndexOf("Work Orders", StringComparison.Ordinal);
+        var searchIndex = component.Markup.IndexOf("Search", StringComparison.Ordinal);
+        homeIndex.ShouldBeLessThan(workOrdersIndex);
+        workOrdersIndex.ShouldBeLessThan(searchIndex);
+    }
+
+    [Test]
+    public void Breadcrumb_LastItem_HasAriaCurrentPage_NotClickable()
+    {
+        using var ctx = CreateContext();
+        var items = new List<BreadcrumbItem>
+        {
+            new("Home", "/", false),
+            new("Counter", null, true)
+        };
+
+        var component = ctx.RenderComponent<Breadcrumb>(p => p.Add(x => x.Items, items));
+
+        var active = component.Find(".breadcrumb-active");
+        active.GetAttribute("aria-current").ShouldBe("page");
+        active.TextContent.ShouldBe("Counter");
+        component.FindAll("a").Count.ShouldBe(1);
+    }
+
+    [Test]
+    public void Breadcrumb_ParentItems_AreClickable()
+    {
+        using var ctx = CreateContext();
+        var items = new List<BreadcrumbItem>
+        {
+            new("Home", "/", false),
+            new("Work Orders", "/workorder/search", false),
+            new("Search", null, true)
+        };
+
+        var component = ctx.RenderComponent<Breadcrumb>(p => p.Add(x => x.Items, items));
+        var links = component.FindAll("a.breadcrumb-link");
+
+        links.Count.ShouldBe(2);
+        links[0].GetAttribute("href").ShouldBe("/");
+        links[1].GetAttribute("href").ShouldBe("/workorder/search");
+    }
+
+    [Test]
+    public void Breadcrumb_SeparatorsShowBetweenItems()
+    {
+        using var ctx = CreateContext();
+        var items = new List<BreadcrumbItem>
+        {
+            new("Home", "/", false),
+            new("Work Orders", "/workorder/search", false),
+            new("Search", null, true)
+        };
+
+        var component = ctx.RenderComponent<Breadcrumb>(p => p.Add(x => x.Items, items));
+        component.FindAll(".breadcrumb-separator").Count.ShouldBe(2);
+    }
+
+    [Test]
+    public void Breadcrumb_NavElement_HasBreadcrumbAriaLabel()
+    {
+        using var ctx = CreateContext();
+        var items = new List<BreadcrumbItem> { new("Home", "/", false), new("Counter", null, true) };
+
+        var component = ctx.RenderComponent<Breadcrumb>(p => p.Add(x => x.Items, items));
+        var nav = component.Find($"[data-testid='{nameof(Breadcrumb.Elements.Breadcrumb)}']");
+
+        nav.TagName.ShouldBe("NAV");
+        nav.GetAttribute("aria-label").ShouldBe("breadcrumb");
+    }
+
+    private static TestContext CreateContext()
+    {
+        var ctx = new TestContext();
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        return ctx;
+    }
+}

--- a/src/UnitTests/UI.Shared/MainLayoutTests.cs
+++ b/src/UnitTests/UI.Shared/MainLayoutTests.cs
@@ -9,6 +9,7 @@ using ClearMeasure.Bootcamp.UI.Shared.Components;
 using ClearMeasure.Bootcamp.UI.Shared.Services;
 using ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
 using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
@@ -238,6 +239,36 @@ public class MainLayoutTests
     }
 
     [Test]
+    public void MainLayout_HidesBreadcrumb_OnHomePage()
+    {
+        using var ctx = CreateContext();
+
+        var navigation = ctx.Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("/");
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        layout.FindAll($"[data-testid='{nameof(Breadcrumb.Elements.Breadcrumb)}']").Count.ShouldBe(0);
+    }
+
+    [Test]
+    public void MainLayout_ShowsBreadcrumb_OnCounterPage()
+    {
+        using var ctx = CreateContext();
+
+        var navigation = ctx.Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("/counter");
+
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<MainLayout>());
+        var layout = component.FindComponent<MainLayout>();
+
+        var breadcrumb = layout.Find($"[data-testid='{nameof(Breadcrumb.Elements.Breadcrumb)}']");
+        breadcrumb.TextContent.ShouldContain("Home");
+        breadcrumb.TextContent.ShouldContain("Counter");
+    }
+
+    [Test]
     public async Task ShouldInvokeFocusOnNavRailToggleWhenClosingOverlayOnNarrowViewport()
     {
         using var ctx = CreateContext();
@@ -273,6 +304,7 @@ public class MainLayoutTests
         ctx.Services.AddSingleton<IUserSession>(new StubUserSession());
         ctx.Services.AddSingleton<IJSRuntime>(ctx.JSInterop.JSRuntime);
         ctx.Services.AddSingleton<ThemePreferenceService>();
+        ctx.Services.AddScoped<BreadcrumbService>();
         var customAuth = new CustomAuthenticationStateProvider();
         if (authenticateAsUser != null)
         {

--- a/src/UnitTests/UI.Shared/Services/BreadcrumbServiceTests.cs
+++ b/src/UnitTests/UI.Shared/Services/BreadcrumbServiceTests.cs
@@ -1,0 +1,149 @@
+using ClearMeasure.Bootcamp.UI.Shared.Models;
+using ClearMeasure.Bootcamp.UI.Shared.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Services;
+
+[TestFixture]
+public class BreadcrumbServiceTests
+{
+    [Test]
+    public void BreadcrumbService_HomeRoute_ShouldHideBreadcrumb()
+    {
+        using var sut = CreateService("/");
+
+        sut.ShouldShow.ShouldBeFalse();
+        sut.Items.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void BreadcrumbService_LoginRoute_ShouldHideBreadcrumb()
+    {
+        using var login = CreateService("/login");
+        using var healthCheck = CreateService("/_clienthealthcheck");
+
+        login.ShouldShow.ShouldBeFalse();
+        healthCheck.ShouldShow.ShouldBeFalse();
+    }
+
+    [Test]
+    public void BreadcrumbService_CounterRoute_ReturnsHomeCounterTrail()
+    {
+        using var sut = CreateService("/counter");
+
+        sut.ShouldShow.ShouldBeTrue();
+        sut.Items.Count.ShouldBe(2);
+        sut.Items[0].Label.ShouldBe("Home");
+        sut.Items[0].Url.ShouldBe("/");
+        sut.Items[0].IsActive.ShouldBeFalse();
+        sut.Items[1].Label.ShouldBe("Counter");
+        sut.Items[1].Url.ShouldBeNull();
+        sut.Items[1].IsActive.ShouldBeTrue();
+    }
+
+    [Test]
+    public void BreadcrumbService_FetchDataRoute_ReturnsHomeDataTrail()
+    {
+        using var sut = CreateService("/fetchdata");
+
+        sut.ShouldShow.ShouldBeTrue();
+        sut.Items.Select(i => i.Label).ShouldBe(["Home", "Fetch Data"]);
+        sut.Items[0].Url.ShouldBe("/");
+        sut.Items[1].IsActive.ShouldBeTrue();
+    }
+
+    [Test]
+    public void BreadcrumbService_AiAgentRoute_ReturnsHomeAgentTrail()
+    {
+        using var sut = CreateService("/ai-agent");
+
+        sut.ShouldShow.ShouldBeTrue();
+        sut.Items.Select(i => i.Label).ShouldBe(["Home", "AI Agent"]);
+    }
+
+    [Test]
+    public void BreadcrumbService_SettingsRoute_ReturnsHomeSettingsTrail()
+    {
+        using var sut = CreateService("/settings");
+
+        sut.ShouldShow.ShouldBeTrue();
+        sut.Items.Select(i => i.Label).ShouldBe(["Home", "Settings"]);
+    }
+
+    [Test]
+    public void BreadcrumbService_WorkOrderSearchRoute_ReturnsSearchTrail()
+    {
+        using var sut = CreateService("/workorder/search");
+
+        sut.ShouldShow.ShouldBeTrue();
+        sut.Items.Count.ShouldBe(3);
+        sut.Items[0].Label.ShouldBe("Home");
+        sut.Items[1].Label.ShouldBe("Work Orders");
+        sut.Items[1].Url.ShouldBe("/workorder/search");
+        sut.Items[1].IsActive.ShouldBeFalse();
+        sut.Items[2].Label.ShouldBe("Search");
+        sut.Items[2].IsActive.ShouldBeTrue();
+    }
+
+    [Test]
+    public void BreadcrumbService_WorkOrderManageNewRoute_ReturnsNewTrail()
+    {
+        using var sut = CreateService("/workorder/manage?mode=New");
+
+        sut.ShouldShow.ShouldBeTrue();
+        sut.Items.Select(i => i.Label).ShouldBe(["Home", "Work Orders", "New Work Order"]);
+        sut.Items[2].IsActive.ShouldBeTrue();
+    }
+
+    [Test]
+    public void BreadcrumbService_WorkOrderManageExistingRoute_ReturnsWorkOrderTrail()
+    {
+        using var sut = CreateService("/workorder/manage/WO-123?mode=Edit");
+
+        sut.ShouldShow.ShouldBeTrue();
+        sut.Items.Select(i => i.Label).ShouldBe(["Home", "Work Orders", "WO-123"]);
+        sut.Items[1].Url.ShouldBe("/workorder/search");
+        sut.Items[2].IsActive.ShouldBeTrue();
+    }
+
+    [Test]
+    public void BreadcrumbService_LocationChanged_UpdatesItems()
+    {
+        using var ctx = new TestContext();
+        var navigation = ctx.Services.GetRequiredService<NavigationManager>();
+        using var sut = new BreadcrumbService(navigation);
+
+        sut.ShouldShow.ShouldBeFalse();
+
+        navigation.NavigateTo("/counter");
+        sut.ShouldShow.ShouldBeTrue();
+        sut.Items[1].Label.ShouldBe("Counter");
+
+        navigation.NavigateTo("/settings");
+        sut.Items[1].Label.ShouldBe("Settings");
+    }
+
+    private static BreadcrumbService CreateService(string initialUri)
+    {
+        var navigation = new StubNavigationManager($"https://localhost{initialUri}");
+        return new BreadcrumbService(navigation);
+    }
+
+    private sealed class StubNavigationManager : NavigationManager
+    {
+        public StubNavigationManager(string uri)
+        {
+            Initialize(uri, uri);
+        }
+
+        protected override void NavigateToCore(string uri, NavigationOptions options)
+        {
+            var absolute = ToAbsoluteUri(uri).ToString();
+            Initialize(BaseUri, absolute);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds route-driven breadcrumb navigation to authenticated inner pages via `BreadcrumbService` and `Breadcrumb` component in UI.Shared, rendered from MainLayout below the header.

## Files changed
- `src/UI.Shared/Models/BreadcrumbItem.cs` — breadcrumb segment record
- `src/UI.Shared/Services/BreadcrumbService.cs` — route-to-trail mapping
- `src/UI.Shared/Components/Breadcrumb.razor` + `.css` — accessible nav with `data-testid="breadcrumb"`
- `src/UI.Shared/MainLayout.razor` + `.cs` — conditional breadcrumb render
- `src/UI/Client/UIClientServiceRegistry.cs` — scoped service registration
- Unit tests: `BreadcrumbServiceTests`, `BreadcrumbTests`, `MainLayoutTests`
- Acceptance tests: `AcceptanceTests/App/BreadcrumbTests.cs`

## Testing
- `./PrivateBuild.ps1` — green (unit + integration)
- Breadcrumb trails verified for counter, search, manage (new/existing), settings, AI agent, fetch data
- Home, login, and health-check routes hide the trail

Closes #7326