### PR TITLE
[FST] Append deployment verification note to README - 20260728-041350 (#7777)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,3 +441,8 @@ Deployment run 20260727-231313 is verified in the UAT environment before release
 ## Deployment Verification 20260728-000302
 
 Deployment run 20260728-000302 is verified in the UAT environment before release.
+
+
+## Deployment Verification 20260728-041350
+
+Deployment run 20260728-041350 is verified in the UAT environment before release.


### PR DESCRIPTION
Documentation-only change: appends deployment verification section for run 20260728-041350 to README.md.

Files changed:
- README.md: Added new deployment verification section at end of file

Testing notes:
- No tests required (documentation-only change per acceptance criteria)
- Private build passed: 130 tests passed, 11 skipped (AI tests without API keys), 0 errors

Closes #7777