### PR TITLE
New API endpoint GET /api/health/detailed for component-level health reporting (#7855)

### DIFF
--- a/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/DetailedHealthEndpointIntegrationTests.cs
@@ -301,7 +301,7 @@ public class DetailedHealthEndpointIntegrationTests
     }
 
     [Test]
-    public async Task GetApiHealthDetailedReturnsTimeZoneId()
+    public async Task Should_IncludeTimeZoneId_When_GetDetailedHealth()
     {
         var response = await _client!.GetAsync("/api/health/detailed");
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -340,6 +340,26 @@ public class DetailedHealthEndpointIntegrationTests
         report!.ProcessPriority.ShouldNotBeNull();
         report.ProcessPriority.ShouldNotBeEmpty();
         report.ProcessPriority.ShouldBe(Process.GetCurrentProcess().PriorityClass.ToString());
+    }
+
+    [Test]
+    public async Task Should_Return200AndSamePayload_When_GetDetailedHealth_LegacyAndV1Paths()
+    {
+        var legacy = await _client!.GetAsync("/api/health/detailed");
+        var v1 = await _client.GetAsync("/api/v1.0/health/detailed");
+
+        legacy.StatusCode.ShouldBe(HttpStatusCode.OK);
+        v1.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var legacyReport = await legacy.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var v1Report = await v1.Content.ReadFromJsonAsync<DetailedHealthReport>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        legacyReport.ShouldNotBeNull();
+        v1Report.ShouldNotBeNull();
+        v1Report!.OverallStatus.ShouldBe(legacyReport!.OverallStatus);
+        v1Report.Components.Count.ShouldBe(legacyReport.Components.Count);
     }
 
     [Test]

--- a/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
+++ b/src/UnitTests/UI.Server/EtagConditionalGetWebTests.cs
@@ -41,4 +41,13 @@ public class EtagConditionalGetWebTests
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Headers.ETag.ShouldNotBeNull();
     }
+
+    [Test]
+    public async Task Should_IncludeEtagHeader_When_GetDetailedHealth()
+    {
+        using var client = _factory!.CreateClient();
+        var response = await client.GetAsync("/api/health/detailed");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.ETag.ShouldNotBeNull();
+    }
 }


### PR DESCRIPTION
## Summary

Implements `GET /api/health/detailed` (and versioned `GET /api/v1.0/health/detailed`) returning JSON with per-component health plus host/runtime metadata.

## Key files

- `UI.Api/DetailedHealthModels.cs`, `HealthReportBuilder.cs`, `IDetailedHealthReportProvider.cs`
- `UI.Api/Controllers/DetailedHealthController.cs` — anonymous, rate-limited, ETag-capable
- `UI.Server/DetailedHealthReportProvider.cs` — aggregates `HealthCheckService` (excludes `live`-tagged probes)
- Unit tests: `HealthReportBuilderTests`, `DetailedHealthReportProviderTests`
- Integration tests: `DetailedHealthEndpointIntegrationTests` (includes versioned route parity)

## Testing

- `./PrivateBuild.ps1` — green (unit + integration)
- Anonymous access verified; expected components: LlmGateway, DataAccess, Server, API, Jeffrey

Closes #7855