### PR TITLE
New API endpoint GET /api/echo with request reflection for debugging (#7785)

### DIFF
--- a/src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UI.Shared;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class EchoEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_ReturnOkJson_From_UnversionedPath()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldBe("application/json");
+    }
+
+    [Test]
+    public async Task Should_ReturnOkJson_From_VersionedPath()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldBe("application/json");
+    }
+
+    [Test]
+    public async Task Should_EchoBackRequestPath_EndToEnd()
+    {
+        var response = await _client!.GetAsync("/api/echo?foo=bar");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await DeserializeEchoResponse(response);
+        payload.Path.ShouldBe("/api/echo");
+        payload.QueryString.ShouldBe("?foo=bar");
+    }
+
+    [Test]
+    public async Task Should_EchoBackCustomHeader_RoundTrip()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.Add("X-Custom", "value123");
+
+        var response = await _client!.SendAsync(request);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await DeserializeEchoResponse(response);
+        payload.Headers.TryGetValue("X-Custom", out var value).ShouldBeTrue();
+        value.ShouldBe("value123");
+    }
+
+    [Test]
+    public async Task Should_RoundTripQueryParameters_InParsedMap()
+    {
+        var response = await _client!.GetAsync("/api/echo?name=John&age=30");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await DeserializeEchoResponse(response);
+        payload.Query.ShouldNotBeNull();
+        payload.Query!["name"].ShouldBe("John");
+        payload.Query["age"].ShouldBe("30");
+    }
+
+    [Test]
+    public async Task Should_IncludeRemoteIpFromRequest_InEchoResponse()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("remoteIpAddress", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_AccessWithoutApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/echo");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/echo");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_ReturnJsonWithAllFields_Present()
+    {
+        var response = await _client!.GetAsync("/api/echo?key=value");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await DeserializeEchoResponse(response);
+        payload.Method.ShouldNotBeNullOrEmpty();
+        payload.Path.ShouldNotBeNullOrEmpty();
+        payload.Scheme.ShouldNotBeNullOrEmpty();
+        payload.Host.ShouldNotBeNullOrEmpty();
+        payload.Protocol.ShouldNotBeNullOrEmpty();
+        payload.Headers.ShouldNotBeNull();
+        payload.Query.ShouldNotBeNull();
+    }
+
+    private static async Task<EchoResponse> DeserializeEchoResponse(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var payload = JsonSerializer.Deserialize<EchoResponse>(json, ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        return payload!;
+    }
+}

--- a/src/UI/Api/Controllers/EchoController.cs
+++ b/src/UI/Api/Controllers/EchoController.cs
@@ -1,0 +1,80 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a JSON snapshot of the incoming HTTP request for client diagnostics.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/echo")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/echo")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class EchoController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON object reflecting key properties of the incoming HTTP request.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var request = HttpContext.Request;
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in request.Headers)
+        {
+            headers[header.Key] = EchoHeaderRedaction.IsSensitive(header.Key)
+                ? EchoHeaderRedaction.RedactedValue
+                : header.Value.ToString();
+        }
+
+        IReadOnlyDictionary<string, string>? query = null;
+        if (request.Query.Count > 0)
+        {
+            query = request.Query.ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.ToString(),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        string? correlationId = null;
+        if (HttpContext.Items.TryGetValue("CorrelationId", out var item) && item is string id)
+        {
+            correlationId = id;
+        }
+
+        var payload = new EchoResponse(
+            Method: request.Method,
+            Path: request.Path.Value ?? string.Empty,
+            QueryString: request.QueryString.Value ?? string.Empty,
+            Scheme: request.Scheme,
+            Host: request.Host.Value ?? string.Empty,
+            Protocol: request.Protocol,
+            RemoteIpAddress: HttpContext.Connection.RemoteIpAddress?.ToString(),
+            Headers: headers,
+            Query: query,
+            CorrelationId: correlationId);
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/echo</c> and <c>GET /api/v1.0/echo</c>.
+/// </summary>
+public record EchoResponse(
+    string Method,
+    string Path,
+    string QueryString,
+    string Scheme,
+    string Host,
+    string Protocol,
+    string? RemoteIpAddress,
+    IReadOnlyDictionary<string, string> Headers,
+    IReadOnlyDictionary<string, string>? Query,
+    string? CorrelationId = null);

--- a/src/UI/Api/EchoHeaderRedaction.cs
+++ b/src/UI/Api/EchoHeaderRedaction.cs
@@ -1,0 +1,30 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Identifies request headers whose values must not be echoed verbatim.
+/// </summary>
+internal static class EchoHeaderRedaction
+{
+    /// <summary>
+    /// Placeholder substituted for redacted header values in echo responses.
+    /// </summary>
+    internal const string RedactedValue = "***REDACTED***";
+
+    /// <summary>
+    /// Matches <see cref="ClearMeasure.Bootcamp.UI.Shared.ApiKeyConstants.HeaderName"/> without a UI.Shared reference.
+    /// </summary>
+    private const string ApiKeyHeaderName = "X-Api-Key";
+
+    private static readonly HashSet<string> SensitiveHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        ApiKeyHeaderName
+    };
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the header name must be redacted in echo output.
+    /// </summary>
+    internal static bool IsSensitive(string headerName) =>
+        SensitiveHeaderNames.Contains(headerName);
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and echo endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/EchoControllerTests.cs
+++ b/src/UnitTests/UI.Api/EchoControllerTests.cs
@@ -1,0 +1,260 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UI.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EchoControllerTests
+{
+    [Test]
+    public void Should_ReturnOkStatus_When_GetEchoCalledWithValidRequest()
+    {
+        var controller = CreateController(new StubEchoHttpContext());
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType!.ShouldContain("application/json");
+    }
+
+    [Test]
+    public void Should_IncludeRequestMethod_InResponse()
+    {
+        var stubContext = new StubEchoHttpContext { Method = "GET" };
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Method.ShouldBe("GET");
+    }
+
+    [Test]
+    public void Should_IncludeRequestPath_InResponse()
+    {
+        var stubContext = new StubEchoHttpContext { Path = "/api/echo" };
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Path.ShouldBe("/api/echo");
+    }
+
+    [Test]
+    public void Should_IncludeQueryString_InResponse()
+    {
+        var stubContext = new StubEchoHttpContext { QueryString = "?foo=bar" };
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.QueryString.ShouldBe("?foo=bar");
+    }
+
+    [Test]
+    public void Should_IncludeSchemeAndHost_InResponse()
+    {
+        var stubContext = new StubEchoHttpContext
+        {
+            Scheme = "https",
+            Host = "localhost:7174"
+        };
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Scheme.ShouldBe("https");
+        payload.Host.ShouldBe("localhost:7174");
+    }
+
+    [Test]
+    public void Should_IncludeProtocolVersion_InResponse()
+    {
+        var stubContext = new StubEchoHttpContext { Protocol = "HTTP/2" };
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Protocol.ShouldBe("HTTP/2");
+    }
+
+    [Test]
+    public void Should_IncludeRemoteIpAddress_InResponse()
+    {
+        var stubContext = new StubEchoHttpContext { RemoteIpAddress = "192.168.1.10" };
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.RemoteIpAddress.ShouldBe("192.168.1.10");
+    }
+
+    [Test]
+    public void Should_IncludeHeadersDictionary_InResponse()
+    {
+        var stubContext = new StubEchoHttpContext();
+        stubContext.Headers["User-Agent"] = "TestAgent/1.0";
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Headers.TryGetValue("User-Agent", out var value).ShouldBeTrue();
+        value.ShouldBe("TestAgent/1.0");
+    }
+
+    [Test]
+    public void Should_RedactAuthorizationHeader_Value()
+    {
+        var stubContext = new StubEchoHttpContext();
+        stubContext.Headers["Authorization"] = "Bearer secret-token";
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Headers.TryGetValue("Authorization", out var value).ShouldBeTrue();
+        value.ShouldBe(EchoHeaderRedaction.RedactedValue);
+    }
+
+    [Test]
+    public void Should_RedactApiKeyHeader_Value()
+    {
+        var stubContext = new StubEchoHttpContext();
+        stubContext.Headers[ApiKeyConstants.HeaderName] = "super-secret-key";
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Headers.TryGetValue(ApiKeyConstants.HeaderName, out var value).ShouldBeTrue();
+        value.ShouldBe(EchoHeaderRedaction.RedactedValue);
+    }
+
+    [Test]
+    public void Should_RedactCookieHeader_Value()
+    {
+        var stubContext = new StubEchoHttpContext();
+        stubContext.Headers["Cookie"] = "session=abc123";
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Headers.TryGetValue("Cookie", out var value).ShouldBeTrue();
+        value.ShouldBe(EchoHeaderRedaction.RedactedValue);
+    }
+
+    [Test]
+    public void Should_IncludeCustomHeaders_InResponse()
+    {
+        var stubContext = new StubEchoHttpContext();
+        stubContext.Headers["Custom-Header"] = "visible-value";
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Headers.TryGetValue("Custom-Header", out var value).ShouldBeTrue();
+        value.ShouldBe("visible-value");
+    }
+
+    [Test]
+    public void Should_ParseQueryParameters_IntoMap_When_QueryPresent()
+    {
+        var stubContext = new StubEchoHttpContext
+        {
+            QueryString = "?name=Alice&role=admin"
+        };
+        var controller = CreateController(stubContext);
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Query.ShouldNotBeNull();
+        payload.Query!["name"].ShouldBe("Alice");
+        payload.Query["role"].ShouldBe("admin");
+    }
+
+    [Test]
+    public void Should_ReturnNullQuery_When_QueryAbsent()
+    {
+        var controller = CreateController(new StubEchoHttpContext());
+
+        var payload = GetPayload(controller.Get());
+
+        payload.Query.ShouldBeNull();
+    }
+
+    private static EchoController CreateController(StubEchoHttpContext stubContext)
+    {
+        return new EchoController
+        {
+            ControllerContext = new ControllerContext { HttpContext = stubContext.HttpContext }
+        };
+    }
+
+    private static EchoResponse GetPayload(IActionResult result)
+    {
+        var content = result.ShouldBeOfType<ContentResult>();
+        var payload = JsonSerializer.Deserialize<EchoResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        return payload!;
+    }
+
+    private sealed class StubEchoHttpContext
+    {
+        private readonly DefaultHttpContext _httpContext = new();
+
+        public StubEchoHttpContext()
+        {
+            _httpContext.Request.Method = "GET";
+            _httpContext.Request.Path = "/api/echo";
+            _httpContext.Request.Scheme = "http";
+            _httpContext.Request.Host = new HostString("localhost");
+            _httpContext.Request.Protocol = "HTTP/1.1";
+        }
+
+        public DefaultHttpContext HttpContext => _httpContext;
+
+        public string Method
+        {
+            set => _httpContext.Request.Method = value;
+        }
+
+        public string Path
+        {
+            set => _httpContext.Request.Path = value;
+        }
+
+        public string QueryString
+        {
+            set => _httpContext.Request.QueryString = new QueryString(value);
+        }
+
+        public string Scheme
+        {
+            set => _httpContext.Request.Scheme = value;
+        }
+
+        public string Host
+        {
+            set => _httpContext.Request.Host = new HostString(value);
+        }
+
+        public string Protocol
+        {
+            set => _httpContext.Request.Protocol = value;
+        }
+
+        public string RemoteIpAddress
+        {
+            set => _httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Parse(value);
+        }
+
+        public IHeaderDictionary Headers => _httpContext.Request.Headers;
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/echo", true)]
+    [TestCase("/api/v1.0/echo", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -107,4 +107,29 @@ public class ApiKeyAuthenticationWebTests
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
     }
+
+    [Test]
+    public async Task Should_Return200_When_EchoWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/echo");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/echo");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_AllowAnonymousAccess_ToEchoEndpoint()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(ApiKeyConstants.HeaderName, "wrong");
+
+        var response = await client.GetAsync("/api/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }


### PR DESCRIPTION
## Summary
Adds `GET /api/echo` and `GET /api/v1.0/echo` returning JSON reflecting the incoming HTTP request for client diagnostics.

## Files
- `src/UI/Api/Controllers/EchoController.cs` — new echo endpoint with `EchoResponse` record
- `src/UI/Api/EchoHeaderRedaction.cs` — redacts Authorization, Cookie, X-Api-Key headers
- `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` — whitelist echo as public path
- `src/UnitTests/UI.Api/EchoControllerTests.cs` — 14 unit tests
- `src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs` — 8 integration tests
- `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` — echo path cases
- `src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs` — echo without API key

## Testing
- `./PrivateBuild.ps1` — all unit + integration tests pass
- Echo returns method, path, query string, scheme, host, protocol, remote IP, headers (redacted), parsed query map
- Accessible without API key when middleware enabled

Closes #7785