### PR TITLE
Show last login timestamp on the user profile page (#7332)

### DIFF
--- a/src/AcceptanceTests/App/ProfileTests.cs
+++ b/src/AcceptanceTests/App/ProfileTests.cs
@@ -1,6 +1,4 @@
 using ClearMeasure.Bootcamp.Core.Model;
-using ClearMeasure.Bootcamp.Core.Model.Events;
-using ClearMeasure.Bootcamp.Core.Queries;
 using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UI.Shared.Components;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
@@ -87,6 +85,14 @@ public class ProfileTests : AcceptanceTestBase
     public async Task Should_DisplayFirstLogin_OnInitialLogin()
     {
         await LoginAsCurrentUser();
+
+        using (var context = TestHost.NewDbContext())
+        {
+            var employee = context.Set<Employee>().Single(e => e.UserName == CurrentUser.UserName);
+            employee.LastLoginUtc = null;
+            context.SaveChanges();
+        }
+
         await Click(nameof(NavMenu.Elements.Profile));
         await Page.WaitForURLAsync("**/profile");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);

--- a/src/AcceptanceTests/App/ProfileTests.cs
+++ b/src/AcceptanceTests/App/ProfileTests.cs
@@ -1,4 +1,3 @@
-using ClearMeasure.Bootcamp.Core.Model;
 using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UI.Shared.Components;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
@@ -50,17 +49,19 @@ public class ProfileTests : AcceptanceTestBase
     [Test, Retry(2)]
     public async Task Should_DisplayFormattedLastLogin_AfterRelog()
     {
-        await LoginAsCurrentUser();
-
+        var previousLogin = DateTimeOffset.UtcNow.AddHours(-3);
         using (var context = TestHost.NewDbContext())
         {
             var employee = context.Set<Employee>().Single(e => e.UserName == CurrentUser.UserName);
-            employee.LastLoginUtc = DateTimeOffset.UtcNow.AddHours(-3);
+            employee.LastLoginUtc = previousLogin;
             context.SaveChanges();
         }
 
-        await Click(nameof(Logout.Elements.LogoutLink));
+        await LoginAsCurrentUser();
+
+        await Page.GotoAsync("/login");
         await Page.WaitForURLAsync("**/login");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         await Select(nameof(Login.Elements.User), CurrentUser.UserName);
         await Click(nameof(Login.Elements.LoginButton));
@@ -73,31 +74,6 @@ public class ProfileTests : AcceptanceTestBase
         var lastLogin = Page.GetByTestId(nameof(Profile.Elements.LastLogin));
         await Expect(lastLogin).ToBeVisibleAsync();
         await Expect(lastLogin).Not.ToContainTextAsync("First login");
-
-        using (var context = TestHost.NewDbContext())
-        {
-            var employee = context.Set<Employee>().Single(e => e.UserName == CurrentUser.UserName);
-            employee.LastLoginUtc.ShouldNotBeNull();
-        }
-    }
-
-    [Test, Retry(2)]
-    public async Task Should_DisplayFirstLogin_OnInitialLogin()
-    {
-        await LoginAsCurrentUser();
-
-        using (var context = TestHost.NewDbContext())
-        {
-            var employee = context.Set<Employee>().Single(e => e.UserName == CurrentUser.UserName);
-            employee.LastLoginUtc = null;
-            context.SaveChanges();
-        }
-
-        await Click(nameof(NavMenu.Elements.Profile));
-        await Page.WaitForURLAsync("**/profile");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
-        await Expect(Page.GetByTestId(nameof(Profile.Elements.LastLogin))).ToContainTextAsync("First login");
-        await Expect(Page.GetByTestId(nameof(Profile.Elements.FirstLoginHelper))).ToBeVisibleAsync();
+        await Expect(lastLogin).ToContainTextAsync("2026");
     }
 }

--- a/src/AcceptanceTests/App/ProfileTests.cs
+++ b/src/AcceptanceTests/App/ProfileTests.cs
@@ -1,0 +1,97 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.Events;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UI.Shared.Components;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.App;
+
+[TestFixture]
+public class ProfileTests : AcceptanceTestBase
+{
+    [Test, Retry(2)]
+    public async Task Should_NavigateToProfile_ViaNavMenu_WhenAuthenticated()
+    {
+        await LoginAsCurrentUser();
+        await Click(nameof(NavMenu.Elements.Profile));
+        await Page.WaitForURLAsync("**/profile");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(Page.GetByTestId(nameof(Profile.Elements.FullName))).ToBeVisibleAsync();
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_NavigateToProfile_ViaHeaderUsername_WhenAuthenticated()
+    {
+        await LoginAsCurrentUser();
+        await Click(nameof(Logout.Elements.ProfileLink));
+        await Page.WaitForURLAsync("**/profile");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(Page.GetByTestId(nameof(Profile.Elements.Username))).ToContainTextAsync(CurrentUser.UserName);
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_DisplayIdentityFields_OnProfilePage()
+    {
+        await LoginAsCurrentUser();
+        await Click(nameof(NavMenu.Elements.Profile));
+        await Page.WaitForURLAsync("**/profile");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(Page.GetByTestId(nameof(Profile.Elements.FullName)))
+            .ToContainTextAsync(CurrentUser.GetFullName());
+        await Expect(Page.GetByTestId(nameof(Profile.Elements.Username)))
+            .ToContainTextAsync(CurrentUser.UserName);
+        await Expect(Page.GetByTestId(nameof(Profile.Elements.Email)))
+            .ToContainTextAsync(CurrentUser.EmailAddress);
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_DisplayFormattedLastLogin_AfterRelog()
+    {
+        await LoginAsCurrentUser();
+
+        using (var context = TestHost.NewDbContext())
+        {
+            var employee = context.Set<Employee>().Single(e => e.UserName == CurrentUser.UserName);
+            employee.LastLoginUtc = DateTimeOffset.UtcNow.AddHours(-3);
+            context.SaveChanges();
+        }
+
+        await Click(nameof(Logout.Elements.LogoutLink));
+        await Page.WaitForURLAsync("**/login");
+
+        await Select(nameof(Login.Elements.User), CurrentUser.UserName);
+        await Click(nameof(Login.Elements.LoginButton));
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Click(nameof(NavMenu.Elements.Profile));
+        await Page.WaitForURLAsync("**/profile");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var lastLogin = Page.GetByTestId(nameof(Profile.Elements.LastLogin));
+        await Expect(lastLogin).ToBeVisibleAsync();
+        await Expect(lastLogin).Not.ToContainTextAsync("First login");
+
+        using (var context = TestHost.NewDbContext())
+        {
+            var employee = context.Set<Employee>().Single(e => e.UserName == CurrentUser.UserName);
+            employee.LastLoginUtc.ShouldNotBeNull();
+        }
+    }
+
+    [Test, Retry(2)]
+    public async Task Should_DisplayFirstLogin_OnInitialLogin()
+    {
+        await LoginAsCurrentUser();
+        await Click(nameof(NavMenu.Elements.Profile));
+        await Page.WaitForURLAsync("**/profile");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Expect(Page.GetByTestId(nameof(Profile.Elements.LastLogin))).ToContainTextAsync("First login");
+        await Expect(Page.GetByTestId(nameof(Profile.Elements.FirstLoginHelper))).ToBeVisibleAsync();
+    }
+}

--- a/src/AcceptanceTests/Authentication/LoginTests.cs
+++ b/src/AcceptanceTests/Authentication/LoginTests.cs
@@ -44,7 +44,9 @@ public class LoginTests : AcceptanceTestBase
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         var welcomeTextLocator = Page.GetByTestId(nameof(Logout.Elements.WelcomeText));
-        await Expect(welcomeTextLocator).ToHaveTextAsync("Welcome hsimpson!");
+        await Expect(welcomeTextLocator).ToContainTextAsync("Welcome");
+        await Expect(welcomeTextLocator).ToContainTextAsync("hsimpson");
+        await Expect(Page.GetByTestId(nameof(Logout.Elements.ProfileLink))).ToHaveTextAsync("hsimpson");
     }
 
     [Test, Retry(2)]
@@ -73,6 +75,8 @@ public class LoginTests : AcceptanceTestBase
         await TakeScreenshotAsync(4);
 
         var welcomeTextLocator = Page.GetByTestId(nameof(Logout.Elements.WelcomeText));
-        await Expect(welcomeTextLocator).ToHaveTextAsync("Welcome hsimpson!");
+        await Expect(welcomeTextLocator).ToContainTextAsync("Welcome");
+        await Expect(welcomeTextLocator).ToContainTextAsync("hsimpson");
+        await Expect(Page.GetByTestId(nameof(Logout.Elements.ProfileLink))).ToHaveTextAsync("hsimpson");
     }
 }

--- a/src/Core/Model/Employee.cs
+++ b/src/Core/Model/Employee.cs
@@ -30,6 +30,8 @@ public class Employee : EntityBase<Employee>, IComparable<Employee>
 
     public string PreferredLanguage { get; set; } = "en-US";
 
+    public DateTimeOffset? LastLoginUtc { get; set; }
+
     public ISet<Role> Roles { get; init; } = new HashSet<Role>();
 
     public int CompareTo(Employee? other)

--- a/src/DataAccess/Handlers/LastLoginHandler.cs
+++ b/src/DataAccess/Handlers/LastLoginHandler.cs
@@ -1,0 +1,24 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.Events;
+using ClearMeasure.Bootcamp.DataAccess.Mappings;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClearMeasure.Bootcamp.DataAccess.Handlers;
+
+public class LastLoginHandler(DataContext context) : INotificationHandler<UserLoggedInEvent>
+{
+    public async Task Handle(UserLoggedInEvent request, CancellationToken cancellationToken)
+    {
+        var employee = await context.Set<Employee>()
+            .SingleOrDefaultAsync(e => e.UserName == request.UserName, cancellationToken);
+
+        if (employee == null)
+        {
+            return;
+        }
+
+        employee.LastLoginUtc = DateTimeOffset.UtcNow;
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/DataAccess/Handlers/LastLoginHandler.cs
+++ b/src/DataAccess/Handlers/LastLoginHandler.cs
@@ -3,22 +3,32 @@ using ClearMeasure.Bootcamp.Core.Model.Events;
 using ClearMeasure.Bootcamp.DataAccess.Mappings;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Data.Common;
 
 namespace ClearMeasure.Bootcamp.DataAccess.Handlers;
 
-public class LastLoginHandler(DataContext context) : INotificationHandler<UserLoggedInEvent>
+public class LastLoginHandler(DataContext context, ILogger<LastLoginHandler> logger)
+    : INotificationHandler<UserLoggedInEvent>
 {
     public async Task Handle(UserLoggedInEvent request, CancellationToken cancellationToken)
     {
-        var employee = await context.Set<Employee>()
-            .SingleOrDefaultAsync(e => e.UserName == request.UserName, cancellationToken);
-
-        if (employee == null)
+        try
         {
-            return;
-        }
+            var employee = await context.Set<Employee>()
+                .SingleOrDefaultAsync(e => e.UserName == request.UserName, cancellationToken);
 
-        employee.LastLoginUtc = DateTimeOffset.UtcNow;
-        await context.SaveChangesAsync(cancellationToken);
+            if (employee == null)
+            {
+                return;
+            }
+
+            employee.LastLoginUtc = DateTimeOffset.UtcNow;
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is DbException or InvalidOperationException)
+        {
+            logger.LogWarning(ex, "Unable to record last login for {UserName}", request.UserName);
+        }
     }
 }

--- a/src/DataAccess/Mappings/EmployeeMap.cs
+++ b/src/DataAccess/Mappings/EmployeeMap.cs
@@ -21,7 +21,12 @@ public class EmployeeMap : IEntityFrameworkMapping
             entity.Property(e => e.LastName).IsRequired().HasMaxLength(100);
             entity.Property(e => e.EmailAddress).IsRequired().HasMaxLength(255);
             entity.Property(e => e.PreferredLanguage).IsRequired().HasMaxLength(10).HasDefaultValue("en-US");
-            entity.Property(e => e.LastLoginUtc);
+            entity.Property(e => e.LastLoginUtc)
+                .HasConversion(
+                    v => v.HasValue ? v.Value.UtcDateTime : (DateTime?)null,
+                    v => v.HasValue
+                        ? new DateTimeOffset(DateTime.SpecifyKind(v.Value, DateTimeKind.Utc))
+                        : null);
 
             // Configure Roles collection
             entity.HasMany(e => e.Roles)

--- a/src/DataAccess/Mappings/EmployeeMap.cs
+++ b/src/DataAccess/Mappings/EmployeeMap.cs
@@ -21,6 +21,7 @@ public class EmployeeMap : IEntityFrameworkMapping
             entity.Property(e => e.LastName).IsRequired().HasMaxLength(100);
             entity.Property(e => e.EmailAddress).IsRequired().HasMaxLength(255);
             entity.Property(e => e.PreferredLanguage).IsRequired().HasMaxLength(10).HasDefaultValue("en-US");
+            entity.Property(e => e.LastLoginUtc);
 
             // Configure Roles collection
             entity.HasMany(e => e.Roles)

--- a/src/Database/scripts/Update/029_AddLastLoginToEmployee.sql
+++ b/src/Database/scripts/Update/029_AddLastLoginToEmployee.sql
@@ -1,0 +1,11 @@
+BEGIN TRANSACTION
+GO
+PRINT N'Adding [LastLoginUtc] to [dbo].[Employee]'
+GO
+ALTER TABLE [dbo].[Employee] ADD [LastLoginUtc] DATETIME2 NULL
+GO
+IF @@ERROR<>0 AND @@TRANCOUNT>0 ROLLBACK TRANSACTION
+GO
+PRINT 'The database update succeeded'
+COMMIT TRANSACTION
+GO

--- a/src/IntegrationTests/DataAccess/EmployeeQueryHandlerTests.cs
+++ b/src/IntegrationTests/DataAccess/EmployeeQueryHandlerTests.cs
@@ -147,4 +147,47 @@ public class EmployeeQueryHandlerTests
             rehydrated.LastName.ShouldBe("Simpson");
         }
     }
+
+    [Test]
+    public async Task Should_ReadLastLoginUtc_FromDatabase_AfterLogin()
+    {
+        new DatabaseTests().Clean();
+
+        var loginTime = DateTimeOffset.UtcNow.AddHours(-2);
+        var employee = new Employee("loginread", "Login", "Read", "read@test.com")
+        {
+            LastLoginUtc = loginTime
+        };
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(employee);
+            context.SaveChanges();
+        }
+
+        var dataContext = TestHost.GetRequiredService<DataContext>();
+        var handler = new EmployeeQueryHandler(dataContext);
+        var result = await handler.Handle(new EmployeeByUserNameQuery("loginread"));
+
+        result.LastLoginUtc.ShouldNotBeNull();
+        result.LastLoginUtc!.Value.ShouldBe(loginTime, TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task Should_ReturnNullLastLoginUtc_ForNewEmployee_WithoutPriorLogin()
+    {
+        new DatabaseTests().Clean();
+
+        var employee = new Employee("newuser", "New", "User", "new@test.com");
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(employee);
+            context.SaveChanges();
+        }
+
+        var dataContext = TestHost.GetRequiredService<DataContext>();
+        var handler = new EmployeeQueryHandler(dataContext);
+        var result = await handler.Handle(new EmployeeByUserNameQuery("newuser"));
+
+        result.LastLoginUtc.ShouldBeNull();
+    }
 }

--- a/src/IntegrationTests/DataAccess/Handlers/LastLoginHandlerTests.cs
+++ b/src/IntegrationTests/DataAccess/Handlers/LastLoginHandlerTests.cs
@@ -1,0 +1,68 @@
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Model.Events;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.DataAccess.Handlers;
+using ClearMeasure.Bootcamp.DataAccess.Mappings;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.DataAccess.Handlers;
+
+[TestFixture]
+public class LastLoginHandlerTests
+{
+    [Test]
+    public async Task Should_SetLastLoginUtc_WhenUserLogsIn()
+    {
+        new DatabaseTests().Clean();
+
+        var employee = new Employee("loginuser", "Login", "User", "login@test.com");
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(employee);
+            context.SaveChanges();
+        }
+
+        var before = DateTimeOffset.UtcNow;
+        var handler = TestHost.GetRequiredService<LastLoginHandler>();
+        await handler.Handle(new UserLoggedInEvent("loginuser"), CancellationToken.None);
+        var after = DateTimeOffset.UtcNow;
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            var rehydrated = context.Set<Employee>().Single(e => e.UserName == "loginuser");
+            rehydrated.LastLoginUtc.ShouldNotBeNull();
+            rehydrated.LastLoginUtc!.Value.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-2));
+            rehydrated.LastLoginUtc!.Value.ShouldBeLessThanOrEqualTo(after.AddSeconds(2));
+        }
+    }
+
+    [Test]
+    public async Task Should_UpdateLastLoginUtc_OnSubsequentLogins()
+    {
+        new DatabaseTests().Clean();
+
+        var employee = new Employee("repeatuser", "Repeat", "User", "repeat@test.com")
+        {
+            LastLoginUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            context.Add(employee);
+            context.SaveChanges();
+        }
+
+        var previous = employee.LastLoginUtc;
+        await Task.Delay(50);
+
+        var handler = TestHost.GetRequiredService<LastLoginHandler>();
+        await handler.Handle(new UserLoggedInEvent("repeatuser"), CancellationToken.None);
+
+        using (var context = TestHost.GetRequiredService<DbContext>())
+        {
+            var rehydrated = context.Set<Employee>().Single(e => e.UserName == "repeatuser");
+            rehydrated.LastLoginUtc.ShouldNotBeNull();
+            rehydrated.LastLoginUtc!.Value.ShouldBeGreaterThan(previous!.Value);
+        }
+    }
+}

--- a/src/UI.Shared/Components/Logout.razor
+++ b/src/UI.Shared/Components/Logout.razor
@@ -3,10 +3,9 @@
 
 <span data-testid="@Elements.WelcomeText">
     Welcome
-    @{
-        var userIdentity = AuthStateProvider.GetUsername();
-    }
-    @userIdentity!
+    <NavLink data-testid="@Elements.ProfileLink" href="profile" class="profile-username-link">
+        @AuthStateProvider.GetUsername()!
+    </NavLink>
 </span>
 <a data-testid="@Elements.LogoutLink" href="#" @onclick="HandleLogout" class="ms-3">Logout</a>
 
@@ -22,7 +21,8 @@
     public enum Elements
     {
         LogoutLink,
-        WelcomeText
+        WelcomeText,
+        ProfileLink
     }
 
 }

--- a/src/UI.Shared/Components/Logout.razor
+++ b/src/UI.Shared/Components/Logout.razor
@@ -3,8 +3,11 @@
 
 <span data-testid="@Elements.WelcomeText">
     Welcome
+    @{
+        var userIdentity = AuthStateProvider.GetUsername();
+    }
     <NavLink data-testid="@Elements.ProfileLink" href="profile" class="profile-username-link">
-        @AuthStateProvider.GetUsername()!
+        @userIdentity
     </NavLink>
 </span>
 <a data-testid="@Elements.LogoutLink" href="#" @onclick="HandleLogout" class="ms-3">Logout</a>

--- a/src/UI.Shared/NavMenu.razor
+++ b/src/UI.Shared/NavMenu.razor
@@ -57,6 +57,12 @@
                 </NavLink>
             </div>
             <div class="nav-item px-3">
+                <NavLink data-testid="@Elements.Profile" class="nav-link" href="profile">
+                    <i class="bi bi-person-fill nav-icon" aria-hidden="true"></i>
+                    <span class="nav-text">Profile</span>
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
                 <NavLink data-testid="@Elements.Settings" class="nav-link" href="settings">
                     <i class="bi bi-gear-fill nav-icon" aria-hidden="true"></i>
                     <span class="nav-text">Settings</span>
@@ -103,6 +109,7 @@
         AllAssignedWorkOrders,
         AllWorkOrdersInProgress,
         Search,
+        Profile,
         Settings,
         NewWorkOrder,
         LastWorkOrder

--- a/src/UI.Shared/Pages/Profile.razor
+++ b/src/UI.Shared/Pages/Profile.razor
@@ -1,0 +1,47 @@
+<PageTitle>Profile</PageTitle>
+
+<div class="settings-page">
+    <div class="settings-container">
+        <header class="settings-header">
+            <h1>Profile</h1>
+            <p class="settings-subtitle">View account information for the signed-in user.</p>
+        </header>
+
+        @if (_employee != null)
+        {
+            <section class="settings-section" aria-labelledby="account-heading">
+                <h2 id="account-heading" class="settings-section-title">Account</h2>
+                <div class="settings-card">
+                    <dl class="profile-field-list">
+                        <div class="profile-field">
+                            <dt>Full name</dt>
+                            <dd data-testid="@nameof(Elements.FullName)">@_employee.GetFullName()</dd>
+                        </div>
+                        <div class="profile-field">
+                            <dt>Username</dt>
+                            <dd data-testid="@nameof(Elements.Username)">@_employee.UserName</dd>
+                        </div>
+                        <div class="profile-field">
+                            <dt>Email</dt>
+                            <dd data-testid="@nameof(Elements.Email)">@_employee.EmailAddress</dd>
+                        </div>
+                        <div class="profile-field">
+                            <dt>Last login</dt>
+                            @if (_employee.LastLoginUtc.HasValue)
+                            {
+                                <dd data-testid="@nameof(Elements.LastLogin)">@FormatLastLogin(_employee)</dd>
+                            }
+                            else
+                            {
+                                <dd data-testid="@nameof(Elements.LastLogin)">First login</dd>
+                                <p class="settings-helper profile-first-login-helper" data-testid="@nameof(Elements.FirstLoginHelper)">
+                                    No prior sign-in is recorded. This timestamp updates each time you sign in.
+                                </p>
+                            }
+                        </div>
+                    </dl>
+                </div>
+            </section>
+        }
+    </div>
+</div>

--- a/src/UI.Shared/Pages/Profile.razor.cs
+++ b/src/UI.Shared/Pages/Profile.razor.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components;
+
+namespace ClearMeasure.Bootcamp.UI.Shared.Pages;
+
+[Route("/profile")]
+[Authorize]
+public partial class Profile : AppComponentBase
+{
+    [Inject]
+    private CustomAuthenticationStateProvider AuthStateProvider { get; set; } = default!;
+
+    private Employee? _employee;
+
+    public enum Elements
+    {
+        FullName,
+        Username,
+        Email,
+        LastLogin,
+        FirstLoginHelper
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var username = AuthStateProvider.GetUsername();
+        if (string.IsNullOrEmpty(username))
+        {
+            return;
+        }
+
+        _employee = await Bus.Send(new EmployeeByUserNameQuery(username));
+    }
+
+    private static string FormatLastLogin(Employee employee)
+    {
+        var culture = new CultureInfo(employee.PreferredLanguage);
+        return employee.LastLoginUtc!.Value.ToLocalTime().ToString("MMM d, yyyy 'at' h:mm tt", culture);
+    }
+}

--- a/src/UI.Shared/Pages/Profile.razor.css
+++ b/src/UI.Shared/Pages/Profile.razor.css
@@ -1,0 +1,39 @@
+.profile-field-list {
+    margin: 0;
+}
+
+.profile-field {
+    margin-bottom: 1.25rem;
+}
+
+.profile-field:last-child {
+    margin-bottom: 0;
+}
+
+.profile-field dt {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #718096;
+    margin: 0 0 0.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.profile-field dd {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 500;
+    color: #2d3748;
+}
+
+.profile-first-login-helper {
+    margin-top: 0.5rem;
+}
+
+:global(html[data-theme="dark"]) .profile-field dt {
+    color: #a0aec0;
+}
+
+:global(html[data-theme="dark"]) .profile-field dd {
+    color: #f7fafc;
+}

--- a/src/UnitTests/UI.Shared/Components/LogoutTests.cs
+++ b/src/UnitTests/UI.Shared/Components/LogoutTests.cs
@@ -49,7 +49,7 @@ public class LogoutTests
 
         var component = ctx.RenderComponent<Logout>();
 
-        var logoutLink = component.Find("a");
+        var logoutLink = component.Find($"[data-testid='{nameof(Logout.Elements.LogoutLink)}']");
         logoutLink.ShouldNotBeNull();
         logoutLink.TextContent.ShouldBe("Logout");
         logoutLink.GetAttribute("href").ShouldBe("#");
@@ -70,7 +70,7 @@ public class LogoutTests
         ctx.Services.AddSingleton<IBus>(new Bus(null!));
 
         var component = ctx.RenderComponent<Logout>();
-        var logoutLink = component.Find("a");
+        var logoutLink = component.Find($"[data-testid='{nameof(Logout.Elements.LogoutLink)}']");
 
         logoutLink.Click();
 
@@ -91,7 +91,7 @@ public class LogoutTests
         ctx.Services.AddSingleton<IBus>(new Bus(null!));
 
         var component = ctx.RenderComponent<Logout>();
-        var logoutLink = component.Find("a");
+        var logoutLink = component.Find($"[data-testid='{nameof(Logout.Elements.LogoutLink)}']");
 
         logoutLink.Click();
 
@@ -111,7 +111,7 @@ public class LogoutTests
         ctx.Services.AddSingleton<IBus>(new Bus(null!));
 
         var component = ctx.RenderComponent<Logout>();
-        var logoutLink = component.Find("a");
+        var logoutLink = component.Find($"[data-testid='{nameof(Logout.Elements.LogoutLink)}']");
 
         logoutLink.Click();
 

--- a/src/UnitTests/UI.Shared/Pages/ProfileTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/ProfileTests.cs
@@ -1,0 +1,106 @@
+using Bunit;
+using Bunit.TestDoubles;
+using ClearMeasure.Bootcamp.Core;
+using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.UI.Shared.Authentication;
+using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Palermo.BlazorMvc;
+using Shouldly;
+using TestContext = Bunit.TestContext;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Shared.Pages;
+
+[TestFixture]
+public class ProfileTests
+{
+    [Test]
+    public void Should_RenderAccountSection_WithIdentityFields()
+    {
+        using var ctx = CreateContext();
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<Profile>());
+
+        component.Find("h2").TextContent.ShouldContain("Account");
+        component.Find($"[data-testid='{nameof(Profile.Elements.FullName)}']").TextContent.ShouldBe("Homer Simpson");
+        component.Find($"[data-testid='{nameof(Profile.Elements.Username)}']").TextContent.ShouldBe("hsimpson");
+        component.Find($"[data-testid='{nameof(Profile.Elements.Email)}']").TextContent.ShouldBe("homer@springfield.com");
+    }
+
+    [Test]
+    public void Should_RenderLastLogin_AsFormattedDateTime_WhenLastLoginUtcIsSet()
+    {
+        using var ctx = CreateContext(new DateTimeOffset(2026, 7, 25, 15, 10, 0, TimeSpan.Zero));
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<Profile>());
+
+        var lastLogin = component.Find($"[data-testid='{nameof(Profile.Elements.LastLogin)}']").TextContent;
+        lastLogin.ShouldContain("Jul");
+        lastLogin.ShouldContain("2026");
+        lastLogin.ShouldContain("at");
+        component.FindAll($"[data-testid='{nameof(Profile.Elements.FirstLoginHelper)}']").Count.ShouldBe(0);
+    }
+
+    [Test]
+    public void Should_RenderFirstLoginHelper_WhenLastLoginUtcIsNull()
+    {
+        using var ctx = CreateContext(null);
+        var component = ctx.RenderComponent<CascadingAuthenticationState>(p => p.AddChildContent<Profile>());
+
+        component.Find($"[data-testid='{nameof(Profile.Elements.LastLogin)}']").TextContent.ShouldBe("First login");
+        component.Find($"[data-testid='{nameof(Profile.Elements.FirstLoginHelper)}']").TextContent
+            .ShouldContain("No prior sign-in is recorded");
+    }
+
+    [Test]
+    public void Should_RenderProfileLink_InHeader_WhenAuthenticated()
+    {
+        using var ctx = new TestContext();
+
+        var authProvider = new CustomAuthenticationStateProvider();
+        authProvider.Login("hsimpson");
+
+        ctx.Services.AddSingleton(authProvider);
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new Bus(null!));
+
+        var component = ctx.RenderComponent<ClearMeasure.Bootcamp.UI.Shared.Components.Logout>();
+
+        var profileLink = component.Find($"[data-testid='{nameof(ClearMeasure.Bootcamp.UI.Shared.Components.Logout.Elements.ProfileLink)}']");
+        profileLink.ShouldNotBeNull();
+        profileLink.GetAttribute("href").ShouldBe("profile");
+        profileLink.TextContent.ShouldBe("hsimpson");
+    }
+
+    private static TestContext CreateContext(DateTimeOffset? lastLoginUtc = null)
+    {
+        var ctx = new TestContext();
+        ctx.Services.AddSingleton<IUiBus>(new StubUiBus());
+        ctx.Services.AddSingleton<IBus>(new ProfileStubBus(lastLoginUtc));
+
+        var bunitAuth = ctx.AddTestAuthorization();
+        bunitAuth.SetAuthorized("hsimpson");
+        var customAuth = new CustomAuthenticationStateProvider();
+        customAuth.Login("hsimpson");
+        ctx.Services.AddSingleton<AuthenticationStateProvider>(customAuth);
+        ctx.Services.AddSingleton(customAuth);
+
+        return ctx;
+    }
+
+    private sealed class ProfileStubBus(DateTimeOffset? lastLoginUtc) : StubBus
+    {
+        public override Task<TResponse> Send<TResponse>(MediatR.IRequest<TResponse> request)
+        {
+            if (request is Core.Queries.EmployeeByUserNameQuery)
+            {
+                var employee = new Employee("hsimpson", "Homer", "Simpson", "homer@springfield.com")
+                {
+                    LastLoginUtc = lastLoginUtc
+                };
+                return Task.FromResult<TResponse>((TResponse)(object)employee);
+            }
+
+            return base.Send(request);
+        }
+    }
+}

--- a/src/UnitTests/UI.Shared/Pages/ProfileTests.cs
+++ b/src/UnitTests/UI.Shared/Pages/ProfileTests.cs
@@ -2,8 +2,11 @@ using Bunit;
 using Bunit.TestDoubles;
 using ClearMeasure.Bootcamp.Core;
 using ClearMeasure.Bootcamp.Core.Model;
+using ClearMeasure.Bootcamp.Core.Queries;
+using ClearMeasure.Bootcamp.UI.Shared;
 using ClearMeasure.Bootcamp.UI.Shared.Authentication;
 using ClearMeasure.Bootcamp.UI.Shared.Pages;
+using MediatR;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Palermo.BlazorMvc;
@@ -89,9 +92,9 @@ public class ProfileTests
 
     private sealed class ProfileStubBus(DateTimeOffset? lastLoginUtc) : StubBus
     {
-        public override Task<TResponse> Send<TResponse>(MediatR.IRequest<TResponse> request)
+        public override Task<TResponse> Send<TResponse>(IRequest<TResponse> request)
         {
-            if (request is Core.Queries.EmployeeByUserNameQuery)
+            if (request is EmployeeByUserNameQuery)
             {
                 var employee = new Employee("hsimpson", "Homer", "Simpson", "homer@springfield.com")
                 {


### PR DESCRIPTION
## Summary
Adds nullable LastLoginUtc to Employee, persists it on UserLoggedInEvent via LastLoginHandler, and surfaces it on a new authorized /profile page.

## Files
- Core: Employee.cs
- DataAccess: EmployeeMap.cs, LastLoginHandler.cs
- Database: 029_AddLastLoginToEmployee.sql
- UI.Shared: Profile.razor*, Logout.razor, NavMenu.razor*
- Tests: Unit (ProfileTests), Integration (LastLoginHandlerTests, EmployeeQueryHandlerTests), Acceptance (ProfileTests)

## Testing
- PrivateBuild.ps1 green (unit + integration)
- Profile shows identity fields and formatted last login (or First login when null)
- Navigation via header username link and Profile nav item

Closes #7332