### PR TITLE
New API endpoint GET /api/health/detailed for component-level health reporting (#7783)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -357,6 +357,8 @@ public class DetailedHealthEndpointIntegrationTests
         names.ShouldContain("Server");
         names.ShouldContain("API");
         names.ShouldContain("Jeffrey");
+        names.ShouldContain("NeedsReboot");
+        names.ShouldContain("ProcessThreadCount");
         foreach (var c in report.Components)
         {
             (c.Status == ComponentHealthStatus.Healthy

--- a/src/UI/Api/Controllers/DetailedHealthController.cs
+++ b/src/UI/Api/Controllers/DetailedHealthController.cs
@@ -25,7 +25,11 @@ public class DetailedHealthController(
     public async Task<IActionResult> GetDetailed(CancellationToken cancellationToken)
     {
         var payload = await detailedHealthReportProvider.GetReportAsync(cancellationToken);
-        return ConditionalJson(payload);
+        var etag = ConditionalGetEtag.CreateWeakEtagForJson(DetailedHealthEtagFingerprint.FromReport(payload));
+        Response.Headers.ETag = etag.ToString();
+        if (ConditionalGetEtag.IfNoneMatchIncludesEtag(Request, etag))
+            return StatusCode(StatusCodes.Status304NotModified);
+        return ConditionalGetEtag.JsonContent(payload);
     }
 
     private IActionResult ConditionalJson<T>(T payload)

--- a/src/UI/Api/DetailedHealthModels.cs
+++ b/src/UI/Api/DetailedHealthModels.cs
@@ -101,3 +101,55 @@ public static class ComponentHealthStatus
     public const string Degraded = nameof(Degraded);
     public const string Unhealthy = nameof(Unhealthy);
 }
+
+/// <summary>
+/// Per-component fingerprint for conditional GET (<see cref="ComponentHealthEntry.ExceptionDetail"/> excluded).
+/// </summary>
+internal sealed record DetailedHealthComponentEtagFingerprint(
+    string Name,
+    string Status,
+    string? Description,
+    string? ExceptionMessage,
+    IReadOnlyList<KeyValuePair<string, string>>? Data);
+
+/// <summary>
+/// Fingerprint payload for conditional GET over <see cref="DetailedHealthReport"/>.
+/// </summary>
+/// <remarks>
+/// Omits <see cref="DetailedHealthReport.CheckedAtUtc"/> and per-component durations. Exception stack traces
+/// (<see cref="ComponentHealthEntry.ExceptionDetail"/>) are omitted so probes can reuse ETags across polls.
+/// </remarks>
+internal sealed record DetailedHealthEtagFingerprint(
+    string OverallStatus,
+    IReadOnlyList<DetailedHealthComponentEtagFingerprint> Components)
+{
+    /// <summary>
+    /// Builds a fingerprint from <paramref name="report"/> omitting volatile fields so repeated polls can yield 304.
+    /// </summary>
+    internal static DetailedHealthEtagFingerprint FromReport(DetailedHealthReport report)
+    {
+        var components = report.Components
+            .OrderBy(c => c.Name, StringComparer.Ordinal)
+            .Select(c => new DetailedHealthComponentEtagFingerprint(
+                c.Name,
+                c.Status,
+                c.Description,
+                c.ExceptionMessage,
+                StableDataEntries(c.Data)))
+            .ToList();
+
+        return new DetailedHealthEtagFingerprint(report.OverallStatus, components);
+    }
+
+    private static IReadOnlyList<KeyValuePair<string, string>>? StableDataEntries(
+        IReadOnlyDictionary<string, object>? data)
+    {
+        if (data is null || data.Count == 0)
+            return null;
+
+        return data
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => KeyValuePair.Create(kv.Key, kv.Value?.ToString() ?? ""))
+            .ToList();
+    }
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -57,12 +57,36 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicVersionOrTimePath(value) || IsPublicHealthPath(value))
         {
             return false;
         }
 
         return true;
+    }
+
+    internal static bool IsPublicHealthPath(string pathValue)
+    {
+        var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (segments.Length >= 2
+            && segments[1].Equals("health", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (segments.Length >= 3
+            && segments[1].StartsWith('v')
+            && segments[2].Equals("health", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     internal static bool IsPublicVersionOrTimePath(string pathValue)

--- a/src/UnitTests/Api/ApiRateLimitingWebTests.cs
+++ b/src/UnitTests/Api/ApiRateLimitingWebTests.cs
@@ -161,4 +161,14 @@ public class ApiRateLimitingWebTests
         for (var i = 0; i < 5; i++)
             (await client.GetAsync("/api/time")).StatusCode.ShouldBe(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_RespectRateLimiting_When_GetDetailedHealthExceedsPermitLimit()
+    {
+        await using var factory = new TunableApiRateLimitWebApplicationFactory(StrictLimitSettings(2));
+        using var client = factory.CreateClient();
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await client.GetAsync("/api/health/detailed")).StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+    }
 }

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -6,8 +6,10 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
 [TestFixture]
 public class ApiKeyAuthenticationMiddlewareTests
 {
-    [TestCase("/api/health", false)]
-    [TestCase("/api/v1.0/health", false)]
+    [TestCase("/api/health", true)]
+    [TestCase("/api/health/detailed", true)]
+    [TestCase("/api/v1.0/health", true)]
+    [TestCase("/api/v1.0/health/detailed", true)]
     [TestCase("/api/diagnostics", false)]
     [TestCase("/api/v1.0/diagnostics", false)]
     [TestCase("/api/version", true)]

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -8,28 +8,19 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
 public class ApiKeyAuthenticationWebTests
 {
     [Test]
-    public async Task Should_Return401_When_ApiHealthCalledWithoutKey()
+    public async Task Should_Return200_When_ApiHealthCalledWithoutKey()
     {
         await using var factory = new ApiKeyProtectedWebApplicationFactory();
         using var client = factory.CreateClient();
 
-        var response = await client.GetAsync("/api/health");
+        var simple = await client.GetAsync("/api/health");
+        simple.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
-    }
+        var detailed = await client.GetAsync("/api/health/detailed");
+        detailed.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-    [Test]
-    public async Task Should_Return200_When_ApiHealthCalledWithValidKey()
-    {
-        await using var factory = new ApiKeyProtectedWebApplicationFactory();
-        using var client = factory.CreateClient();
-        client.DefaultRequestHeaders.Add(
-            ApiKeyConstants.HeaderName,
-            ApiKeyProtectedWebApplicationFactory.TestApiKey);
-
-        var response = await client.GetAsync("/api/health");
-
-        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var versioned = await client.GetAsync("/api/v1.0/health/detailed");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
 
     [Test]
@@ -66,7 +57,7 @@ public class ApiKeyAuthenticationWebTests
         using var client = factory.CreateClient();
         client.DefaultRequestHeaders.Add(ApiKeyConstants.HeaderName, "wrong");
 
-        var response = await client.GetAsync("/api/v1.0/health");
+        var response = await client.GetAsync("/api/v1.0/WeatherForecast");
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }

--- a/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
+++ b/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
@@ -33,11 +33,37 @@ public class EtagConditionalGetWebTests
         (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
     }
 
+    [TestCase("/api/health/detailed")]
+    [TestCase("/api/v1.0/health/detailed")]
+    public async Task Should_Return304NotModified_When_IfNoneMatchMatchesEtag_DetailedHealth(string path)
+    {
+        using var client = _factory!.CreateClient();
+        var first = await client.GetAsync(path);
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        first.Headers.ETag.ShouldNotBeNull();
+
+        using var second = new HttpRequestMessage(HttpMethod.Get, path);
+        second.Headers.IfNoneMatch.Add(first.Headers.ETag!);
+        var notModified = await client.SendAsync(second);
+        notModified.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
+    }
+
     [Test]
     public async Task Should_IncludeEtagHeader_When_GetSimpleHealth()
     {
         using var client = _factory!.CreateClient();
         var response = await client.GetAsync("/api/health");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+    }
+
+    [TestCase("/api/health/detailed")]
+    [TestCase("/api/v1.0/health/detailed")]
+    public async Task Should_IncludeEtagHeader_When_GetDetailedHealth(string path)
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.GetAsync(path);
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Headers.ETag.ShouldNotBeNull();
     }

--- a/src/UnitTests/UI/Api/DetailedHealthEtagFingerprintTests.cs
+++ b/src/UnitTests/UI/Api/DetailedHealthEtagFingerprintTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class DetailedHealthEtagFingerprintTests
+{
+    private static DetailedHealthReport BuildReport(DateTime checkedAtUtc, double durationA, double durationB)
+    {
+        return new DetailedHealthReport
+        {
+            OverallStatus = ComponentHealthStatus.Degraded,
+            CheckedAtUtc = checkedAtUtc,
+            ProcessId = 1,
+            OsDescription = "test-os",
+            FrameworkDescription = "test-framework",
+            GcMemoryMb = 10,
+            WorkingSetMb = 20,
+            ProcessorCount = 4,
+            Is64BitProcess = true,
+            TimeZoneId = "UTC",
+            ProcessPriority = "Normal",
+            Components =
+            [
+                new ComponentHealthEntry
+                {
+                    Name = "Alpha",
+                    Status = ComponentHealthStatus.Healthy,
+                    DurationMs = durationA,
+                    ExceptionDetail = "stacktrace-alpha"
+                },
+                new ComponentHealthEntry
+                {
+                    Name = "Beta",
+                    Status = ComponentHealthStatus.Degraded,
+                    DurationMs = durationB,
+                    ExceptionDetail = "stacktrace-beta"
+                }
+            ]
+        };
+    }
+
+    [Test]
+    public void FromReport_Should_ProduceEquivalentJson_When_OnlyVolatileFieldsDiffer()
+    {
+        var a = DetailedHealthEtagFingerprint.FromReport(
+            BuildReport(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), 1.5, 2.0));
+        var b = DetailedHealthEtagFingerprint.FromReport(
+            BuildReport(new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Utc), 99.0, 0.1));
+
+        JsonSerializer.Serialize(a, ConditionalGetEtag.JsonSerializerOptions)
+            .ShouldBe(JsonSerializer.Serialize(b, ConditionalGetEtag.JsonSerializerOptions));
+    }
+
+    [Test]
+    public void FromReport_Should_ProduceDifferentJson_When_ComponentStatusChanges()
+    {
+        static DetailedHealthReport oneStatus(string componentStatus)
+        {
+            return new DetailedHealthReport
+            {
+                OverallStatus = componentStatus,
+                CheckedAtUtc = DateTime.UtcNow,
+                ProcessId = 1,
+                OsDescription = "test-os",
+                FrameworkDescription = "test-framework",
+                GcMemoryMb = 10,
+                WorkingSetMb = 20,
+                ProcessorCount = 4,
+                Is64BitProcess = true,
+                TimeZoneId = "UTC",
+                ProcessPriority = "Normal",
+                Components =
+                [
+                    new ComponentHealthEntry { Name = "X", Status = componentStatus }
+                ]
+            };
+        }
+
+        var degraded = DetailedHealthEtagFingerprint.FromReport(oneStatus(ComponentHealthStatus.Degraded));
+        var healthy = DetailedHealthEtagFingerprint.FromReport(oneStatus(ComponentHealthStatus.Healthy));
+
+        JsonSerializer.Serialize(degraded, ConditionalGetEtag.JsonSerializerOptions)
+            .ShouldNotBe(JsonSerializer.Serialize(healthy, ConditionalGetEtag.JsonSerializerOptions));
+    }
+}

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using ClearMeasure.Bootcamp.UI.Api;
 using ClearMeasure.Bootcamp.UI.Server;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Shouldly;
 
@@ -450,5 +451,43 @@ public class DetailedHealthReportProviderTests
         component.ExceptionDetail.ShouldContain("TimeoutException");
         component.Data.ShouldNotBeNull();
         component.Data!["endpoint"].ShouldBe("https://api.example.com");
+    }
+
+    [Test]
+    public async Task Should_CallHealthCheckServiceAndReturnReport_When_GetReportAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHealthChecks()
+            .AddCheck("API", () => HealthCheckResult.Healthy("ok"))
+            .AddCheck("DataAccess", () => HealthCheckResult.Degraded("slow"));
+        await using var provider = services.BuildServiceProvider();
+        var healthCheckService = provider.GetRequiredService<HealthCheckService>();
+        var reportProvider = new DetailedHealthReportProvider(healthCheckService, TimeProvider.System);
+
+        var report = await reportProvider.GetReportAsync();
+
+        report.Components.Count.ShouldBe(2);
+        report.OverallStatus.ShouldBe(ComponentHealthStatus.Degraded);
+        report.Components.ShouldContain(c => c.Name == "API" && c.Status == ComponentHealthStatus.Healthy);
+        report.Components.ShouldContain(c => c.Name == "DataAccess" && c.Status == ComponentHealthStatus.Degraded);
+    }
+
+    [Test]
+    public async Task Should_ExcludeLiveTaggedChecks_When_GetReportAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHealthChecks()
+            .AddCheck("API", () => HealthCheckResult.Healthy())
+            .AddCheck("LiveProbe", () => HealthCheckResult.Unhealthy("live only"), tags: ["live"]);
+        await using var provider = services.BuildServiceProvider();
+        var healthCheckService = provider.GetRequiredService<HealthCheckService>();
+        var reportProvider = new DetailedHealthReportProvider(healthCheckService, TimeProvider.System);
+
+        var report = await reportProvider.GetReportAsync();
+
+        report.Components.Select(c => c.Name).ShouldContain("API");
+        report.Components.Select(c => c.Name).ShouldNotContain("LiveProbe");
     }
 }


### PR DESCRIPTION
## Summary
Implements machine-consumable `GET /api/health/detailed` returning per-component health JSON for ops/monitoring probes.

## Changes
- **ApiKeyAuthenticationMiddleware** — exclude `/api/health` and `/api/health/detailed` (versioned paths included) from API key validation
- **DetailedHealthController** — stable weak ETag via `DetailedHealthEtagFingerprint` for conditional GET 304
- **DetailedHealthModels** — fingerprint types omit volatile fields (timestamps, durations, stack traces, host metadata)
- **Tests** — ETag fingerprint unit tests, 304 integration for legacy/versioned routes, live-tag filtering, rate limiting, NeedsReboot/ProcessThreadCount component assertions

## Testing
- `./PrivateBuild.ps1` — green (unit + integration)
- Acceptance tests skipped (no UX change)

Closes #7783