### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260726-171453-1of10 (#7611)

### DIFF
--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,31 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal JSON greeting for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON greeting for reachability checks.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        ConditionalGetEtag.JsonContent(new HelloResponse("Hello, World!"));
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/hello</c> and <c>GET /api/v1.0/hello</c>.
+/// </summary>
+public record HelloResponse(string Message);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnOk_With_HelloWorld_Message()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+        var payload = JsonSerializer.Deserialize<HelloResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Message.ShouldBe("Hello, World!");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/hello", true)]
+    [TestCase("/api/v1.0/hello", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
## Summary
Adds anonymous GET /api/hello smoke endpoint returning {"message":"Hello, World!"}.

## Files
- src/UI/Api/Controllers/HelloController.cs
- src/UI/Server/ApiKeyAuthenticationMiddleware.cs
- src/UnitTests/UI.Api/HelloControllerTests.cs
- src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs

## Testing
PrivateBuild.ps1 passed.

Closes #7611