### PR TITLE
New API endpoint GET /api/version for build and deployment metadata (#7786)

### DIFF
--- a/src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class VersionEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task GetApiVersion_Returns200_WithAllRequiredProperties()
+    {
+        var response = await _client!.GetAsync("/api/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("assemblyVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("informationalVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("buildConfiguration", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("environment", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("machineName", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("frameworkDescription", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task GetVersionedApiVersion_Returns200_WithAllRequiredProperties()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/version");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("assemblyVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("informationalVersion", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("buildConfiguration", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("environment", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("machineName", out _).ShouldBeTrue();
+        doc.RootElement.TryGetProperty("frameworkDescription", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task GetApiVersion_AllowsAnonymousAccess_NoApiKeyRequired()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/version");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/version");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task GetApiVersion_ReturnsWeakETag_AndSupports304()
+    {
+        var first = await _client!.GetAsync("/api/version");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var etag = first.Headers.ETag;
+        etag.ShouldNotBeNull();
+
+        using var second = new HttpRequestMessage(HttpMethod.Get, "/api/version");
+        second.Headers.IfNoneMatch.Add(etag);
+        var notModified = await _client.SendAsync(second);
+        notModified.StatusCode.ShouldBe(HttpStatusCode.NotModified);
+        (await notModified.Content.ReadAsByteArrayAsync()).Length.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task GetApiVersion_CachesResponse_ForConfiguredPeriod()
+    {
+        using var first = await _client!.GetAsync("/api/version");
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        first.Headers.Age.ShouldBeNull();
+
+        using var second = await _client.GetAsync("/api/version");
+        second.StatusCode.ShouldBe(HttpStatusCode.OK);
+        second.Headers.Age.ShouldNotBeNull();
+        second.Headers.Age!.Value.TotalSeconds.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetApiVersion_ExposesEnvironment_FromHost()
+    {
+        var response = await _client!.GetAsync("/api/version");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<VersionMetadataResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Environment.ShouldBe("Testing");
+        payload.BuildConfiguration.ShouldNotBeNullOrEmpty();
+    }
+}

--- a/src/UI/Api/Controllers/VersionController.cs
+++ b/src/UI/Api/Controllers/VersionController.cs
@@ -31,9 +31,11 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
         var assembly = Assembly.GetExecutingAssembly();
         var assemblyVersion = assembly.GetName().Version?.ToString();
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var buildConfiguration = VersionMetadataReader.GetBuildConfiguration(assembly);
         var payload = new VersionMetadataResponse(
             AssemblyVersion: assemblyVersion,
             InformationalVersion: informationalVersion,
+            BuildConfiguration: buildConfiguration,
             Environment: hostEnvironment.EnvironmentName,
             MachineName: Environment.MachineName,
             FrameworkDescription: RuntimeInformation.FrameworkDescription);
@@ -51,6 +53,16 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
 public record VersionMetadataResponse(
     string? AssemblyVersion,
     string? InformationalVersion,
+    string? BuildConfiguration,
     string? Environment,
     string MachineName,
     string FrameworkDescription);
+
+/// <summary>
+/// Reads build metadata from assembly attributes.
+/// </summary>
+internal static class VersionMetadataReader
+{
+    internal static string? GetBuildConfiguration(Assembly assembly) =>
+        assembly.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration;
+}

--- a/src/UI/Api/UI.Api.csproj
+++ b/src/UI/Api/UI.Api.csproj
@@ -7,6 +7,9 @@
 		<AssemblyName>ClearMeasure.Bootcamp.$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>ClearMeasure.Bootcamp.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<Configurations>Debug;Release;exclude-maui.slnf</Configurations>
+		<Version>1.0.0</Version>
+		<InformationalVersion>1.0.0</InformationalVersion>
+		<AssemblyConfiguration>$(Configuration)</AssemblyConfiguration>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/UnitTests/UI.Api/VersionControllerTests.cs
+++ b/src/UnitTests/UI.Api/VersionControllerTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api;
 using ClearMeasure.Bootcamp.UI.Api.Controllers;
@@ -13,7 +15,7 @@ namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
 public class VersionControllerTests
 {
     [Test]
-    public void Get_Should_ReturnOk_WithExpectedShape()
+    public void Get_ReturnsVersionMetadata_WithBuildConfiguration()
     {
         var stubHostEnvironment = new StubHostEnvironment("TestEnvironment");
         var controller = new VersionController(stubHostEnvironment)
@@ -32,9 +34,44 @@ public class VersionControllerTests
         payload.ShouldNotBeNull();
         payload!.AssemblyVersion.ShouldNotBeNullOrEmpty();
         payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+        payload.BuildConfiguration.ShouldNotBeNullOrEmpty();
         payload.Environment.ShouldBe("TestEnvironment");
         payload.MachineName.ShouldBe(Environment.MachineName);
         payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+    }
+
+    [Test]
+    public void Get_BuildConfiguration_MatchesAssemblyConfigurationAttribute()
+    {
+        var uiApiAssembly = typeof(VersionController).Assembly;
+        var expected = uiApiAssembly.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration;
+
+        var stubHostEnvironment = new StubHostEnvironment("TestEnvironment");
+        var controller = new VersionController(stubHostEnvironment)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+        var content = result.ShouldBeOfType<ContentResult>();
+        var payload = JsonSerializer.Deserialize<VersionMetadataResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+
+        payload.ShouldNotBeNull();
+        expected.ShouldNotBeNullOrEmpty();
+        payload!.BuildConfiguration.ShouldBe(expected);
+    }
+
+    [Test]
+    public void Get_BuildConfiguration_IsNullWhenAttributeAbsent()
+    {
+        var assemblyName = new AssemblyName("VersionMetadataTestAssembly");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+        moduleBuilder.DefineType("Placeholder").CreateType();
+
+        VersionMetadataReader.GetBuildConfiguration(assemblyBuilder).ShouldBeNull();
     }
 
     private sealed class StubHostEnvironment(string environmentName) : IHostEnvironment


### PR DESCRIPTION
## Summary
Adds `buildConfiguration` to the existing `GET /api/version` and `GET /api/v1.0/version` responses, populated from `AssemblyConfigurationAttribute`.

## Files
- `src/UI/Api/Controllers/VersionController.cs` — new `BuildConfiguration` field + `VersionMetadataReader`
- `src/UI/Api/UI.Api.csproj` — emit `Version`, `InformationalVersion`, `AssemblyConfiguration`
- `src/UnitTests/UI.Api/VersionControllerTests.cs` — unit tests for build configuration
- `src/IntegrationTests/Api/VersionEndpointIntegrationTests.cs` — HTTP integration tests

## Testing
- `PrivateBuild.ps1` green (unit + integration)
- New tests cover anonymous access, ETag/304, output cache, and both routes

Closes #7786