### PR TITLE
Fix two master-CI flakes: GC-memory self-comparison and login render race

### DIFF
--- a/src/AcceptanceTests/Authentication/LoginTests.cs
+++ b/src/AcceptanceTests/Authentication/LoginTests.cs
@@ -6,6 +6,20 @@ namespace ClearMeasure.Bootcamp.AcceptanceTests.Authentication;
 [TestFixture]
 public class LoginTests : AcceptanceTestBase
 {
+    /// <summary>
+    /// The employee &lt;option&gt; elements are rendered only after the Blazor WASM app
+    /// boots interactively and the employee list loads. WaitForLoadStateAsync(NetworkIdle)
+    /// does not guarantee that render has happened, so wait for the option itself.
+    /// Options live inside a closed &lt;select&gt; and therefore have no bounding box —
+    /// they are never "visible" to Playwright, so wait for Attached, not Visible.
+    /// </summary>
+    private static Task WaitForEmployeeOptionsRenderedAsync(ILocator employeeOption) =>
+        employeeOption.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Attached,
+            Timeout = 90_000
+        });
+
     [Test, Retry(2)]
     public void VerifySetup()
     {
@@ -19,13 +33,13 @@ public class LoginTests : AcceptanceTestBase
     public async Task Should_DisplayUppercaseNames_InLoginDropdown()
     {
         await Page.GotoAsync("/login");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         var userSelect = Page.GetByTestId(nameof(Login.Elements.User));
+        var homerOption = userSelect.Locator("option[value='hsimpson']");
+        await WaitForEmployeeOptionsRenderedAsync(homerOption);
+
         var placeholderOption = userSelect.Locator("option[value='']");
         await Expect(placeholderOption).ToHaveTextAsync("-- Select a parishioner or staff member --");
-
-        var homerOption = userSelect.Locator("option[value='hsimpson']");
         await Expect(homerOption).ToHaveTextAsync("HOMER SIMPSON");
     }
 
@@ -33,10 +47,10 @@ public class LoginTests : AcceptanceTestBase
     public async Task Should_LoginSuccessfully_UsingUsernameValue_NotDisplayLabel()
     {
         await Page.GotoAsync("/login");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         var userSelect = Page.GetByTestId(nameof(Login.Elements.User));
         var homerOption = userSelect.Locator("option[value='hsimpson']");
+        await WaitForEmployeeOptionsRenderedAsync(homerOption);
         await Expect(homerOption).ToHaveTextAsync("HOMER SIMPSON");
 
         await Select(nameof(Login.Elements.User), "hsimpson");

--- a/src/AcceptanceTests/ServerFixture.cs
+++ b/src/AcceptanceTests/ServerFixture.cs
@@ -47,6 +47,12 @@ public class ServerFixture
         SlowMo = configuration.GetValue<int>("SlowMo");
         HeadlessTestBrowser = configuration.GetValue<bool>("HeadlessTestBrowser");
 
+        // Playwright's Expect(...) assertions do NOT inherit the browser context's
+        // default timeout (set to 60s in AcceptanceTestBase) — they default to 5s.
+        // Under LevelOfParallelism(4) a cold Blazor WASM render can exceed 5s, so an
+        // assertion that is merely waiting for the first render fails with
+        // "<element(s) not found>". Align the assertion budget with the action budget.
+        Assertions.SetDefaultExpectTimeout(30_000);
 
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
 

--- a/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
+++ b/src/UnitTests/UI/Server/DetailedHealthReportProviderTests.cs
@@ -15,6 +15,21 @@ public class DetailedHealthReportProviderTests
         public override DateTimeOffset GetUtcNow() => new(utcNow, TimeSpan.Zero);
     }
 
+    /// <summary>
+    /// Live process memory is sampled once inside the provider and again by the test
+    /// microseconds later. Any allocation — or a background GC — between the two samples
+    /// shifts the value, and because both are rounded to whole megabytes, crossing a single
+    /// 1 MiB boundary is enough to break exact equality (observed in CI: "should be 148 but
+    /// was 147"). These assertions verify the property is wired to the corresponding reader,
+    /// so compare against a fresh sample within a tolerance rather than demanding equality.
+    /// </summary>
+    private const int MemorySampleToleranceMb = 64;
+
+    private static void ShouldTrackLiveSample(int reported, int freshSample) =>
+        reported.ShouldBeInRange(
+            freshSample - MemorySampleToleranceMb,
+            freshSample + MemorySampleToleranceMb);
+
     [Test]
     public void FromComponentStatuses_Should_MapStatusesAndOverall()
     {
@@ -239,7 +254,7 @@ public class DetailedHealthReportProviderTests
             TimeProvider.System);
 
         detailed.GcMemoryMb.ShouldBeGreaterThanOrEqualTo(0);
-        detailed.GcMemoryMb.ShouldBe(DetailedHealthReportProvider.GetGcMemoryMb());
+        ShouldTrackLiveSample(detailed.GcMemoryMb, DetailedHealthReportProvider.GetGcMemoryMb());
     }
 
     [Test]
@@ -256,7 +271,7 @@ public class DetailedHealthReportProviderTests
             TimeProvider.System);
 
         detailed.WorkingSetMb.ShouldBeGreaterThanOrEqualTo(0);
-        detailed.WorkingSetMb.ShouldBe(DetailedHealthReportProvider.GetWorkingSetMb());
+        ShouldTrackLiveSample(detailed.WorkingSetMb, DetailedHealthReportProvider.GetWorkingSetMb());
     }
 
     [Test]
@@ -303,7 +318,7 @@ public class DetailedHealthReportProviderTests
         var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
 
         detailed.GcMemoryMb.ShouldBeGreaterThanOrEqualTo(0);
-        detailed.GcMemoryMb.ShouldBe(DetailedHealthReportProvider.GetGcMemoryMb());
+        ShouldTrackLiveSample(detailed.GcMemoryMb, DetailedHealthReportProvider.GetGcMemoryMb());
     }
 
     [Test]
@@ -318,7 +333,7 @@ public class DetailedHealthReportProviderTests
         var detailed = DetailedHealthReportProvider.FromHealthReport(report, TimeProvider.System);
 
         detailed.WorkingSetMb.ShouldBeGreaterThanOrEqualTo(0);
-        detailed.WorkingSetMb.ShouldBe(DetailedHealthReportProvider.GetWorkingSetMb());
+        ShouldTrackLiveSample(detailed.WorkingSetMb, DetailedHealthReportProvider.GetWorkingSetMb());
     }
 
     [Test]


### PR DESCRIPTION
Master CI flaked on **2 of 4** consecutive AI-factory happy-path runs today (issues #8148, #8154), in two different jobs. The factory's *"re-run 1 failed check once for flake tolerance"* masked both — every run still went green — so the only visible cost was wall clock: **master CI went from ~7 min to ~16 min** on each hit.

## Flake A — `DetailedHealthReportProviderTests` memory assertions

Failed on `5e8ee88a` as **"Integration Build (SQL container)"**, but the job name is misleading: it died in the **UnitTests** assembly, with no SQL or container involved.

```csharp
detailed.GcMemoryMb.ShouldBe(DetailedHealthReportProvider.GetGcMemoryMb());
```

`FromComponentStatuses(...)` samples live process memory internally; the test sampled it **again** microseconds later and demanded exact equality. Any allocation (or a background GC) crossing a 1 MiB rounding boundary flips the value — CI reported `should be 148 but was 147`.

Verified empirically: sampling twice with a 4 MiB allocation between them returns `first=6MB second=10MB`.

**Why this one matters most:** all four `Integration Build` variants (SQL container, SQLite, ARM SQLite, Windows LocalDB) call the same `Build` function, so this ran **4× per master build** — four independent chances to turn one build red.

- Replaced exact equality with `ShouldTrackLiveSample` (±64 MB of a fresh sample).
- Applied to **all 4** occurrences — both `GcMemoryMb` and both `WorkingSetMb` assertions. The `FromHealthReport` pair was latent with the identical defect.

## Flake B — `LoginTests` Blazor WASM render race

Failed on `9cfc9b36` as **"Acceptance Tests"**:

```
Locator expected to have text 'HOMER SIMPSON'
But was: '<element(s) not found>'
  - Expect "ToHaveTextAsync" with timeout 5000ms
```

**The deeper cause is systemic.** `AcceptanceTestBase` calls `browserContext.SetDefaultTimeout(60_000)`, but that governs **actions only** — Playwright's `Expect(...)` assertions have a *separate* budget defaulting to **5 s**, and `Assertions.SetDefaultExpectTimeout` was never called anywhere in the suite. So every assertion had a 5 s ceiling while every action had 60 s.

Under `LevelOfParallelism(4)` a cold WASM render exceeds 5 s, and an assertion merely waiting for first render fails. That is why the test already carried `Retry(2)` and still lost — and it is the common cause behind the run of one-test-at-a-time flake fixes in this repo's history (`b0d0483c`, `040f83dd`), each of which treated a symptom.

- Set `Assertions.SetDefaultExpectTimeout(30_000)` once in `ServerFixture`, aligning the assertion budget with the action budget for the whole suite.
- Wait explicitly for the employee `<option>` to attach in both login tests, dropping the `WaitForLoadStateAsync(NetworkIdle)` that does not imply a WASM render.
  - `Attached`, **not** `Visible` — options inside a closed `<select>` have no bounding box, so a `Visible` wait would hang until timeout.

## Verification

- Unit suite green **9 consecutive runs** (310/310 each).
- `LoginTests` **4/4** green, driving the real UI via Playwright.
- Full acceptance suite: **80 passed, 4 skipped, 3 failed**. Those 3 — `ShouldKeepPromptVisibleWhenResizingWithLongConversation`, `Should_DisplayChurchTitle_WithDarkGreyColor`, `TracerBullet_WorkerReceivesCommandAndReplies` — fail **identically on unmodified master** in this local environment (verified by stashing the change and re-running), so they are pre-existing and unrelated to this PR.

Test-only; no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcgCxutT8QZ42njwkMgLvx