### PR TITLE
[FST] Add /api/hello endpoint returning greeting - 20260729-231948-1of1 (#8209)

### DIFF
--- a/.bob/notes/pending-notes.txt
+++ b/.bob/notes/pending-notes.txt
@@ -1,0 +1,4 @@
+{"id":"87345173-fcc2-4d9f-ba47-78df593e1930","ts":"2026-07-29T23:24:53.067Z","path":"/workspace/src/UI/Api/Controllers/HelloController.cs","version":"1.0.0","taskID":"b1526e4c-1cdd-4559-8f54-a93a275e16fb"}
+{"id":"c88c9f18-b637-4279-89d4-67a5420e8904","ts":"2026-07-29T23:25:04.117Z","path":"/workspace/src/UnitTests/UI.Api/HelloControllerTests.cs","version":"1.0.0","taskID":"b1526e4c-1cdd-4559-8f54-a93a275e16fb"}
+{"id":"c8a80a9d-a6f2-4828-ae18-d464fe62a097","ts":"2026-07-29T23:25:20.464Z","path":"/workspace/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs","version":"1.0.0","taskID":"b1526e4c-1cdd-4559-8f54-a93a275e16fb"}
+{"id":"78bb5292-b6c8-4f49-bafa-36503118b23c","ts":"2026-07-29T23:25:35.853Z","path":"/workspace/src/AcceptanceTests/Api/HelloEndpointAcceptanceTests.cs","version":"1.0.0","taskID":"b1526e4c-1cdd-4559-8f54-a93a275e16fb"}

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,37 @@
+## Work Item Context
+
+- **Issue:** #8209 — [FST] Add /api/hello endpoint returning greeting - 20260729-231948-1of1
+- **URL:** https://github.com/ClearMeasureLabs/bootcamp-palermo-workorders/issues/8209
+- **Previous Status:** Test Design
+- **Current Status:** Development
+- **Repository:** ClearMeasureLabs/bootcamp-palermo-workorders
+- **Workflow Key:** complete:8209:Test Design
+- **Occurred At:** 2026-07-29T23:23:48.6107069+00:00
+- **AI Factory Label:** AI Factory
+- **Ready to Move Label:** Ready To Move
+- **AI Factory API URL:** https://aisoftwarefactory-jeffreyalienware.ngrok.app
+
+---
+
+Development task: implement the work item in the repository already cloned in your workspace. Use ONLY the AI Factory callback API for everything outside git (`AI_FACTORY_API_URL` from the Work Item Context above) — work item reads/comments/labels AND all pull-request operations (`/api/tools/workitems/{id}/pullrequests` create/get/checks/merge). Do NOT call api.github.com for PR operations. Be terse; journal at phase transitions only.
+
+From the Work Item Context read: `AI_FACTORY_API_URL`, `ISSUE_NUMBER`, `AUTO_MERGE_LABEL`. Branch name: `ibmbob/$ISSUE_NUMBER-development`.
+
+**FIX-FORWARD MODE (only if the Work Item Context contains `EXISTING_PR_NUMBER` / `EXISTING_PR_BRANCH` / `EXISTING_PR_URL`):** this item was DEMOTED from Functional Validation because its PR could not be merged. Do the following instead of the numbered steps below, and DO the rest of the polling/complete flow on the SAME PR:
+- Do NOT create a new branch or a new PR. NEVER merge the PR — merges happen ONLY in Functional Validation, performed by the factory, never by you.
+- Check out `EXISTING_PR_BRANCH`. Bring it up to date by MERGING master INTO the branch: `git merge origin/master`. **Do NOT rebase and do NOT force-push** — a rebase rewrites pushed history and invalidates review context and in-flight checks.
+- Resolve any merge conflicts, preserving BOTH the feature changes and master's changes.
+- Address the newest `🤖` demotion comment on the work item (it states the merge-failure reason).
+- Push normally (`git push`, never `--force`).
+- Poll `GET .../pullrequests/$EXISTING_PR_NUMBER/checks` (as in step 5) and, ONLY on green, `POST .../workitems/$ISSUE_NUMBER/complete`. Completion means "the PR is mergeable again"; the item returns to Functional Validation where the review re-runs and the FACTORY merges. Skip step 6 entirely (you never merge in fix-forward mode).
+
+If `EXISTING_PR_*` is ABSENT, follow the normal first-pass flow below unchanged.
+
+1. `GET .../workitems/$ISSUE_NUMBER` — read requirements (concept + UX/technical/test design sections). Read `AGENTS.md` if present.
+2. Branch off the base branch; implement the change with tests, following existing patterns. Every commit message contains `#$ISSUE_NUMBER` and `[AB#$ISSUE_NUMBER]`. Push.
+3. Run the repo's private build (`pwsh ./PrivateBuild.ps1` or per AGENTS.md). Fix until green — do NOT open a PR on a red build.
+4. Create the PR via callback: `POST .../workitems/$ISSUE_NUMBER/pullrequests` with `{"headBranch":"ibmbob/$ISSUE_NUMBER-development","baseBranch":null,"title":"<issue title> (#$ISSUE_NUMBER)","body":"<short summary + files + testing notes>","draft":false}`. Save `pullRequest.number` and `url`; journal one comment with the URL.
+5. Poll `GET .../pullrequests/$PR_NUMBER/checks` every 30s (≤30 tries) until `checks.status` != "pending". On `failure`: diagnose, fix, commit, push, repeat. ONLY on `success`: make ONE final call — `POST .../workitems/$ISSUE_NUMBER/complete` with `{"comment": "🤖 PR open, CI green, ready for review — <PR link>"}`. This posts the journal comment AND signals the factory, which advances the item deterministically. NEVER call it before checks report success; on unrecoverable failure call it with `"succeeded": false` and a failure summary instead.
+6. Auto-merge ONLY if the work item's labels include `AUTO_MERGE_LABEL`: `POST .../pullrequests/$PR_NUMBER/merge` with `{"mergeMethod":"squash"}` (retry ≤10× on 30s if checks pending), then journal the merge. Otherwise the open green PR is the final state.
+
+If a step fails after 3 retries, post one failure comment and stop without the label.

--- a/src/AcceptanceTests/Api/HelloEndpointAcceptanceTests.cs
+++ b/src/AcceptanceTests/Api/HelloEndpointAcceptanceTests.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Text.Json;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.AcceptanceTests.Api;
+
+[TestFixture]
+public class HelloEndpointAcceptanceTests : AcceptanceTestBase
+{
+    protected override bool RequiresBrowser => false;
+
+    [Test]
+    public async Task HelloEndpoint_Should_ReturnGreeting_WithoutAuthentication()
+    {
+        if (!ServerFixture.StartLocalServer)
+            Assert.Ignore("Requires local server with HTTP access to /api/*");
+
+        using var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+        using var client = new HttpClient(handler) { BaseAddress = new Uri(ServerFixture.ApplicationBaseUrl) };
+        
+        var response = await client.GetAsync("/api/v1.0/hello");
+        
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldBe("application/json");
+        
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var message = json.RootElement.GetProperty("message").GetString();
+        message.ShouldBe("Hello, World!");
+    }
+}

--- a/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Text.Json;
+using ClearMeasure.Bootcamp.UnitTests.UI.Server;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class HelloEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task GetHello_Should_ReturnOkWithJsonMessage()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldBe("application/json");
+        
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var message = json.RootElement.GetProperty("message").GetString();
+        message.ShouldBe("Hello, World!");
+    }
+}

--- a/src/UI/Api/Controllers/HelloController.cs
+++ b/src/UI/Api/Controllers/HelloController.cs
@@ -1,0 +1,25 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace ClearMeasure.Bootcamp.UI.Api.Controllers;
+
+/// <summary>
+/// Exposes a minimal greeting endpoint for testing and integration purposes.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+[EnableRateLimiting(ApiRateLimiting.PolicyName)]
+public class HelloController : ControllerBase
+{
+    /// <summary>
+    /// Returns a JSON greeting message.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get() =>
+        Ok(new { message = "Hello, World!" });
+}

--- a/src/UnitTests/UI.Api/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Api/HelloControllerTests.cs
@@ -1,0 +1,31 @@
+using ClearMeasure.Bootcamp.UI.Api.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Api;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    [Test]
+    public void Get_Should_ReturnHelloWorldJson()
+    {
+        var controller = new HelloController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var result = controller.Get();
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.StatusCode.ShouldBe(200);
+        
+        var value = okResult.Value;
+        value.ShouldNotBeNull();
+        
+        var messageProperty = value.GetType().GetProperty("message");
+        messageProperty.ShouldNotBeNull();
+        messageProperty.GetValue(value).ShouldBe("Hello, World!");
+    }
+}


### PR DESCRIPTION
## Summary

Implements a minimal GET /api/hello endpoint that returns JSON greeting.

## Files Changed
- `src/UI/Api/Controllers/HelloController.cs` - New controller with versioned API route
- `src/UnitTests/UI.Api/HelloControllerTests.cs` - Unit tests
- `src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs` - Integration tests
- `src/AcceptanceTests/Api/HelloEndpointAcceptanceTests.cs` - Acceptance tests

## Testing
- All unit tests passing
- All integration tests passing
- All acceptance tests passing
- Private build successful (SQLite)

Returns HTTP 200 with `{"message": "Hello, World!"}`. No authentication required.

Closes #8209