### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260729-214912-1of1 (#8202)

### DIFF
--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,32 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal JSON greeting endpoint for connectivity checks.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/hello")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON greeting message.
+    /// </summary>
+    /// <returns>A JSON object containing a greeting message.</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult Get() =>
+        new JsonResult(new { message = "Hello, World!" })
+        {
+            StatusCode = StatusCodes.Status200OK
+        };
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,31 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnJsonGreeting()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var jsonResult = result.ShouldBeOfType<JsonResult>();
+        jsonResult.StatusCode.ShouldBe(200);
+        
+        var value = jsonResult.Value;
+        value.ShouldNotBeNull();
+        
+        var messageProperty = value.GetType().GetProperty("message");
+        messageProperty.ShouldNotBeNull();
+        messageProperty.GetValue(value).ShouldBe("Hello, World!");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a minimal GET /api/hello endpoint returning {"message": "Hello, World!"} with HTTP 200.

## Files Changed
- src/UI/Api/Controllers/HelloController.cs - New controller with GET endpoint
- src/UnitTests/UI.Api/HelloControllerTests.cs - Unit tests

## Testing
- Unit tests pass (HelloControllerTests.Get_Should_ReturnJsonGreeting)
- Private build passed: 130 tests passed, 11 skipped
- Follows PingController pattern with JsonResult for JSON response
- Includes AllowAnonymous, rate limiting, and API versioning

Closes #8202