### PR TITLE
New API endpoint GET /api/version for build and deployment metadata (#7858)

### DIFF
--- a/src/UI/Api/Controllers/VersionController.cs
+++ b/src/UI/Api/Controllers/VersionController.cs
@@ -31,9 +31,11 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
         var assembly = Assembly.GetExecutingAssembly();
         var assemblyVersion = assembly.GetName().Version?.ToString();
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var buildConfiguration = assembly.GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration;
         var payload = new VersionMetadataResponse(
             AssemblyVersion: assemblyVersion,
             InformationalVersion: informationalVersion,
+            BuildConfiguration: buildConfiguration,
             Environment: hostEnvironment.EnvironmentName,
             MachineName: Environment.MachineName,
             FrameworkDescription: RuntimeInformation.FrameworkDescription);
@@ -51,6 +53,7 @@ public class VersionController(IHostEnvironment hostEnvironment) : ControllerBas
 public record VersionMetadataResponse(
     string? AssemblyVersion,
     string? InformationalVersion,
+    string? BuildConfiguration,
     string? Environment,
     string MachineName,
     string FrameworkDescription);

--- a/src/UnitTests/UI.Api/VersionControllerTests.cs
+++ b/src/UnitTests/UI.Api/VersionControllerTests.cs
@@ -32,9 +32,29 @@ public class VersionControllerTests
         payload.ShouldNotBeNull();
         payload!.AssemblyVersion.ShouldNotBeNullOrEmpty();
         payload.InformationalVersion.ShouldNotBeNullOrEmpty();
+        payload.BuildConfiguration.ShouldNotBeNullOrWhiteSpace();
         payload.Environment.ShouldBe("TestEnvironment");
         payload.MachineName.ShouldBe(Environment.MachineName);
         payload.FrameworkDescription.ShouldBe(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+    }
+
+    [Test]
+    public void VersionController_Get_Should_IncludeBuildConfiguration()
+    {
+        var stubHostEnvironment = new StubHostEnvironment("TestEnvironment");
+        var controller = new VersionController(stubHostEnvironment)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var payload = JsonSerializer.Deserialize<VersionMetadataResponse>(
+            content.Content!,
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.BuildConfiguration.ShouldNotBeNullOrWhiteSpace();
     }
 
     private sealed class StubHostEnvironment(string environmentName) : IHostEnvironment


### PR DESCRIPTION
## Summary
Adds `BuildConfiguration` to the existing `GET /api/version` JSON response by reading `AssemblyConfigurationAttribute` from the executing assembly.

## Files changed
- `src/UI/Api/Controllers/VersionController.cs` — populate `BuildConfiguration` on `VersionMetadataResponse`
- `src/UnitTests/UI.Api/VersionControllerTests.cs` — assert non-empty `BuildConfiguration` in existing shape test; add dedicated test

## Testing
- `PrivateBuild.ps1` green (unit + integration)
- `VersionControllerTests` (2 tests) pass

Closes #7858