### PR TITLE
Add /api/hello endpoint returning greeting (#7685)

### DIFF
--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,26 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a greeting endpoint for testing and verification.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a greeting message.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        Ok(new { message = "Hello, World!" });
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -20,8 +20,9 @@ public class HelloControllerTests
 
         var okResult = result.ShouldBeOfType<OkObjectResult>();
         okResult.StatusCode.ShouldBe(200);
+        okResult.Value.ShouldNotBeNull();
         
-        var responseValue = okResult.Value.ShouldBeOfType<dynamic>();
-        responseValue.message.ShouldBe("Hello, World!");
+        var message = okResult.Value.GetType().GetProperty("message")?.GetValue(okResult.Value);
+        message.ShouldBe("Hello, World!");
     }
 }

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,27 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_ShouldReturnGreetingMessage()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.StatusCode.ShouldBe(200);
+        
+        var responseValue = okResult.Value.ShouldBeOfType<dynamic>();
+        responseValue.message.ShouldBe("Hello, World!");
+    }
+}


### PR DESCRIPTION
## Summary
Implements a new `/api/hello` HTTP endpoint that returns a JSON greeting message.

## Files Changed
- `src/UI/Api/Controllers/HelloController.cs` - New controller with GET endpoint
- `src/UnitTests/UI.Api/HelloControllerTests.cs` - Unit tests for the endpoint

## Testing
Unit tests pass (311/311). Endpoint returns: `{ "message": "Hello, World!" }`

Closes #7685