### PR TITLE
New API endpoint POST /api/tools/guid-generator for on-demand GUID creation (#7859)

### DIFF
--- a/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/GuidGeneratorEndpointIntegrationTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using System.Net.Http.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using ClearMeasure.Bootcamp.UnitTests.Api;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class GuidGeneratorEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200WithGuids_When_PostUnversionedEndpoint()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        payload.ShouldNotBeNull();
+        payload!.Guids.Count.ShouldBe(1);
+        Guid.TryParse(payload.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200WithGuids_When_PostVersionedEndpoint()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/v1.0/tools/guid-generator", new { });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        payload.ShouldNotBeNull();
+        payload!.Guids.Count.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task Should_Return200WithCountGuids_When_PostWithCountParameter()
+    {
+        var response = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 10 });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<GuidGeneratorResponse>();
+        payload.ShouldNotBeNull();
+        payload!.Guids.Count.ShouldBe(10);
+        foreach (var guid in payload.Guids)
+        {
+            Guid.TryParse(guid, out _).ShouldBeTrue();
+        }
+    }
+
+    [Test]
+    public async Task Should_Return400_When_PostWithInvalidCount()
+    {
+        var tooMany = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 101 });
+        tooMany.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        var zero = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = 0 });
+        zero.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        var negative = await _client!.PostAsJsonAsync("/api/tools/guid-generator", new { count = -1 });
+        negative.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_Respect_RateLimiting_When_PostMultipleTimes()
+    {
+        await using var factory = new RateLimitedApiWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        (await client.PostAsJsonAsync("/api/tools/guid-generator", new { })).StatusCode
+            .ShouldBe(HttpStatusCode.OK);
+        (await client.PostAsJsonAsync("/api/tools/guid-generator", new { })).StatusCode
+            .ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+}

--- a/src/UI/Api/Controllers/GuidGeneratorController.cs
+++ b/src/UI/Api/Controllers/GuidGeneratorController.cs
@@ -1,0 +1,61 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Generates one or more GUIDs on demand for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/tools/guid-generator")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/tools/guid-generator")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class GuidGeneratorController : ControllerBase
+{
+    private const int MinCount = 1;
+    private const int MaxCount = 100;
+
+    /// <summary>
+    /// Generates new GUIDs. Optional <paramref name="count"/> defaults to 1 (valid range 1–100).
+    /// </summary>
+    /// <param name="request">Optional JSON body with a <c>count</c> property.</param>
+    /// <param name="count">Optional query-string override for the number of GUIDs to generate.</param>
+    [HttpPost]
+    [AllowAnonymous]
+    public IActionResult Post([FromBody] GuidGeneratorRequest? request, [FromQuery] int? count)
+    {
+        var resolvedCount = count ?? request?.Count ?? 1;
+
+        if (resolvedCount < MinCount || resolvedCount > MaxCount)
+        {
+            return Problem(
+                detail: $"count must be between {MinCount} and {MaxCount} inclusive.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var guids = new string[resolvedCount];
+        for (var i = 0; i < resolvedCount; i++)
+        {
+            guids[i] = Guid.NewGuid().ToString("D");
+        }
+
+        return Ok(new GuidGeneratorResponse(guids));
+    }
+}
+
+/// <summary>
+/// JSON request body for <c>POST /api/tools/guid-generator</c>.
+/// </summary>
+/// <param name="Count">Number of GUIDs to generate (1–100). Defaults to 1 when omitted.</param>
+public record GuidGeneratorRequest(int? Count);
+
+/// <summary>
+/// JSON payload returned by <c>POST /api/tools/guid-generator</c>.
+/// </summary>
+/// <param name="Guids">Generated GUID strings in lowercase hyphenated format.</param>
+public record GuidGeneratorResponse(IReadOnlyList<string> Guids);

--- a/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
+++ b/src/UnitTests/UI.Api/GuidGeneratorControllerTests.cs
@@ -1,0 +1,109 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class GuidGeneratorControllerTests
+{
+    [Test]
+    public void Should_Post_ReturnSingleGuid_When_DefaultCount()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(null, null);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.StatusCode.ShouldBe(200);
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(1);
+        Guid.TryParse(payload.Guids[0], out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public void Should_Post_ReturnArrayOfGuids_When_CountSpecified()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(5), null);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(5);
+        payload.Guids.Distinct().Count().ShouldBe(5);
+        foreach (var guid in payload.Guids)
+        {
+            Guid.TryParse(guid, out _).ShouldBeTrue();
+        }
+    }
+
+    [Test]
+    public void Should_Post_ReturnBadRequest_When_CountIsZero()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(0), null);
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Should_Post_ReturnBadRequest_When_CountExceedsMaximum()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(101), null);
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Should_Post_ReturnBadRequest_When_CountIsNegative()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(-1), null);
+
+        var objectResult = result.ShouldBeOfType<ObjectResult>();
+        objectResult.StatusCode.ShouldBe(400);
+    }
+
+    [Test]
+    public void Should_Post_ReturnValidGuidFormat_When_GuidsGenerated()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(new GuidGeneratorRequest(3), null);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        foreach (var guid in payload.Guids)
+        {
+            Guid.TryParse(guid, out var parsed).ShouldBeTrue();
+            guid.ShouldBe(parsed.ToString("D"));
+            guid.ShouldBe(guid.ToLowerInvariant());
+        }
+    }
+
+    [Test]
+    public void Should_Post_UseQueryStringCount_When_Provided()
+    {
+        var controller = CreateController();
+
+        var result = controller.Post(null, 2);
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        var payload = ok.Value.ShouldBeOfType<GuidGeneratorResponse>();
+        payload.Guids.Count.ShouldBe(2);
+    }
+
+    private static GuidGeneratorController CreateController() =>
+        new()
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+}


### PR DESCRIPTION
## Summary
Adds `POST /api/tools/guid-generator` — a stateless utility endpoint that returns one or more GUIDs.

## Changes
- `GuidGeneratorController` with unversioned + versioned routes, rate limiting, anonymous access
- Optional `count` via JSON body or query string (default 1, max 100)
- Unit tests: `GuidGeneratorControllerTests.cs`
- Integration tests: `GuidGeneratorEndpointIntegrationTests.cs`

## Testing
- `./PrivateBuild.ps1` — green (unit + integration)
- Acceptance tests skipped (backend-only, no UX change)

Closes #7859