### PR TITLE
[FST] Add /api/hello endpoint returning greeting (#8214)

### DIFF
--- a/src/UI/Server/Controllers/HelloController.cs
+++ b/src/UI/Server/Controllers/HelloController.cs
@@ -1,0 +1,17 @@
+using Asp.Versioning;
+using ClearMeasure.Bootcamp.UI.Api;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route($"{ApiRoutes.VersionedApiPrefix}/hello")]
+public class HelloController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        return Ok(new { message = "Hello, World!" });
+    }
+}

--- a/src/UnitTests/UI.Server/HelloControllerTests.cs
+++ b/src/UnitTests/UI.Server/HelloControllerTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Text.Json;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.UnitTests.UI.Server;
+
+[TestFixture]
+public class HelloControllerTests
+{
+    private ApiVersioningRoutingWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new ApiVersioningRoutingWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200_When_GetHello_V1Path()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+    }
+
+    [Test]
+    public async Task Should_ReturnCorrectMessage_When_GetHello()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("message").GetString().ShouldBe("Hello, World!");
+    }
+
+    [Test]
+    public async Task Should_ReturnNotSuccess_When_GetHello_UnsupportedVersion()
+    {
+        var response = await _client!.GetAsync("/api/v2.0/hello");
+
+        response.IsSuccessStatusCode.ShouldBeFalse();
+        response.StatusCode.ShouldBeOneOf(HttpStatusCode.NotFound, HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_IncludeSupportedVersionsHeader_When_GetHello()
+    {
+        var response = await _client!.GetAsync("/api/v1.0/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.TryGetValues("api-supported-versions", out var values).ShouldBeTrue();
+        values.ShouldNotBeNull();
+        string.Join(", ", values!).ShouldContain("1.0");
+    }
+}


### PR DESCRIPTION
Implements a minimal GET /api/hello endpoint that returns {"message": "Hello, World!"} with HTTP 200.

**Files Added:**
- src/UI/Server/Controllers/HelloController.cs - API controller with versioned route
- src/UnitTests/UI.Server/HelloControllerTests.cs - Unit tests covering all acceptance criteria

**Testing:**
- All 4 unit tests pass (200 status, correct message, unsupported version handling, API versioning headers)
- Private build passed: 130/141 tests (11 skipped)
- No authentication required as specified

Closes #8214