### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260726-211258-6of10 (#7722)

### DIFF
--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,26 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal greeting endpoint for integration and testing.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON greeting with HTTP 200.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        Ok(new { message = "Hello, World!" });
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,31 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+using System.Text.Json;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJsonGreeting_With200Status()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.StatusCode.ShouldBe(200);
+
+        var jsonElement = ((JsonElement)okResult.Value).GetRawText();
+        var doc = JsonDocument.Parse(jsonElement);
+        var root = doc.RootElement;
+        root.TryGetProperty("message", out var messageProp).ShouldBeTrue();
+        messageProp.GetString().ShouldBe("Hello, World!");
+    }
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -2,7 +2,6 @@ using ClearMeasure.Bootcamp.UI.Api.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Shouldly;
-using System.Text.Json;
 
 namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
 
@@ -22,10 +21,10 @@ public class HelloControllerTests
         var okResult = result.ShouldBeOfType<OkObjectResult>();
         okResult.StatusCode.ShouldBe(200);
 
-        var jsonElement = ((JsonElement)okResult.Value).GetRawText();
-        var doc = JsonDocument.Parse(jsonElement);
-        var root = doc.RootElement;
-        root.TryGetProperty("message", out var messageProp).ShouldBeTrue();
-        messageProp.GetString().ShouldBe("Hello, World!");
+        var responseObject = okResult.Value.ShouldNotBeNull();
+        var messageProperty = responseObject.GetType().GetProperty("message");
+        messageProperty.ShouldNotBeNull();
+        var messageValue = messageProperty.GetValue(responseObject);
+        messageValue.ShouldBe("Hello, World!");
     }
 }


### PR DESCRIPTION
## Summary
Implements a minimal `GET /api/hello` endpoint returning `{"message": "Hello, World!"}` with HTTP 200 status.

## Files Changed
- `src/UI/Api/Controllers/HelloController.cs` — New controller with versioned routes, rate limiting, anonymous access
- `src/UnitTests/UI.Api/HelloControllerTests.cs` — Unit test verifying HTTP 200 and JSON payload

## Testing
- Unit test: `Get_Should_ReturnJsonGreeting_With200Status()` passes
- Build: Clean compile with 0 errors
- No authentication required; follows PingController pattern

Closes #7722