### PR TITLE
[FST] Add /api/hello endpoint returning greeting (#8199)

### DIFF
--- a/.bob/notes/pending-notes.txt
+++ b/.bob/notes/pending-notes.txt
@@ -1,3 +1,4 @@
 {"id":"5fc8e0c1-8a1e-41ca-826e-826b5f63965d","ts":"2026-07-29T21:37:52.744Z","path":"/workspace/src/UI/Api/Controllers/HelloController.cs","version":"1.0.0","taskID":"e553fc05-6f05-44ce-b92c-77c9b1e5ea64"}
 {"id":"77444265-9e86-4ffb-ab59-fff371751d7f","ts":"2026-07-29T21:38:06.716Z","path":"/workspace/src/UnitTests/UI.Api/HelloControllerTests.cs","version":"1.0.0","taskID":"e553fc05-6f05-44ce-b92c-77c9b1e5ea64"}
 {"id":"6f55cccf-395e-408e-a0ad-33640feb4064","ts":"2026-07-29T21:38:22.049Z","path":"/workspace/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs","version":"1.0.0","taskID":"e553fc05-6f05-44ce-b92c-77c9b1e5ea64"}
+{"id":"4da29e0b-b282-4f53-bef6-4f70ca1649c0","ts":"2026-07-29T21:42:02.992Z","path":"/workspace/src/UI/Server/ApiKeyAuthenticationMiddleware.cs","version":"1.0.0","taskID":"e553fc05-6f05-44ce-b92c-77c9b1e5ea64"}

--- a/.bob/notes/pending-notes.txt
+++ b/.bob/notes/pending-notes.txt
@@ -1,0 +1,3 @@
+{"id":"5fc8e0c1-8a1e-41ca-826e-826b5f63965d","ts":"2026-07-29T21:37:52.744Z","path":"/workspace/src/UI/Api/Controllers/HelloController.cs","version":"1.0.0","taskID":"e553fc05-6f05-44ce-b92c-77c9b1e5ea64"}
+{"id":"77444265-9e86-4ffb-ab59-fff371751d7f","ts":"2026-07-29T21:38:06.716Z","path":"/workspace/src/UnitTests/UI.Api/HelloControllerTests.cs","version":"1.0.0","taskID":"e553fc05-6f05-44ce-b92c-77c9b1e5ea64"}
+{"id":"6f55cccf-395e-408e-a0ad-33640feb4064","ts":"2026-07-29T21:38:22.049Z","path":"/workspace/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs","version":"1.0.0","taskID":"e553fc05-6f05-44ce-b92c-77c9b1e5ea64"}

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,37 @@
+## Work Item Context
+
+- **Issue:** #8199 — [FST] Add /api/hello endpoint returning greeting - 20260729-213137-1of1
+- **URL:** https://github.com/ClearMeasureLabs/bootcamp-palermo-workorders/issues/8199
+- **Previous Status:** Test Design
+- **Current Status:** Development
+- **Repository:** ClearMeasureLabs/bootcamp-palermo-workorders
+- **Workflow Key:** complete:8199:Test Design
+- **Occurred At:** 2026-07-29T21:35:55.2489023+00:00
+- **AI Factory Label:** AI Factory
+- **Ready to Move Label:** Ready To Move
+- **AI Factory API URL:** https://aisoftwarefactory-jeffreyalienware.ngrok.app
+
+---
+
+Development task: implement the work item in the repository already cloned in your workspace. Use ONLY the AI Factory callback API for everything outside git (`AI_FACTORY_API_URL` from the Work Item Context above) — work item reads/comments/labels AND all pull-request operations (`/api/tools/workitems/{id}/pullrequests` create/get/checks/merge). Do NOT call api.github.com for PR operations. Be terse; journal at phase transitions only.
+
+From the Work Item Context read: `AI_FACTORY_API_URL`, `ISSUE_NUMBER`, `AUTO_MERGE_LABEL`. Branch name: `ibmbob/$ISSUE_NUMBER-development`.
+
+**FIX-FORWARD MODE (only if the Work Item Context contains `EXISTING_PR_NUMBER` / `EXISTING_PR_BRANCH` / `EXISTING_PR_URL`):** this item was DEMOTED from Functional Validation because its PR could not be merged. Do the following instead of the numbered steps below, and DO the rest of the polling/complete flow on the SAME PR:
+- Do NOT create a new branch or a new PR. NEVER merge the PR — merges happen ONLY in Functional Validation, performed by the factory, never by you.
+- Check out `EXISTING_PR_BRANCH`. Bring it up to date by MERGING master INTO the branch: `git merge origin/master`. **Do NOT rebase and do NOT force-push** — a rebase rewrites pushed history and invalidates review context and in-flight checks.
+- Resolve any merge conflicts, preserving BOTH the feature changes and master's changes.
+- Address the newest `🤖` demotion comment on the work item (it states the merge-failure reason).
+- Push normally (`git push`, never `--force`).
+- Poll `GET .../pullrequests/$EXISTING_PR_NUMBER/checks` (as in step 5) and, ONLY on green, `POST .../workitems/$ISSUE_NUMBER/complete`. Completion means "the PR is mergeable again"; the item returns to Functional Validation where the review re-runs and the FACTORY merges. Skip step 6 entirely (you never merge in fix-forward mode).
+
+If `EXISTING_PR_*` is ABSENT, follow the normal first-pass flow below unchanged.
+
+1. `GET .../workitems/$ISSUE_NUMBER` — read requirements (concept + UX/technical/test design sections). Read `AGENTS.md` if present.
+2. Branch off the base branch; implement the change with tests, following existing patterns. Every commit message contains `#$ISSUE_NUMBER` and `[AB#$ISSUE_NUMBER]`. Push.
+3. Run the repo's private build (`pwsh ./PrivateBuild.ps1` or per AGENTS.md). Fix until green — do NOT open a PR on a red build.
+4. Create the PR via callback: `POST .../workitems/$ISSUE_NUMBER/pullrequests` with `{"headBranch":"ibmbob/$ISSUE_NUMBER-development","baseBranch":null,"title":"<issue title> (#$ISSUE_NUMBER)","body":"<short summary + files + testing notes>","draft":false}`. Save `pullRequest.number` and `url`; journal one comment with the URL.
+5. Poll `GET .../pullrequests/$PR_NUMBER/checks` every 30s (≤30 tries) until `checks.status` != "pending". On `failure`: diagnose, fix, commit, push, repeat. ONLY on `success`: make ONE final call — `POST .../workitems/$ISSUE_NUMBER/complete` with `{"comment": "🤖 PR open, CI green, ready for review — <PR link>"}`. This posts the journal comment AND signals the factory, which advances the item deterministically. NEVER call it before checks report success; on unrecoverable failure call it with `"succeeded": false` and a failure summary instead.
+6. Auto-merge ONLY if the work item's labels include `AUTO_MERGE_LABEL`: `POST .../pullrequests/$PR_NUMBER/merge` with `{"mergeMethod":"squash"}` (retry ≤10× on 30s if checks pending), then journal the merge. Otherwise the open green PR is the final state.
+
+If a step fails after 3 retries, post one failure comment and stop without the label.

--- a/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class HelloEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndPlainTextGreeting_When_GetUnversioned()
+    {
+        var response = await _client!.GetAsync("/api/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("Hello, World!");
+    }
+
+    [Test]
+    public async Task Should_Return200AndPlainTextGreeting_When_GetVersioned()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("text/plain");
+        (await response.Content.ReadAsStringAsync()).ShouldBe("Hello, World!");
+    }
+
+    [Test]
+    public async Task Should_Return200WithoutApiKey_When_HelloAndMiddlewareEnabled()
+    {
+        await using var factory = new ApiKeyProtectedWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var unversioned = await client.GetAsync("/api/hello");
+        unversioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await unversioned.Content.ReadAsStringAsync()).ShouldBe("Hello, World!");
+
+        var versioned = await client.GetAsync("/api/v1.0/hello");
+        versioned.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await versioned.Content.ReadAsStringAsync()).ShouldBe("Hello, World!");
+    }
+}

--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,32 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a simple greeting endpoint.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a greeting message.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        new ContentResult
+        {
+            Content = "Hello, World!",
+            ContentType = "text/plain; charset=utf-8",
+            StatusCode = StatusCodes.Status200OK
+        };
+}

--- a/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
+++ b/src/UI/Server/ApiKeyAuthenticationMiddleware.cs
@@ -78,7 +78,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[1];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         if (segments.Length >= 3
@@ -87,7 +88,8 @@ public sealed class ApiKeyAuthenticationMiddleware(RequestDelegate next)
             var leaf = segments[2];
             return leaf.Equals("version", StringComparison.OrdinalIgnoreCase)
                    || leaf.Equals("time", StringComparison.OrdinalIgnoreCase)
-                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase);
+                   || leaf.Equals("ping", StringComparison.OrdinalIgnoreCase)
+                   || leaf.Equals("hello", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,27 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnPlainTextGreeting()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var content = result.ShouldBeOfType<ContentResult>();
+        content.StatusCode.ShouldBe(200);
+        content.ContentType.ShouldNotBeNull();
+        content.ContentType.ShouldContain("text/plain");
+        content.Content.ShouldBe("Hello, World!");
+    }
+}


### PR DESCRIPTION
Adds /api/hello endpoint returning "Hello, World!" as plain text.

## Files Changed
- src/UI/Api/Controllers/HelloController.cs - New controller
- src/UI/Server/ApiKeyAuthenticationMiddleware.cs - Added hello to public endpoints
- Unit and integration tests

## Testing
All tests passing. Endpoint accessible without API key.

Closes #8199