### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260726-201330-1of10 (#7681)

### DIFF
--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,26 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal greeting endpoint for health checks and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a greeting message as JSON.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        Ok(new { message = "Hello, World!" });
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnHelloWorldJson_WithHttp200()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.StatusCode.ShouldBe(200);
+        
+        var value = okResult.Value;
+        value.ShouldNotBeNull();
+        
+        var jsonString = JsonSerializer.Serialize(value);
+        jsonString.ShouldContain("message");
+        jsonString.ShouldContain("Hello, World!");
+    }
+}


### PR DESCRIPTION
## Summary
Added a minimal `GET /api/hello` endpoint returning `{"message": "Hello, World!"}` with HTTP 200 status.

## Files Changed
- `src/UI/Api/Controllers/HelloController.cs` — New endpoint with rate limiting and anonymous access
- `src/UnitTests/UI.Api/HelloControllerTests.cs` — Unit test verifying status 200 and JSON response

## Testing
- Unit test `Get_Should_ReturnHelloWorldJson_WithHttp200()` passes
- Build successful (Release configuration)
- Follows existing patterns from `PingController` and `TimeController`

Closes #7681