### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260726-204847-7of10 (#7712)

### DIFF
--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,26 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal JSON greeting endpoint for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON greeting message.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        Ok(new { message = "Hello, World!" });
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,53 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_Return200WithJsonContentType()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.StatusCode.ShouldBe(200);
+    }
+
+    [Test]
+    public void Get_Should_ReturnCorrectMessageField()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        var value = okResult.Value.ShouldNotBeNull();
+        var message = ((dynamic)value).message;
+        message.ShouldBe("Hello, World!");
+    }
+
+    [Test]
+    public void Get_Should_ReturnOkActionResult()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        result.ShouldBeOfType<OkObjectResult>();
+    }
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -2,6 +2,7 @@ using ClearMeasure.Bootcamp.UI.Api.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Shouldly;
+using System.Text.Json;
 
 namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
 
@@ -34,7 +35,9 @@ public class HelloControllerTests
 
         var okResult = result.ShouldBeOfType<OkObjectResult>();
         var value = okResult.Value.ShouldNotBeNull();
-        var message = ((dynamic)value).message;
+        
+        var jsonElement = JsonSerializer.SerializeToElement(value);
+        var message = jsonElement.GetProperty("message").GetString();
         message.ShouldBe("Hello, World!");
     }
 


### PR DESCRIPTION
Implements `GET /api/hello` endpoint returning JSON greeting.

**Changes:**
- Added `HelloController.cs` in `src/UI/Api/Controllers/` following PingController pattern
- Added `HelloControllerTests.cs` in `src/UnitTests/UI.Api/` with three NUnit tests

**Testing:**
- Get_Should_Return200WithJsonContentType: Verifies HTTP 200 status
- Get_Should_ReturnCorrectMessageField: Verifies JSON message field equals "Hello, World!"
- Get_Should_ReturnOkActionResult: Verifies OkObjectResult type
- All unit tests pass

Closes #7712