### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260728-152734-4of25 (#8052)

### DIFF
--- a/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class HelloEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200WithJsonHelloWorld_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("{\"message\":\"Hello, World!\"}");
+    }
+
+    [Test]
+    public async Task Should_Return200WithJsonHelloWorld_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("{\"message\":\"Hello, World!\"}");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_HelloAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/hello");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await unversioned.Content.ReadAsStringAsync()).ShouldBe("{\"message\":\"Hello, World!\"}");
+
+        var versioned = await client.GetAsync("/api/v1.0/hello");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await versioned.Content.ReadAsStringAsync()).ShouldBe("{\"message\":\"Hello, World!\"}");
+    }
+}

--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,30 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal JSON greeting probe for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a static JSON greeting for reachability checks.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() => Ok(new HelloResponse("Hello, World!"));
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/hello</c> and <c>GET /api/v1.0/hello</c>.
+/// </summary>
+public record HelloResponse(string Message);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and hello endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,41 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJsonHelloWorld()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.StatusCode.ShouldBe(200);
+        var response = ok.Value.ShouldBeOfType<HelloResponse>();
+        response.Message.ShouldBe("Hello, World!");
+    }
+
+    [Test]
+    public void Get_Should_ReturnGreetingRecord()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.Value.ShouldNotBeNull();
+        ok.Value.ShouldBeOfType<HelloResponse>();
+    }
+}

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/hello", true)]
+    [TestCase("/api/v1.0/hello", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
## Summary
Adds anonymous `GET /api/hello` and `GET /api/v1.0/hello` returning `{"message":"Hello, World!"}` with HTTP 200.

## Files
- `src/UI/Api/Controllers/HelloController.cs` — new controller
- `src/UnitTests/UI.Api/HelloControllerTests.cs` — unit tests
- `src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs` — integration tests
- `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` — public skip for hello paths
- `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` — middleware test cases

## Testing
- PrivateBuild.ps1 green (unit + integration)
- HelloControllerTests: JSON shape and message text
- HelloEndpointIntegrationTests: unversioned/versioned routes, no API key required

Closes #8052