### PR TITLE
[FST] Add /api/hello endpoint returning greeting (#8200)

### DIFF
--- a/src/UI/Server/Controllers/HelloController.cs
+++ b/src/UI/Server/Controllers/HelloController.cs
@@ -1,0 +1,16 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/hello")]
+public class HelloController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult GetHello()
+    {
+        return Ok(new { message = "Hello, World!" });
+    }
+}

--- a/src/UnitTests/UI.Server/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Server/HelloControllerTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Text.Json;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    private ApiVersioningRoutingWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new ApiVersioningRoutingWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200_When_GetHello()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+    }
+
+    [Test]
+    public async Task Should_ReturnExpectedMessage_When_GetHello()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("message").GetString().ShouldBe("Hello, World!");
+    }
+
+    [Test]
+    public async Task Should_AllowAnonymousAccess_When_GetHello()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_IncludeSupportedVersionsHeader_When_GetHello()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues("api-supported-versions", out var values).ShouldBeTrue();
+        values.ShouldNotBeNull();
+        string.Join(", ", values!).ShouldContain("1.0");
+    }
+}


### PR DESCRIPTION
Implements GET /api/hello endpoint returning {"message": "Hello, World!"} with HTTP 200.

**Files Added:**
- src/UI/Server/Controllers/HelloController.cs
- src/UnitTests/UI.Server/HelloControllerTests.cs

**Testing:**
- All 130 tests pass including 4 new unit tests
- Endpoint accessible at /api/v1.0/hello
- Anonymous access (no auth required)
- API versioning and headers validated

Closes #8200