### PR TITLE
New API endpoint GET /api/echo with request reflection for debugging (#7857)

### DIFF
--- a/src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class EchoEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        AssertEchoShape(doc.RootElement);
+    }
+
+    [Test]
+    public async Task Should_Return200AndJson_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/echo");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        AssertEchoShape(doc.RootElement);
+    }
+
+    [Test]
+    public async Task Should_ReflectRequestMethod_When_Called()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Method.ShouldBe("GET");
+    }
+
+    [Test]
+    public async Task Should_ReflectRequestPath_When_Called()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Path.ShouldBe("/api/echo");
+    }
+
+    [Test]
+    public async Task Should_ReflectQueryString_When_CalledWithQuery()
+    {
+        var response = await _client!.GetAsync("/api/echo?foo=bar&tag=a&tag=b");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.QueryString.ShouldBe("?foo=bar&tag=a&tag=b");
+        payload.Query.ShouldContainKey("foo");
+        payload.Query["foo"].ShouldBe(["bar"]);
+        payload.Query.ShouldContainKey("tag");
+        payload.Query["tag"].ShouldBe(["a", "b"]);
+    }
+
+    [Test]
+    public async Task Should_ReflectHeaders_When_CalledWithHeaders()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/echo");
+        request.Headers.TryAddWithoutValidation("User-Agent", "EchoIntegrationTest/1.0");
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+
+        var response = await _client!.SendAsync(request);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<EchoResponse>(
+            ConditionalGetEtag.JsonSerializerOptions);
+        payload.ShouldNotBeNull();
+        payload!.Headers.Keys.ShouldContain(k => k.Equals("User-Agent", StringComparison.OrdinalIgnoreCase));
+        payload.Headers.Keys.ShouldContain(k => k.Equals("Accept", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public async Task Should_ReflectRemoteIp_When_Called()
+    {
+        var response = await _client!.GetAsync("/api/echo");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+        doc.RootElement.TryGetProperty("remoteIp", out _).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_EchoAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/echo");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var versioned = await client.GetAsync("/api/v1.0/echo");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private static void AssertEchoShape(JsonElement root)
+    {
+        root.TryGetProperty("method", out _).ShouldBeTrue();
+        root.TryGetProperty("path", out _).ShouldBeTrue();
+        root.TryGetProperty("queryString", out _).ShouldBeTrue();
+        root.TryGetProperty("scheme", out _).ShouldBeTrue();
+        root.TryGetProperty("host", out _).ShouldBeTrue();
+        root.TryGetProperty("protocol", out _).ShouldBeTrue();
+        root.TryGetProperty("remoteIp", out _).ShouldBeTrue();
+        root.TryGetProperty("headers", out _).ShouldBeTrue();
+        root.TryGetProperty("query", out _).ShouldBeTrue();
+    }
+}

--- a/src/UI/Api/Controllers/EchoController.cs
+++ b/src/UI/Api/Controllers/EchoController.cs
@@ -1,0 +1,48 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a JSON reflection of the incoming HTTP request for client and operator debugging.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/echo")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/echo")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class EchoController : ControllerBase
+{
+    /// <summary>
+    /// Returns key properties of the current HTTP request (method, path, query, headers, host, client IP).
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        var request = Request;
+        var headers = request.Headers
+            .ToDictionary(h => h.Key, h => string.Join(", ", h.Value.ToArray()), StringComparer.OrdinalIgnoreCase);
+        var query = request.Query
+            .ToDictionary(
+                q => q.Key,
+                q => q.Value.Select(v => v ?? string.Empty).ToArray(),
+                StringComparer.OrdinalIgnoreCase);
+
+        var payload = new EchoResponse(
+            Method: request.Method,
+            Path: request.Path.Value ?? string.Empty,
+            QueryString: request.QueryString.Value ?? string.Empty,
+            Scheme: request.Scheme,
+            Host: request.Host.Value ?? string.Empty,
+            Protocol: request.Protocol,
+            RemoteIp: HttpContext.Connection.RemoteIpAddress?.ToString(),
+            Headers: headers,
+            Query: query);
+
+        return ConditionalGetEtag.JsonContent(payload);
+    }
+}

--- a/src/UI/Api/EchoModels.cs
+++ b/src/UI/Api/EchoModels.cs
@@ -1,0 +1,15 @@
+namespace ClearMeasure.Bootcamp.UI.Api;
+
+/// <summary>
+/// JSON payload for <c>GET /api/echo</c> and <c>GET /api/v1.0/echo</c>.
+/// </summary>
+public sealed record EchoResponse(
+    string Method,
+    string Path,
+    string QueryString,
+    string Scheme,
+    string Host,
+    string Protocol,
+    string? RemoteIp,
+    IReadOnlyDictionary<string, string> Headers,
+    IReadOnlyDictionary<string, string[]> Query);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and echo endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("echo", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/EchoControllerTests.cs
+++ b/src/UnitTests/UI.Api/EchoControllerTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class EchoControllerTests
+{
+    private static EchoController CreateController(HttpContext httpContext)
+    {
+        return new EchoController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    private static EchoResponse Deserialize(ContentResult content) =>
+        JsonSerializer.Deserialize<EchoResponse>(content.Content!, ConditionalGetEtag.JsonSerializerOptions)!;
+
+    [Test]
+    public void Get_ReturnsJsonWithRequestMethod_When_Called()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+
+        var result = CreateController(context).Get();
+        var payload = Deserialize(result.ShouldBeOfType<ContentResult>());
+
+        payload.Method.ShouldBe("GET");
+    }
+
+    [Test]
+    public void Get_ReturnsJsonWithRequestPath_When_Called()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/echo";
+
+        var result = CreateController(context).Get();
+        var payload = Deserialize(result.ShouldBeOfType<ContentResult>());
+
+        payload.Path.ShouldBe("/api/echo");
+    }
+
+    [Test]
+    public void Get_ReturnsJsonWithQueryString_When_Called()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?foo=bar&baz=1");
+
+        var result = CreateController(context).Get();
+        var payload = Deserialize(result.ShouldBeOfType<ContentResult>());
+
+        payload.QueryString.ShouldBe("?foo=bar&baz=1");
+    }
+
+    [Test]
+    public void Get_ReturnsJsonWithSchemeHostPort_When_Called()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("localhost", 7174);
+        context.Request.Protocol = HttpProtocol.Http2;
+
+        var result = CreateController(context).Get();
+        var payload = Deserialize(result.ShouldBeOfType<ContentResult>());
+
+        payload.Scheme.ShouldBe("https");
+        payload.Host.ShouldBe("localhost:7174");
+        payload.Protocol.ShouldBe(HttpProtocol.Http2);
+    }
+
+    [Test]
+    public void Get_ReturnsJsonWithRemoteIp_When_Called()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Loopback;
+
+        var result = CreateController(context).Get();
+        var payload = Deserialize(result.ShouldBeOfType<ContentResult>());
+
+        payload.RemoteIp.ShouldBe("127.0.0.1");
+    }
+
+    [Test]
+    public void Get_ReturnsJsonWithHeaders_When_Called()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.UserAgent = "EchoTestAgent/1.0";
+        context.Request.Headers.Accept = "application/json";
+
+        var result = CreateController(context).Get();
+        var payload = Deserialize(result.ShouldBeOfType<ContentResult>());
+
+        payload.Headers.ShouldContainKey("User-Agent");
+        payload.Headers["User-Agent"].ShouldBe("EchoTestAgent/1.0");
+        payload.Headers.ShouldContainKey("Accept");
+        payload.Headers["Accept"].ShouldBe("application/json");
+    }
+
+    [Test]
+    public void Get_ReturnsJsonWithParsedQuery_When_Called()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?foo=bar&tag=a&tag=b");
+
+        var result = CreateController(context).Get();
+        var payload = Deserialize(result.ShouldBeOfType<ContentResult>());
+
+        payload.Query.ShouldContainKey("foo");
+        payload.Query["foo"].ShouldBe(["bar"]);
+        payload.Query.ShouldContainKey("tag");
+        payload.Query["tag"].ShouldBe(["a", "b"]);
+    }
+
+    [Test]
+    public void Get_ReturnsApplicationJsonContentType_When_Called()
+    {
+        var context = new DefaultHttpContext();
+
+        var result = CreateController(context).Get();
+        var content = result.ShouldBeOfType<ContentResult>();
+
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldBe("application/json; charset=utf-8");
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/echo", true)]
+    [TestCase("/api/v1.0/echo", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
## Summary
Adds `GET /api/echo` and `GET /api/v1.0/echo` returning JSON that reflects key HTTP request properties for debugging.

## Files
- `src/UI/Api/Controllers/EchoController.cs` — controller
- `src/UI/Api/EchoModels.cs` — EchoResponse record
- `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` — public bypass for echo
- `src/UnitTests/UI.Api/EchoControllerTests.cs` — unit tests
- `src/IntegrationTests/Api/EchoEndpointIntegrationTests.cs` — integration tests
- `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` — middleware tests

## Testing
- `./PrivateBuild.ps1` green (unit + integration)
- Covers unversioned/versioned routes, query/header reflection, API-key bypass

Closes #7857