### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260726-002315-1of1 (#7365)

### DIFF
--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,38 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal JSON greeting probe for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON greeting with HTTP 200.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var payload = new HelloResponse("Hello, World!");
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(payload);
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/hello</c> and <c>GET /api/v1.0/hello</c>.
+/// </summary>
+public record HelloResponse(string Message);

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnOk_WithJsonContent()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<HelloResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Message.ShouldBe("Hello, World!");
+    }
+}


### PR DESCRIPTION
Adds GET /api/hello returning {"message":"Hello, World!"} with HTTP 200.

**Files:**
- src/UI/Api/Controllers/HelloController.cs
- src/UnitTests/UI.Api/HelloControllerTests.cs

**Testing:** PrivateBuild.ps1 green; HelloControllerTests verifies 200, application/json, message field.

Closes #7365