### PR TITLE
[FST] Add /api/hello endpoint returning greeting (#8217)

### DIFF
--- a/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
+++ b/src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Net.Http.Json;
+using Shouldly;
+
+namespace ClearMeasure.Bootcamp.IntegrationTests.Api;
+
+[TestFixture]
+public class HelloEndpointIntegrationTests
+{
+    private DiagnosticsWebApplicationFactory? _factory;
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new DiagnosticsWebApplicationFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task Should_Return200AndJsonGreeting_When_GetHello()
+    {
+        var response = await _client!.GetAsync("/api/hello");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        mediaType.ShouldNotBeNull();
+        mediaType!.ShouldContain("application/json");
+        
+        var result = await response.Content.ReadFromJsonAsync<HelloResponse>();
+        result.ShouldNotBeNull();
+        result!.Message.ShouldBe("Hello, World!");
+    }
+
+    private record HelloResponse(string Message);
+}

--- a/src/UI/Server/Controllers/HelloController.cs
+++ b/src/UI/Server/Controllers/HelloController.cs
@@ -1,0 +1,16 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClearMeasure.Bootcamp.UI.Server.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/[controller]")]
+public class HelloController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        return Ok(new { message = "Hello, World!" });
+    }
+}


### PR DESCRIPTION
Added a simple /api/hello endpoint that returns a JSON greeting message.

**Files Changed:**
- src/UI/Server/Controllers/HelloController.cs - New controller with GET endpoint
- src/IntegrationTests/Api/HelloEndpointIntegrationTests.cs - Integration tests

**Testing:**
- Private build passed: 131 tests passed, 11 skipped
- New integration test validates endpoint returns 200 OK with JSON greeting

Closes #8217