### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260728-164357-8of25 (#8103)

### DIFF
--- a/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class HelloEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJsonMessage_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("{\"message\":\"Hello, World!\"}");
+    }
+
+    [Test]
+    public async Task Should_Return200AndJsonMessage_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("{\"message\":\"Hello, World!\"}");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_HelloAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/hello");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await unversioned.Content.ReadAsStringAsync()).ShouldBe("{\"message\":\"Hello, World!\"}");
+
+        var versioned = await client.GetAsync("/api/v1.0/hello");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await versioned.Content.ReadAsStringAsync()).ShouldBe("{\"message\":\"Hello, World!\"}");
+    }
+}

--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,30 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal JSON greeting for operators and integrations.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a static greeting message as JSON.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() => Ok(new HelloResponse("Hello, World!"));
+}
+
+/// <summary>
+/// JSON payload for <c>GET /api/hello</c> and <c>GET /api/v1.0/hello</c>.
+/// </summary>
+public record HelloResponse(string Message);

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace ClearMeasure.Bootcamp.UI.Server;
 
 /// <summary>
-/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, and ping endpoints.
+/// Enforces an optional shared API key on <c>/api/*</c> routes, excluding public version, time, ping, and hello endpoints.
 /// </summary>
 public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
 {
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_Return200AndJsonHelloWorld()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var ok = result.ShouldBeOfType<OkObjectResult>();
+        ok.StatusCode.ShouldBe(200);
+        var payload = JsonSerializer.Deserialize<HelloResponse>(
+            JsonSerializer.Serialize(ok.Value),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        payload.ShouldNotBeNull();
+        payload!.Message.ShouldBe("Hello, World!");
+    }
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using ClearMeasure.Bootcamp.UI.Api.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -21,10 +20,7 @@ public class HelloControllerTests
 
         var ok = result.ShouldBeOfType<OkObjectResult>();
         ok.StatusCode.ShouldBe(200);
-        var payload = JsonSerializer.Deserialize<HelloResponse>(
-            JsonSerializer.Serialize(ok.Value),
-            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-        payload.ShouldNotBeNull();
-        payload!.Message.ShouldBe("Hello, World!");
+        var payload = ok.Value.ShouldBeOfType<HelloResponse>();
+        payload.Message.ShouldBe("Hello, World!");
     }
 }

--- a/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
+++ b/src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs
@@ -16,6 +16,8 @@ public class ApiKeyAuthenticationMiddlewareTests
     [TestCase("/api/v1.0/time", true)]
     [TestCase("/api/ping", true)]
     [TestCase("/api/v1.0/ping", true)]
+    [TestCase("/api/hello", true)]
+    [TestCase("/api/v1.0/hello", true)]
     [TestCase("/api/WeatherForecast", false)]
     public void ShouldValidate_ReturnsExpected_When_PathAndOptions(string path, bool expectPublicSkip)
     {


### PR DESCRIPTION
## Summary
Adds public `GET /api/hello` and `GET /api/v1.0/hello` JSON probe returning `{"message":"Hello, World!"}`.

## Files
- `src/UI/Api/Controllers/HelloController.cs` — new controller
- `src/UI/Server/ApiKeyAuthenticationMiddleware.cs` — whitelist hello paths
- `src/UnitTests/UI.Api/HelloControllerTests.cs` — unit test
- `src/UnitTests/UI.Server/ApiKeyAuthenticationMiddlewareTests.cs` — middleware test cases
- `src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs` — integration tests

## Testing
- Private build green (unit + integration)
- Unit: controller returns 200 + JSON message
- Integration: unversioned/versioned routes, no API key required

Closes #8103