### PR TITLE
Add tooltip to all icon buttons showing their action (#7331)

### DIFF
--- a/src/AcceptanceTests/App/HealthCheckLinkAttributeParityTests.cs
+++ b/src/AcceptanceTests/App/HealthCheckLinkAttributeParityTests.cs
@@ -1,0 +1,24 @@
+using ClearMeasure.Bootcamp.UI.Shared.Components;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
+
+[TestFixture]
+public class HealthCheckLinkAttributeParityTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldHaveMatchingTitleAndAriaLabelOnHealthCheckLink()
+    {
+        await Page.GotoAsync("/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var link = Page.GetByTestId(nameof(HealthCheckLink.Elements.HealthCheckLink));
+        await Expect(link).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+
+        var title = await link.GetAttributeAsync("title");
+        var ariaLabel = await link.GetAttributeAsync("aria-label");
+        title.ShouldBe("Health Check");
+        ariaLabel.ShouldBe("Health Check");
+        title.ShouldBe(ariaLabel);
+    }
+}

--- a/src/AcceptanceTests/App/NavRailToggleAttributeParityTests.cs
+++ b/src/AcceptanceTests/App/NavRailToggleAttributeParityTests.cs
@@ -1,0 +1,23 @@
+using ClearMeasure.Bootcamp.UI.Shared;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
+
+[TestFixture]
+public class NavRailToggleAttributeParityTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldHaveMatchingTitleAndAriaLabelOnNavRailToggle()
+    {
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await Task.Delay(GetInputDelayMs());
+
+        var toggle = Page.GetByTestId(nameof(MainLayout.Elements.NavRailToggle));
+        await Expect(toggle).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+
+        var title = await toggle.GetAttributeAsync("title");
+        var ariaLabel = await toggle.GetAttributeAsync("aria-label");
+        title.ShouldNotBeNull();
+        ariaLabel.ShouldNotBeNull();
+        title.ShouldBe(ariaLabel);
+    }
+}

--- a/src/AcceptanceTests/WorkOrders/SpeechDictationAttributeParityTests.cs
+++ b/src/AcceptanceTests/WorkOrders/SpeechDictationAttributeParityTests.cs
@@ -1,0 +1,36 @@
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.WorkOrders;
+
+[TestFixture]
+public class SpeechDictationAttributeParityTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task ShouldHaveMatchingTitleAndAriaLabelOnAllSpeechDictateButtons()
+    {
+        await LoginAsCurrentUser();
+
+        var order = await CreateAndSaveNewWorkOrder();
+        order = await ClickWorkOrderNumberFromSearchPage(order);
+
+        var testIds = new[]
+        {
+            nameof(WorkOrderManage.Elements.SpeakTitle),
+            nameof(WorkOrderManage.Elements.DictateTitle),
+            nameof(WorkOrderManage.Elements.SpeakDescription),
+            nameof(WorkOrderManage.Elements.DictateDescription)
+        };
+
+        foreach (var testId in testIds)
+        {
+            var button = Page.GetByTestId(testId);
+            await Expect(button).ToBeVisibleAsync();
+
+            var title = await button.GetAttributeAsync("title");
+            var ariaLabel = await button.GetAttributeAsync("aria-label");
+            title.ShouldNotBeNull();
+            ariaLabel.ShouldNotBeNull();
+            title.ShouldBe(ariaLabel);
+        }
+    }
+}

--- a/src/UI.Shared/Components/HealthCheckLink.razor
+++ b/src/UI.Shared/Components/HealthCheckLink.razor
@@ -1,4 +1,4 @@
-<a data-testid="@Elements.HealthCheckLink" href="/_clienthealthcheck" class="health-check-link" title="Health Check">
+<a data-testid="@Elements.HealthCheckLink" href="/_clienthealthcheck" class="health-check-link" title="Health Check" aria-label="Health Check">
     <i class="bi bi-gear-fill" aria-hidden="true"></i> Health Check
 </a>
 

--- a/src/UI.Shared/NavMenu.razor
+++ b/src/UI.Shared/NavMenu.razor
@@ -1,7 +1,7 @@
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">Menu</a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
+        <button title="Navigation menu" aria-label="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
             <span class="navbar-toggler-icon"></span>
         </button>
     </div>

--- a/src/UnitTests/UI.Shared/Components/HealthCheckLinkTests.cs
+++ b/src/UnitTests/UI.Shared/Components/HealthCheckLinkTests.cs
@@ -1,0 +1,29 @@
+using Bunit;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.UI.Shared.Components;
+using ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
+using Microsoft.Extensions.DependencyInjection;
+using Palermo.BlazorMvc;
+using Shouldly;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Components;
+
+[TestFixture]
+public class HealthCheckLinkTests
+{
+    [Test]
+    public void ShouldRenderHealthCheckLinkWithTitleAndAriaLabel()
+    {
+        using var ctx = new TestContext();
+
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+
+        var component = ctx.RenderComponent<HealthCheckLink>();
+
+        var link = component.Find($"[data-testid='{nameof(HealthCheckLink.Elements.HealthCheckLink)}']");
+        link.GetAttribute("title").ShouldBe("Health Check");
+        link.GetAttribute("aria-label").ShouldBe("Health Check");
+    }
+}

--- a/src/UnitTests/UI.Shared/NavMenuTests.cs
+++ b/src/UnitTests/UI.Shared/NavMenuTests.cs
@@ -1,0 +1,37 @@
+using Bunit;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Services;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
+using Microsoft.Extensions.DependencyInjection;
+using Palermo.BlazorMvc;
+using Shouldly;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared;
+
+[TestFixture]
+public class NavMenuTests
+{
+    [Test]
+    public void ShouldRenderNavBarTogglerWithTitleAndAriaLabel()
+    {
+        using var ctx = new TestContext();
+
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession());
+
+        var component = ctx.RenderComponent<NavMenu>();
+
+        var toggler = component.Find("button.navbar-toggler");
+        toggler.GetAttribute("title").ShouldBe("Navigation menu");
+        toggler.GetAttribute("aria-label").ShouldBe("Navigation menu");
+    }
+
+    private sealed class StubUserSession : IUserSession
+    {
+        public Task<Employee?> GetCurrentUserAsync() => Task.FromResult<Employee?>(null);
+    }
+}

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageDictationTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageDictationTests.cs
@@ -37,6 +37,21 @@ public class WorkOrderManageDictationTests
     }
 
     [Test]
+    public void ShouldAssertDictateTitleButtonHasMatchingTitleAndAriaLabel()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateTitle}']");
+            element.GetAttribute("title").ShouldBe("Dictate title");
+            element.GetAttribute("aria-label").ShouldBe("Dictate title");
+        });
+    }
+
+    [Test]
     public void ShouldRenderDictateDescriptionButton()
     {
         using var ctx = CreateTestContext(out _);
@@ -50,6 +65,21 @@ public class WorkOrderManageDictationTests
             element.TagName.ShouldBe("BUTTON", StringCompareShould.IgnoreCase);
             element.GetAttribute("type").ShouldBe("button");
             element.GetAttribute("aria-pressed").ShouldBe("false");
+        });
+    }
+
+    [Test]
+    public void ShouldAssertDictateDescriptionButtonHasMatchingTitleAndAriaLabel()
+    {
+        using var ctx = CreateTestContext(out _);
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.DictateDescription}']");
+            element.GetAttribute("title").ShouldBe("Dictate description");
+            element.GetAttribute("aria-label").ShouldBe("Dictate description");
         });
     }
 

--- a/src/UnitTests/UI.Shared/Pages/WorkOrderManageSpeechTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/WorkOrderManageSpeechTests.cs
@@ -50,6 +50,36 @@ public class WorkOrderManageSpeechTests
     }
 
     [Test]
+    public void ShouldAssertSpeakTitleButtonHasMatchingTitleAndAriaLabel()
+    {
+        using var ctx = new TestContext();
+
+        var user = new Employee("jpalermo", "Jeffrey", "Palermo", "jp@example.com");
+        user.Id = Guid.NewGuid();
+        user.PreferredLanguage = "es-ES";
+
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IWorkOrderBuilder>(new StubWorkOrderBuilder());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
+        ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
+        ctx.Services.AddSpeechSynthesis();
+        ctx.Services.AddSpeechRecognition();
+
+        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.SpeakTitle}']");
+            element.GetAttribute("title").ShouldBe("Speak title");
+            element.GetAttribute("aria-label").ShouldBe("Speak title");
+        });
+    }
+
+    [Test]
     public void ShouldRenderSpeakDescriptionButton()
     {
         using var ctx = new TestContext();
@@ -76,6 +106,35 @@ public class WorkOrderManageSpeechTests
             element.ShouldNotBeNull();
             element.TagName.ShouldBe("BUTTON", StringCompareShould.IgnoreCase);
             element.GetAttribute("type").ShouldBe("button");
+        });
+    }
+
+    [Test]
+    public void ShouldAssertSpeakDescriptionButtonHasMatchingTitleAndAriaLabel()
+    {
+        using var ctx = new TestContext();
+
+        var user = new Employee("jpalermo", "Jeffrey", "Palermo", "jp@example.com");
+        user.Id = Guid.NewGuid();
+
+        ctx.Services.AddSingleton<IBus>(new StubBus());
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IWorkOrderBuilder>(new StubWorkOrderBuilder());
+        ctx.Services.AddSingleton<IUserSession>(new StubUserSession(user));
+        ctx.Services.AddSingleton<ITranslationService>(new StubTranslationService());
+        ctx.Services.AddSpeechSynthesis();
+        ctx.Services.AddSpeechRecognition();
+
+        var navigationManager = ctx.Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(navigationManager.GetUriWithQueryParameter("Mode", "New"));
+
+        var component = ctx.RenderComponent<WorkOrderManage>();
+
+        component.WaitForAssertion(() =>
+        {
+            var element = component.Find($"[data-testid='{WorkOrderManage.Elements.SpeakDescription}']");
+            element.GetAttribute("title").ShouldBe("Speak description");
+            element.GetAttribute("aria-label").ShouldBe("Speak description");
         });
     }
 


### PR DESCRIPTION
## Summary

Adds `aria-label` attributes to icon-only controls that already had `title` tooltips, ensuring screen-reader parity per UX spec.

## Changes

- `NavMenu.razor` — added `aria-label="Navigation menu"` on navbar-toggler
- `HealthCheckLink.razor` — added `aria-label="Health Check"` on anchor
- Unit tests: NavMenuTests, HealthCheckLinkTests, WorkOrderManage speech/dictation parity tests
- Acceptance tests: NavRailToggleAttributeParityTests, HealthCheckLinkAttributeParityTests, SpeechDictationAttributeParityTests

## Testing

- `PrivateBuild.ps1` — green (unit + integration)
- New unit tests verify `title` === `aria-label` on all in-scope controls
- New acceptance tests verify attribute parity via Playwright

Closes #7331