### PR TITLE
Add navigate hide button (#7854)

### DIFF
--- a/src/UI.Shared/NavMenu.Razor.cs
+++ b/src/UI.Shared/NavMenu.Razor.cs
@@ -11,15 +11,6 @@ public partial class NavMenu : AppComponentBase,
 {
     [Inject] public IUserSession? UserSession { get; set; }
 
-    private bool collapseNavMenu = true;
-
-    private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
-
-    private void ToggleNavMenu()
-    {
-        collapseNavMenu = !collapseNavMenu;
-    }
-
     private Employee? CurrentUser { get; set; }
 
     protected override async Task OnInitializedAsync()

--- a/src/UI.Shared/NavMenu.razor
+++ b/src/UI.Shared/NavMenu.razor
@@ -1,13 +1,4 @@
-<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">Menu</a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-    </div>
-</div>
-
-<div class="@NavMenuCssClass nav-scrollable" @onclick="ToggleNavMenu">
+<div class="nav-scrollable">
     <nav class="flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">

--- a/src/UI.Shared/NavMenu.razor.css
+++ b/src/UI.Shared/NavMenu.razor.css
@@ -1,47 +1,8 @@
-﻿/* Navigation Toggle Button */
-.navbar-toggler {
-    appearance: none;
-    cursor: pointer;
-    width: 3.5rem;
-    height: 2.5rem;
-    color: #2d3748;
-    position: absolute;
-    top: 0.5rem;
-    right: 1rem;
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    border-radius: 6px;
-    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2845, 55, 72, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.75rem rgba(255, 255, 255, 0.8);
-    transition: all 0.2s ease-in-out;
-}
-
-.navbar-toggler:hover {
-    background-color: rgba(255, 255, 255, 0.9);
-    border-color: rgba(0, 0, 0, 0.3);
-}
-
-.navbar-toggler:checked {
-    background-color: rgba(255, 255, 255, 1);
-}
-
-/* Top Navigation Bar */
-.top-row {
-    min-height: 3.5rem;
-    background: rgba(255, 255, 255, 0.8);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.navbar-brand {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: #2d3748 !important;
-    text-decoration: none;
-}
-
-/* Navigation Items Container */
+﻿/* Navigation Items Container */
 .nav-scrollable {
     background: transparent;
-    min-height: calc(100vh - 3.5rem);
-    display: none;
+    display: block;
+    overflow-y: auto;
 }
 
 .nav-scrollable nav {
@@ -162,21 +123,21 @@
     color: #dd6b20;
 }
 
-/* Mobile Toggle State */
-.navbar-toggler:checked ~ .nav-scrollable {
-    display: block;
-    animation: slideDown 0.3s ease-out;
+.nav-scrollable::-webkit-scrollbar {
+    width: 6px;
 }
 
-@keyframes slideDown {
-    from {
-        opacity: 0;
-        transform: translateY(-10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+.nav-scrollable::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.nav-scrollable::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 3px;
+}
+
+.nav-scrollable::-webkit-scrollbar-thumb:hover {
+    background: rgba(0, 0, 0, 0.3);
 }
 
 /* Responsive Design */
@@ -198,43 +159,8 @@
     }
 }
 
-@media (min-width: 641px) {
-    .navbar-toggler {
-        display: none;
-    }
-
-    .nav-scrollable {
-        display: block !important;
-        height: calc(100vh - 3.5rem);
-        overflow-y: auto;
-        box-shadow: none;
-    }
-    
-    .nav-scrollable::-webkit-scrollbar {
-        width: 6px;
-    }
-    
-    .nav-scrollable::-webkit-scrollbar-track {
-        background: transparent;
-    }
-    
-    .nav-scrollable::-webkit-scrollbar-thumb {
-        background: rgba(0, 0, 0, 0.2);
-        border-radius: 3px;
-    }
-    
-    .nav-scrollable::-webkit-scrollbar-thumb:hover {
-        background: rgba(0, 0, 0, 0.3);
-    }
-}
-
 /* Focus states for accessibility */
 .nav-item .nav-link:focus {
     outline: 2px solid #4a5568;
-    outline-offset: 2px;
-}
-
-.navbar-toggler:focus {
-    outline: 2px solid #2d3748;
     outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary

Completes #7854: header nav-rail toggle on `MainLayout` collapses the left sidebar on wide viewports and drives a mobile overlay drawer at ≤768px. Removes the legacy `NavMenu` navbar-toggler now superseded by the rail toggle.

## Files

- `MainLayout.razor` / `.razor.cs` / `.razor.css` — toggle button, state, CSS collapse/overlay
- `wwwroot/js/mainLayoutNav.js` — viewport `matchMedia` interop
- `NavMenu.razor` / `.Razor.cs` / `.razor.css` — removed legacy toggler
- `MainLayoutTests.cs` — bUnit coverage
- `NavRailToggleTests.cs` — Playwright acceptance tests

## Testing

- `PrivateBuild.ps1` — green (unit + integration)
- bUnit: aria/classes/icons/focus on narrow viewport
- Playwright: wide collapse, mobile overlay, anonymous landing

Closes #7854