### PR TITLE
New API endpoint GET /api/tools/random for configurable random data generation (#7863)

### DIFF
--- a/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs
@@ -1,0 +1,144 @@
+using System.Globalization;
+using System.Net;
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class ToolsRandomEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200WithRandomNumber_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=number");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        var body = await response.Content.ReadAsStringAsync();
+        int.TryParse(body, NumberStyles.Integer, CultureInfo.InvariantCulture, out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200WithRandomNumber_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/tools/random?type=number");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        var body = await response.Content.ReadAsStringAsync();
+        int.TryParse(body, NumberStyles.Integer, CultureInfo.InvariantCulture, out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200WithRandomString_When_GetString()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=string");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Length.ShouldBe(16);
+        Regex.IsMatch(body, "^[a-zA-Z0-9]+$").ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200WithUuid_When_GetUuid()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=uuid");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        Guid.TryParse(body, out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200WithColor_When_GetColor()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=color");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        Regex.IsMatch(body, "^#[0-9A-Fa-f]{6}$").ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200AndVary_When_CalledTwiceForNumber()
+    {
+        var first = await _client!.GetAsync("/api/tools/random?type=number&min=0&max=1000000");
+        var second = await _client.GetAsync("/api/tools/random?type=number&min=0&max=1000000");
+
+        first.StatusCode.ShouldBe(HttpStatusCode.OK);
+        second.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var firstBody = await first.Content.ReadAsStringAsync();
+        var secondBody = await second.Content.ReadAsStringAsync();
+        firstBody.ShouldNotBe(secondBody);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_TypeMissing()
+    {
+        var response = await _client!.GetAsync("/api/tools/random");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("problem+json");
+    }
+
+    [Test]
+    public async Task Should_Return400_When_InvalidType()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=invalid");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("problem+json");
+    }
+
+    [Test]
+    public async Task Should_Return400_When_MinGreaterThanMax()
+    {
+        var response = await _client!.GetAsync("/api/tools/random?type=number&min=100&max=50");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("problem+json");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_MiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/tools/random?type=number");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/tools/random?type=number");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/src/UI/Api/Controllers/ToolsRandomController.cs
+++ b/src/UI/Api/Controllers/ToolsRandomController.cs
@@ -1,0 +1,97 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes configurable random data generation for scripts and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/random")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/random")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class ToolsRandomController(Random? random = null) : ControllerBase
+{
+    private readonly Random _random = random ?? Random.Shared;
+
+    /// <summary>
+    /// Returns a random value as plain text for the requested <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">One of <c>number</c>, <c>string</c>, <c>uuid</c>, or <c>color</c> (case-insensitive).</param>
+    /// <param name="min">Inclusive lower bound for <c>number</c> (default 0).</param>
+    /// <param name="max">Exclusive upper bound for <c>number</c> (default 100).</param>
+    /// <param name="length">Length for <c>string</c> (default 16, maximum 256).</param>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get(
+        [FromQuery] string? type,
+        [FromQuery] int? min,
+        [FromQuery] int? max,
+        [FromQuery] int? length)
+    {
+        if (string.IsNullOrWhiteSpace(type) || !RandomToolsGenerator.SupportedTypes.Contains(type))
+        {
+            return Problem(
+                detail: "Query parameter 'type' is required and must be one of: number, string, uuid, color.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        string content;
+        switch (type.ToLowerInvariant())
+        {
+            case "number":
+            {
+                var resolvedMin = RandomToolsGenerator.ResolveMin(min);
+                var resolvedMax = RandomToolsGenerator.ResolveMax(max);
+                if (resolvedMin >= resolvedMax)
+                {
+                    return Problem(
+                        detail: "For type 'number', 'min' must be less than 'max'.",
+                        statusCode: StatusCodes.Status400BadRequest);
+                }
+
+                content = RandomToolsGenerator.GenerateNumber(_random, resolvedMin, resolvedMax);
+                break;
+            }
+
+            case "string":
+            {
+                var resolvedLength = RandomToolsGenerator.ResolveStringLength(length);
+                if (resolvedLength <= 0 || resolvedLength > RandomToolsGenerator.MaxStringLength)
+                {
+                    return Problem(
+                        detail: $"For type 'string', 'length' must be between 1 and {RandomToolsGenerator.MaxStringLength}.",
+                        statusCode: StatusCodes.Status400BadRequest);
+                }
+
+                content = RandomToolsGenerator.GenerateString(_random, resolvedLength);
+                break;
+            }
+
+            case "uuid":
+                content = Guid.NewGuid().ToString();
+                break;
+
+            case "color":
+                content = RandomToolsGenerator.GenerateColor(_random);
+                break;
+
+            default:
+                return Problem(
+                    detail: "Query parameter 'type' is required and must be one of: number, string, uuid, color.",
+                    statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        return new ContentResult
+        {
+            Content = content,
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = StatusCodes.Status200OK
+        };
+    }
+}

--- a/src/UI/Api/RandomToolsGenerator.cs
+++ b/src/UI/Api/RandomToolsGenerator.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using System.Text;
+
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// Generates random plain-text values for the tools/random API.
+/// </summary>
+public static class RandomToolsGenerator
+{
+    private const int DefaultMin = 0;
+    private const int DefaultMax = 100;
+    private const int DefaultStringLength = 16;
+    internal const int MaxStringLength = 256;
+
+    private const string AlphanumericCharset =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    /// <summary>
+    /// Supported <c>type</c> query values (case-insensitive).
+    /// </summary>
+    public static readonly HashSet<string> SupportedTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "number",
+        "string",
+        "uuid",
+        "color"
+    };
+
+    /// <summary>
+    /// Generates a random number as a decimal string using an exclusive upper bound.
+    /// </summary>
+    public static string GenerateNumber(Random random, int min = DefaultMin, int max = DefaultMax) =>
+        random.Next(min, max).ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Generates a random alphanumeric string of the requested length.
+    /// </summary>
+    public static string GenerateString(Random random, int length = DefaultStringLength)
+    {
+        var builder = new StringBuilder(length);
+        for (var i = 0; i < length; i++)
+        {
+            var index = random.Next(AlphanumericCharset.Length);
+            builder.Append(AlphanumericCharset[index]);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Generates a random hex color code in <c>#RRGGBB</c> form.
+    /// </summary>
+    public static string GenerateColor(Random random)
+    {
+        var r = random.Next(256);
+        var g = random.Next(256);
+        var b = random.Next(256);
+        return string.Create(CultureInfo.InvariantCulture, $"#{r:X2}{g:X2}{b:X2}");
+    }
+
+    internal static int ResolveMin(int? min) => min ?? DefaultMin;
+
+    internal static int ResolveMax(int? max) => max ?? DefaultMax;
+
+    internal static int ResolveStringLength(int? length) => length ?? DefaultStringLength;
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and tools/random endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -57,7 +57,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             return false;
         }
 
-        if (IsPublicVersionOrTimePath(value))
+        if (IsPublicUtilityApiPath(value))
         {
             return false;
         }
@@ -65,7 +65,7 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
         return true;
     }
 
-    internal static bool IsPublicVersionOrTimePath(string pathValue)
+    internal static bool IsPublicUtilityApiPath(string pathValue)
     {
         var segments = pathValue.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 2 || !segments[0].Equals("api", StringComparison.OrdinalIgnoreCase))
@@ -75,23 +75,36 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 
         if (segments.Length == 2)
         {
-            var leaf = segments[1];
-            return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+            return IsPublicUtilityLeaf(segments[1]);
+        }
+
+        if (segments.Length == 3
+            && segments[1].Equals("tools", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("random", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         if (segments.Length >= 3
             && segments[1].StartsWith("v", StringComparison.OrdinalIgnoreCase))
         {
-            var leaf = segments[2];
-            return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+            if (IsPublicUtilityLeaf(segments[2]))
+            {
+                return true;
+            }
+
+            return segments.Length >= 4
+                   && segments[2].Equals("tools", StringComparison.OrdinalIgnoreCase)
+                   && segments[3].Equals("random", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;
     }
+
+    private static bool IsPublicUtilityLeaf(string segment) =>
+        segment.Equals("version", StringComparison.OrdinalIgnoreCase)
+        || segment.Equals("time", StringComparison.OrdinalIgnoreCase)
+        || segment.Equals("ping", StringComparison.OrdinalIgnoreCase);
 
     private static bool FixedTimeEqualsUtf8(string expected, string provided)
     {

--- a/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
+++ b/src/UnitTests/UI.Api/ToolsRandomControllerTests.cs
@@ -1,0 +1,168 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class ToolsRandomControllerTests
+{
+    [Test]
+    public void Get_WithTypeNumber_Should_ReturnPlainTextNumber()
+    {
+        var controller = CreateController(new StubRandom(42));
+
+        var result = controller.Get("number", null, null, null);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        var value = int.Parse(content.Content!, CultureInfo.InvariantCulture);
+        value.ShouldBeInRange(0, 99);
+    }
+
+    [Test]
+    public void Get_WithTypeNumber_And_CustomBounds_Should_ReturnNumberInRange()
+    {
+        var controller = CreateController(new StubRandom(7));
+
+        var result = controller.Get("number", 10, 20, null);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        var value = int.Parse(content.Content!, CultureInfo.InvariantCulture);
+        value.ShouldBeGreaterThanOrEqualTo(10);
+        value.ShouldBeLessThan(20);
+    }
+
+    [Test]
+    public void Get_WithTypeNumber_And_InvalidBounds_Should_Return400()
+    {
+        var controller = CreateController(new StubRandom(1));
+
+        var result = controller.Get("number", 100, 50, null);
+
+        var problem = result.ShouldBeOfType<ObjectResult>();
+        problem.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_WithTypeString_Should_ReturnPlainTextAlphanumeric()
+    {
+        var controller = CreateController(new StubRandom(12345));
+
+        var result = controller.Get("string", null, null, null);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        content.Content!.Length.ShouldBe(16);
+        Regex.IsMatch(content.Content, "^[a-zA-Z0-9]+$").ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_WithTypeString_And_CustomLength_Should_ReturnStringOfLength()
+    {
+        var controller = CreateController(new StubRandom(99));
+
+        var result = controller.Get("string", null, null, 8);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.Content!.Length.ShouldBe(8);
+    }
+
+    [Test]
+    public void Get_WithTypeString_And_InvalidLength_Should_Return400()
+    {
+        var controller = CreateController(new StubRandom(1));
+
+        controller.Get("string", null, null, 0).ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(400);
+        controller.Get("string", null, null, -1).ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(400);
+        controller.Get("string", null, null, 257).ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_WithTypeUuid_Should_ReturnPlainTextGuid()
+    {
+        var controller = CreateController(new StubRandom(1));
+
+        var result = controller.Get("uuid", null, null, null);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        Guid.TryParse(content.Content, out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_WithTypeColor_Should_ReturnHexColorCode()
+    {
+        var controller = CreateController(new StubRandom(0xAABBCC));
+
+        var result = controller.Get("color", null, null, null);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        Regex.IsMatch(content.Content!, "^#[0-9A-Fa-f]{6}$").ShouldBeTrue();
+    }
+
+    [Test]
+    public void Get_WithMissingType_Should_Return400()
+    {
+        var controller = CreateController(new StubRandom(1));
+
+        var result = controller.Get(null, null, null, null);
+
+        result.ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_WithInvalidType_Should_Return400()
+    {
+        var controller = CreateController(new StubRandom(1));
+
+        var result = controller.Get("invalid", null, null, null);
+
+        result.ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Get_WithTypeIgnoreCase_Should_Succeed()
+    {
+        var controller = CreateController(new StubRandom(5));
+
+        controller.Get("NUMBER", null, null, null).ShouldBeOfType<ContentResult>();
+        controller.Get("String", null, null, null).ShouldBeOfType<ContentResult>();
+        controller.Get("UUID", null, null, null).ShouldBeOfType<ContentResult>();
+        controller.Get("Color", null, null, null).ShouldBeOfType<ContentResult>();
+    }
+
+    [Test]
+    public void Get_WithStubRandom_Should_GenerateDeterministicNumber()
+    {
+        var controller = CreateController(new StubRandom(3));
+
+        var result = controller.Get("number", 0, 10, null);
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.Content.ShouldBe("3");
+    }
+
+    private static ToolsRandomController CreateController(Random random) =>
+        new(random)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+    private sealed class StubRandom(int nextValue) : Random
+    {
+        public override int Next(int minValue, int maxValue) =>
+            Math.Clamp(nextValue, minValue, maxValue - 1);
+
+        public override int Next(int maxValue) => Math.Clamp(nextValue, 0, maxValue - 1);
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/tools/random", true)]
+    [TestCase("/api/v1.0/tools/random", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationWebTests.cs
@@ -107,4 +107,17 @@ public class ApiKeyAuthenticationWebTests
         versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
         (await versioned.Content.ReadAsStringAsync()).ShouldBe("pong");
     }
+
+    [Test]
+    public async Task Should_Return200_When_ToolsRandomWithoutKey()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/tools/random?type=number");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/tools/random?type=number");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }


### PR DESCRIPTION
## Summary
Adds `GET /api/tools/random` — a stateless utility endpoint for generating random plain-text data (number, string, uuid, color).

## Files
- `src/UI/Api/Controllers/ToolsRandomController.cs` — controller with dual routes, rate limiting, anonymous access
- `src/UI/Api/RandomToolsGenerator.cs` — generation/validation helper
- `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` — public allowlist for tools/random
- `src/UnitTests/UI.Api/ToolsRandomControllerTests.cs` — 12 unit tests with StubRandom
- `src/IntegrationTests/Api/ToolsRandomEndpointIntegrationTests.cs` — 10 integration tests
- Updated API-key middleware/web tests

## Testing
- `./PrivateBuild.ps1` green (unit + integration)
- No Blazor/acceptance changes (no UX impact)

Closes #7863