### PR TITLE
Add repo-committed feature-loop and feature-loop-dispatch skills

### DIFF
--- a/.claude/factory-loop.json
+++ b/.claude/factory-loop.json
@@ -1,0 +1,43 @@
+{
+  "tracker": "github-projects-v2",
+  "repo": "ClearMeasureLabs/bootcamp-palermo-workorders",
+  "project": { "owner": "ClearMeasureLabs", "ownerType": "organization", "number": 1 },
+  "columns": {
+    "Conceptual Definition": "design",
+    "UX Design": "design",
+    "Technical Design": "design",
+    "Test Design": "design",
+    "Development": "implement",
+    "Functional Testing": "verify",
+    "UX Testing": "verify",
+    "Release Queue": "terminal",
+    "Done": "terminal"
+  },
+  "doneForNowColumn": "Functional Testing",
+  "privateBuild": "pwsh -NoProfile ./privatebuild.ps1",
+  "acceptanceGate": "pwsh -NoProfile ./acceptancetests.ps1",
+  "expectedSuites": { "UnitTests": null, "IntegrationTests": null, "AcceptanceTests": null },
+  "mergeMethod": "merge",
+  "prePushGate": "merge-master-into-branch",
+  "issueClosePolicy": "close-on-merge-stay-closed",
+  "subagents": { "default": "sonnet", "implement": "sonnet", "complex": "sonnet", "mechanical": "sonnet" },
+  "subagentIsolation": "worktree-per-subagent",
+  "subagentPerColumn": true,
+  "columnProgression": "one-column-at-a-time",
+  "cleanupOnImplement": false,
+  "boardIds": {
+    "projectId": "PVT_kwDOAGeHnM4BHwEz",
+    "statusFieldId": "PVTSSF_lADOAGeHnM4BHwEzzg4ad5k",
+    "statusOptions": {
+      "Conceptual Definition": "c61d01c4",
+      "UX Design": "7e0d075c",
+      "Technical Design": "379cf003",
+      "Test Design": "f75ad846",
+      "Development": "47fc9ee4",
+      "Functional Testing": "b10cd406",
+      "UX Testing": "98b442f0",
+      "Release Queue": "eacd281f",
+      "Done": "98236657"
+    }
+  }
+}

--- a/.claude/factory-loop.json
+++ b/.claude/factory-loop.json
@@ -14,8 +14,8 @@
     "Done": "terminal"
   },
   "doneForNowColumn": "Functional Testing",
-  "privateBuild": "pwsh -NoProfile ./privatebuild.ps1",
-  "acceptanceGate": "pwsh -NoProfile ./acceptancetests.ps1",
+  "privateBuild": "pwsh -NoProfile ./PrivateBuild.ps1",
+  "acceptanceGate": "pwsh -NoProfile ./AcceptanceTests.ps1",
   "expectedSuites": { "UnitTests": null, "IntegrationTests": null, "AcceptanceTests": null },
   "mergeMethod": "merge",
   "prePushGate": "merge-master-into-branch",

--- a/.claude/skills/feature-loop-dispatch/Check-StalledLanes.ps1
+++ b/.claude/skills/feature-loop-dispatch/Check-StalledLanes.ps1
@@ -3,7 +3,7 @@
 # Safe: read-only against GitHub (REST only). Exit code 0 = no stalls, 2 = stalls found.
 #
 # Usage:
-#   pwsh -NoProfile ./Check-StalledLanes.ps1 -Repo ClearMeasure/Clear-Measure-Intelligence-Scorecard [-StaleMinutes 15] [-Json]
+#   pwsh -NoProfile ./Check-StalledLanes.ps1 -Repo ClearMeasureLabs/bootcamp-palermo-workorders [-StaleMinutes 15] [-Json]
 #
 # Detects, per open PR:
 #   GREEN_UNMERGED  - every check-run 'success' for > StaleMinutes, PR still open (stalled at merge step)

--- a/.claude/skills/feature-loop-dispatch/Check-StalledLanes.ps1
+++ b/.claude/skills/feature-loop-dispatch/Check-StalledLanes.ps1
@@ -1,0 +1,131 @@
+# Check-StalledLanes.ps1
+# Feature-loop stall watchdog. Detects lanes that stopped making progress without anyone noticing.
+# Safe: read-only against GitHub (REST only). Exit code 0 = no stalls, 2 = stalls found.
+#
+# Usage:
+#   pwsh -NoProfile ./Check-StalledLanes.ps1 -Repo ClearMeasure/Clear-Measure-Intelligence-Scorecard [-StaleMinutes 15] [-Json]
+#
+# Detects, per open PR:
+#   GREEN_UNMERGED  - every check-run 'success' for > StaleMinutes, PR still open (stalled at merge step)
+#   DIRTY           - PR has merge conflicts (needs master re-merged into branch)
+#   CI_FAILED       - one or more check-runs concluded failure/cancelled/timed_out (needs fix+repush)
+#   CI_STUCK        - newest check-run started > 60 min ago and still not completed
+# And per recently-merged PR (last 30):
+#   MERGED_ISSUE_OPEN - PR body says "Closes #N" (or branch names issue N) but issue N is still open
+#                       > StaleMinutes after merge (missing closing keyword / stalled closeout)
+
+param(
+    [Parameter(Mandatory = $true)][string]$Repo,
+    [int]$StaleMinutes = 15,
+    # Directory containing subagent task .output files; when provided, lanes whose output
+    # file hasn't been touched in LocalStaleMinutes are flagged LOCAL_STALL (catches stalls
+    # in the pre-PR phase that GitHub state can't show).
+    [string]$TasksDir,
+    # Comma-separated task/agent IDs that are currently ACTIVE; only these are checked for
+    # LOCAL_STALL. Without it every historical completed task file would be flagged.
+    [string[]]$ActiveIds = @(),
+    [int]$LocalStaleMinutes = 25,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+$now = [DateTimeOffset]::UtcNow
+$stalls = @()
+
+function Get-CheckSummary([string]$sha) {
+    $runs = gh api "repos/$Repo/commits/$sha/check-runs" --paginate --jq '[.check_runs[] | {name, status, conclusion, completed_at, started_at}]' | ConvertFrom-Json
+    if (-not $runs) { return $null }
+    $total      = $runs.Count
+    $success    = @($runs | Where-Object { $_.conclusion -eq 'success' }).Count
+    $failed     = @($runs | Where-Object { $_.conclusion -in @('failure', 'cancelled', 'timed_out', 'action_required') }).Count
+    $incomplete = @($runs | Where-Object { $_.status -ne 'completed' }).Count
+    $lastDone   = ($runs | Where-Object { $_.completed_at } | Sort-Object completed_at | Select-Object -Last 1).completed_at
+    $firstStart = ($runs | Where-Object { $_.started_at } | Sort-Object started_at | Select-Object -First 1).started_at
+    [pscustomobject]@{
+        Total = $total; Success = $success; Failed = $failed; Incomplete = $incomplete
+        LastCompletedAt = if ($lastDone) { [DateTimeOffset]$lastDone } else { $null }
+        FirstStartedAt  = if ($firstStart) { [DateTimeOffset]$firstStart } else { $null }
+        FailedNames = @($runs | Where-Object { $_.conclusion -in @('failure', 'cancelled', 'timed_out', 'action_required') } | ForEach-Object name)
+    }
+}
+
+# ---- Open PRs ----
+$openPrs = gh pr list -R $Repo --state open --limit 50 --json number,headRefName,headRefOid,mergeStateStatus,updatedAt,title | ConvertFrom-Json
+foreach ($pr in $openPrs) {
+    $ci = Get-CheckSummary $pr.headRefOid
+    if (-not $ci) {
+        $stalls += [pscustomobject]@{ Kind = 'CI_STUCK'; PR = $pr.number; Branch = $pr.headRefName; Detail = 'No check-runs found on head commit (push may not have triggered CI).' }
+        continue
+    }
+    if ($ci.Failed -gt 0) {
+        $stalls += [pscustomobject]@{ Kind = 'CI_FAILED'; PR = $pr.number; Branch = $pr.headRefName; Detail = "Failed jobs: $($ci.FailedNames -join ', '). Needs fix + re-push." }
+        continue
+    }
+    if ($ci.Incomplete -gt 0) {
+        if ($ci.FirstStartedAt -and (($now - $ci.FirstStartedAt).TotalMinutes -gt 60)) {
+            $stalls += [pscustomobject]@{ Kind = 'CI_STUCK'; PR = $pr.number; Branch = $pr.headRefName; Detail = "CI running > 60 min ($($ci.Incomplete) job(s) incomplete)." }
+        }
+        continue  # CI still running within tolerance — not a stall
+    }
+    if ($ci.Success -eq $ci.Total -and $ci.Total -gt 0) {
+        $greenAge = if ($ci.LastCompletedAt) { ($now - $ci.LastCompletedAt).TotalMinutes } else { [double]::MaxValue }
+        if ($pr.mergeStateStatus -eq 'DIRTY') {
+            $stalls += [pscustomobject]@{ Kind = 'DIRTY'; PR = $pr.number; Branch = $pr.headRefName; Detail = 'Merge conflicts with base. Re-merge master into branch, rebuild, re-push.' }
+        }
+        elseif ($greenAge -gt $StaleMinutes) {
+            $stalls += [pscustomobject]@{ Kind = 'GREEN_UNMERGED'; PR = $pr.number; Branch = $pr.headRefName; Detail = ('All {0} checks green for {1:n0} min but PR not merged. Lane stalled at merge/triage step.' -f $ci.Total, $greenAge) }
+        }
+    }
+}
+
+# ---- Recently merged PRs whose linked issue is still open ----
+$mergedPrs = gh pr list -R $Repo --state merged --limit 30 --json number,body,headRefName,mergedAt | ConvertFrom-Json
+foreach ($pr in $mergedPrs) {
+    $mergedAge = ($now - [DateTimeOffset]$pr.mergedAt).TotalMinutes
+    if ($mergedAge -le $StaleMinutes) { continue }
+    $issueNums = @()
+    if ($pr.body) {
+        $issueNums += [regex]::Matches($pr.body, '(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)') | ForEach-Object { $_.Groups[1].Value }
+    }
+    if ($pr.headRefName -match '(?:issue|fix)[/\-](\d+)') { $issueNums += $Matches[1] }
+    foreach ($n in ($issueNums | Select-Object -Unique)) {
+        try { $state = gh api "repos/$Repo/issues/$n" --jq .state 2>$null } catch { continue }
+        if ($state -eq 'open') {
+            $subs = gh api "repos/$Repo/issues/$n/sub_issues" --jq '[.[] | select(.state == "open")] | length' 2>$null
+            if ([int]$subs -gt 0) { continue }  # deliberately open: clamped behind open children
+            $stalls += [pscustomobject]@{ Kind = 'MERGED_ISSUE_OPEN'; PR = $pr.number; Branch = $pr.headRefName; Detail = ('PR merged {0:n0} min ago but issue #{1} is still open with no open children (missing closing keyword or stalled closeout).' -f $mergedAge, $n) }
+        }
+    }
+}
+
+# ---- Local lane liveness (pre-PR phase, invisible to GitHub) ----
+if ($TasksDir -and (Test-Path $TasksDir) -and $ActiveIds.Count -gt 0) {
+    $cutoff = (Get-Date).AddMinutes(-$LocalStaleMinutes)
+    foreach ($id in $ActiveIds) {
+        $f = Get-Item -Path (Join-Path $TasksDir "$id.output") -ErrorAction SilentlyContinue
+        if (-not $f) {
+            $stalls += [pscustomobject]@{ Kind = 'LOCAL_STALL'; PR = 0; Branch = $id; Detail = 'Active lane has no task output file at all.' }
+        }
+        elseif ($f.LastWriteTime -lt $cutoff) {
+            $stalls += [pscustomobject]@{
+                Kind = 'LOCAL_STALL'; PR = 0; Branch = $id
+                Detail = ('ACTIVE lane output untouched since {0:HH:mm:ss} (> {1} min) - stalled pre-PR.' -f $f.LastWriteTime, $LocalStaleMinutes)
+            }
+        }
+    }
+}
+
+if ($Json) {
+    $stalls | ConvertTo-Json -Depth 4
+}
+else {
+    $stamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss zzz')
+    if ($stalls.Count -eq 0) {
+        Write-Output "[$stamp] OK - no stalled lanes detected in $Repo."
+    }
+    else {
+        Write-Output "[$stamp] $($stalls.Count) STALL(S) detected in ${Repo}:"
+        $stalls | ForEach-Object { Write-Output ("  [{0}] PR #{1} ({2}) - {3}" -f $_.Kind, $_.PR, $_.Branch, $_.Detail) }
+    }
+}
+exit ($stalls.Count -gt 0 ? 2 : 0)

--- a/.claude/skills/feature-loop-dispatch/SKILL.md
+++ b/.claude/skills/feature-loop-dispatch/SKILL.md
@@ -119,8 +119,8 @@ item**, including verbatim:
 > board column at a time via a fresh perspective per column (design → implement →
 > verify), never skipping columns, recording no-op justifications for non-applicable
 > columns; merge origin/master into the branch and re-run the private build
-> (`pwsh -NoProfile ./privatebuild.ps1`) before any push or PR; run
-> `pwsh -NoProfile ./acceptancetests.ps1` before opening the PR; triage every bot review
+> (`pwsh -NoProfile ./PrivateBuild.ps1`) before any push or PR; run
+> `pwsh -NoProfile ./AcceptanceTests.ps1` before opening the PR; triage every bot review
 > finding (fix or explicitly decline with a PR reply) before merge; a PR is complete only
 > when every check-run `conclusion` is `success` via
 > `gh api repos/{o}/{r}/commits/{sha}/check-runs` — never a shell exit code; follow the

--- a/.claude/skills/feature-loop-dispatch/SKILL.md
+++ b/.claude/skills/feature-loop-dispatch/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: feature-loop-dispatch
+description: >
+  Authorize a batch of work items for full autonomous implementation in this repo
+  (ClearMeasureLabs/bootcamp-palermo-workorders). Resolves each item's epic/child tree,
+  computes a children-first execution order, and dispatches one dedicated sub-session
+  (subagent) per work item that runs the /feature-loop skill end-to-end — code, tests,
+  PR, API-verified green CI, merge, and board moves on
+  https://github.com/orgs/ClearMeasureLabs/projects/1 — with epic clamp rules enforced.
+  Use when asked to "dispatch the feature loop on ...", "implement these work items", or
+  when /feature-loop-dispatch is invoked with a list of issue numbers. The invoking
+  session stays alive as the orchestrator until every authorized item is Done.
+---
+
+# Feature-Loop Dispatch
+
+You are the **orchestrator**. The user has authorized the listed work items for full,
+unattended implementation. From this point the session runs to completion without asking
+anything further — every decision is made autonomously under the rules below.
+
+The per-item rules are defined by this repo's `/feature-loop` skill
+(`.claude/skills/feature-loop/SKILL.md`) and `.claude/factory-loop.json`. Those two files
+are the contract; a user's own global rules may add to but never weaken them.
+
+## Phase 0 — Start the stall watchdog (before any dispatch)
+
+Sub-sessions stall silently: they spawn a background CI poller and end their turn, and the
+poller's completion notification routes to whoever is listening (often the orchestrator,
+not the stopped lane) — so a PR can sit fully green and unmerged for hours. Detection must
+therefore be EXTERNAL and MECHANICAL, never dependent on the stalled agent itself:
+
+1. Run `pwsh -NoProfile .claude/skills/feature-loop-dispatch/Check-StalledLanes.ps1
+   -Repo ClearMeasureLabs/bootcamp-palermo-workorders` once now to baseline (read-only,
+   REST-only; exit 2 = stalls found).
+2. Run it as a HEARTBEAT, not an alarm: launch a background command that sleeps ~15
+   minutes, runs ONE check (pass `-TasksDir <session tasks dir>` so pre-PR local stalls
+   are caught via output-file staleness), and EXITS UNCONDITIONALLY — its exit wakes you
+   every cycle regardless of findings. RE-ARM IT AT THE END OF EVERY TURN in which it
+   fired. An alarm that only fires on detected trouble misses undetectable trouble (local
+   builds, harness runs, agents waiting on dead background tasks); a heartbeat guarantees
+   an orchestrator wake-up with fresh eyes each cycle. NEVER wait open-ended on lane
+   notifications alone.
+3. For every stall it reports, act immediately:
+   - `GREEN_UNMERGED` → SendMessage the owning lane: "PR #N is green; triage bots, merge,
+     move card, report." If the lane is unresumable, do the merge-side finish yourself
+     (verify check-runs, triage/reply bot findings, merge, card move) or spawn a fresh
+     closer subagent.
+   - `DIRTY` → order (or spawn) a conflict-resolution pass: merge master into the branch,
+     rebuild, re-push, re-verify.
+   - `CI_FAILED` / `CI_STUCK` → order a fix-and-repush or re-trigger.
+   - `MERGED_ISSUE_OPEN` → close the issue yourself with the merge-evidence comment
+     (verify sub_issues first; an issue clamped open behind open children is NOT a stall).
+
+## Communication standard (applies to every update, issue comment, and PR description)
+
+Write like a software delivery leader briefing a stakeholder: Clarity first. Plain
+software-team vocabulary only — work item, defect, pull request, build, automated tests,
+test run, board status, dependency. Never invent orchestration jargon. Specifically:
+
+- Don't say "evidence PR" — say "a pull request that commits the test-run results
+  (logs/output) to the repository."
+- Don't say "clamp / clamped" — say "the parent work item stays open and its board status
+  moves back to match its least-finished open sub-item" (the rule itself is unchanged;
+  only the wording is).
+- Don't say "lane," "loop," "chain," or agent IDs in user-facing updates — say "the work
+  on item #N."
+- Don't say "blocks #N's passing evidence" — say "defect #X must be fixed before we can
+  re-run the tests and show item #N working."
+- Every status update states, in order: what happened, what it means for the work item,
+  and what happens next. A reader who has not followed the session must understand it
+  cold.
+
+## Inputs
+
+The argument is a list of GitHub issue numbers (the "authorized set"). If no argument is
+given, ask once for the list before starting; that is the only permitted question.
+
+Configuration comes from the repo's `.claude/factory-loop.json` (tracker, project, column
+map, private build command, merge method, cached board IDs).
+
+## Phase 1 — Resolve the tree (before any work)
+
+1. `gh api rate_limit --jq .resources` — record the budget. Board IDs (project ID, Status
+   field ID, Status option IDs) are pre-cached in `factory-loop.json` `boardIds` — use
+   them for every card move this session. Re-fetch via GraphQL
+   (`organization(login:"ClearMeasureLabs"){projectV2(number:1){...}}`) ONLY if a
+   mutation fails with an unknown-ID error, and update `factory-loop.json` when you do.
+   All other reads/writes use REST.
+2. For every authorized item, recursively resolve
+   `gh api repos/{o}/{r}/issues/{n}/sub_issues` to the deepest descendant. The full tree
+   of every authorized item joins the work set — authorizing an epic authorizes its open
+   descendants.
+3. Build the execution order:
+   - **Children first, depth-first.** A parent/epic enters the dispatch queue only after
+     ALL of its open descendants are Done.
+   - Open leaf items (no open children) are the initial dispatch wave.
+   - Independent items (no shared ancestor-ordering constraint between them) run in
+     parallel; explicitly ordered chains run sequentially.
+4. Post the resolved tree and planned order as a comment on each authorized top-level
+   item, and print it in the session before dispatching.
+
+## Phase 2 — Dispatch one sub-session per work item
+
+For each work item whose turn has arrived, launch **one dedicated subagent** (its own
+session) via the Agent tool:
+
+- `subagent_type: "claude"` (general, full tools), `model: "sonnet"` — never Haiku.
+- `isolation: "worktree"` — every writing sub-session gets its own git worktree. No two
+  sub-sessions ever share a checkout.
+- Run in the background so independent items proceed concurrently. Cap concurrency at 3
+  writing sub-sessions to protect the GitHub API budget and local build resources.
+
+The subagent's prompt must instruct it to **run the feature loop on exactly that one work
+item**, including verbatim:
+
+> Run the feature loop on work item #N in ClearMeasureLabs/bootcamp-palermo-workorders.
+> Follow this repo's `.claude/skills/feature-loop/SKILL.md` and
+> `.claude/factory-loop.json` exactly: work in your own worktree from origin/master; one
+> board column at a time via a fresh perspective per column (design → implement →
+> verify), never skipping columns, recording no-op justifications for non-applicable
+> columns; merge origin/master into the branch and re-run the private build
+> (`pwsh -NoProfile ./privatebuild.ps1`) before any push or PR; run
+> `pwsh -NoProfile ./acceptancetests.ps1` before opening the PR; triage every bot review
+> finding (fix or explicitly decline with a PR reply) before merge; a PR is complete only
+> when every check-run `conclusion` is `success` via
+> `gh api repos/{o}/{r}/commits/{sha}/check-runs` — never a shell exit code; follow the
+> Testing Policy (unit + integration + full-system Playwright in the same PR, or an
+> explicit stated reason a layer doesn't apply). Use REST for all reads/comments; use
+> only the cached board IDs from `.claude/factory-loop.json` for card moves. Any
+> discovered follow-up work becomes a CHILD sub-issue of #N (POST the child's numeric id
+> to `repos/{o}/{r}/issues/N/sub_issues`), placed in the leftmost column — report every
+> child you create in your final summary. When #N is merged and CI-verified green, move
+> its card to the `doneForNowColumn` from factory-loop.json and report: final board
+> column, PR number, merge commit SHA, and any children created.
+
+**Anti-stall requirements — add these to every sub-session prompt verbatim:**
+
+> ANTI-STALL RULES (mandatory): (1) NO DISPATCHER CHAINS — you may spawn subagents for
+> column work, but a subagent you spawn must DO work, never merely re-delegate to another
+> subagent; at most one delegation hop below you. (2) SYNCHRONOUS FINISH — once CI is
+> green, do the bot-finding triage, merge, issue close, and card move in the SAME turn;
+> never end your turn between "CI green" and "merged". (3) When waiting on CI, poll with
+> a bounded foreground loop or a background task you own, and after EVERY resumption
+> re-check the PR state directly with `gh` before assuming anything. (4) If any gh call
+> is blocked by a permission hook or classifier, do not stop silently — report the exact
+> blocked command and error in your final message so the orchestrator can act. (5) If
+> your worktree becomes unusable, report it immediately rather than improvising outside
+> it. (6) Every wait must have a deadline: if a subagent or CI run you're waiting on has
+> made no observable progress in 20 minutes, stop waiting, check state directly, and
+> either take over the work yourself or report the blockage.
+
+## Phase 3 — Epic clamp and promotion (orchestrator's job, after every completion)
+
+When a sub-session reports completion:
+
+1. Verify its claims independently: check-runs green on the merge commit, card in the
+   reported column. Never take a subagent's word for CI.
+2. **New children discovered** by the sub-session join the work set immediately, are
+   dispatched under the same rules, and clamp their parent (below).
+3. **Clamp every affected ancestor:** for each ancestor of the completed/changed item,
+   set `ancestor_status = min(intended_status, min(status of each open child))`. An
+   ancestor is never in a more senior (further right) column than its least-advanced open
+   child, is pulled BACK (and reopened if closed) when a child appears behind it, and
+   each clamp is recorded as a comment on the ancestor naming the child that caused it.
+4. **Promote epics only by clamp release:** when the last open child of an epic reaches
+   Done, advance the epic one column at a time — each column transition performed by its
+   own dedicated subagent per the column rules (a no-op justification pass is still a
+   pass) — until it too is Done. An epic never advances in the same action that closed
+   its child.
+5. Dispatch the next queued item(s) whose prerequisites are now met.
+
+## Phase 4 — Walk-away completion
+
+The orchestrator loop continues until every item in the (grown) work set is Done or hard-
+blocked. Do not stop because the session is long; use background subagents and wait for
+their notifications — but NEVER wait on notifications alone: keep the Phase 0 watchdog
+running on its ≤15-minute cadence for the whole session, because a completed grandchild's
+notification may route to you instead of its stopped parent lane, leaving that lane
+permanently asleep. When a notification arrives from a grandchild (an agent you did not
+spawn), relay its result to the owning lane via SendMessage yourself — do not assume the
+lane saw it. If a sub-session fails, read its output, fix the dispatch (new
+subagent, corrected prompt, or a filed child defect), and continue — a local build
+failure is diagnosed to root cause, never dismissed as environmental.
+
+Finish with a single summary: per item — final column, PR, merge SHA, children created
+(and their outcomes), plus any item left blocked and exactly why.
+
+## Hard rules (restated, non-negotiable)
+
+- One subagent = one work item's current column step; no subagent carries an item across
+  multiple columns, and the orchestrator itself never edits code.
+- Every writing subagent: Sonnet + own worktree.
+- A parent never outranks its least-advanced open child on the board.
+- CI is verified via the check-runs API only.
+- REST-first; cached board IDs from `factory-loop.json`; check `rate_limit` before each
+  dispatch wave.

--- a/.claude/skills/feature-loop/SKILL.md
+++ b/.claude/skills/feature-loop/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: feature-loop
+description: >
+  Run the feature loop on ONE GitHub work item in this repo: drive it across the
+  ClearMeasureLabs project board (https://github.com/orgs/ClearMeasureLabs/projects/1)
+  one column at a time — design, implement, verify — through code, tests, a conflict-free
+  PR, API-verified green CI, bot-finding triage, merge, and board moves. Use when asked to
+  "run the feature loop on work item #N", "work issue #N through the board", or when
+  /feature-loop N is invoked. For a batch of items, use /feature-loop-dispatch instead.
+---
+
+# Feature Loop (single work item)
+
+Drives exactly one work item end-to-end. Configuration (board, columns, build commands,
+merge policy, cached board IDs) comes from `.claude/factory-loop.json` at the repo root.
+These rules are the contract for this repository; a user's own global rules may add to but
+never weaken them.
+
+## Children first, depth-first (before touching the item)
+
+Resolve `gh api repos/{owner}/{repo}/issues/{N}/sub_issues` BEFORE touching #N. Recurse to
+the deepest open descendant and work the tree bottom-up: a child is driven to Done, then
+its parent is reconsidered. A parent is never started while any of its descendants are
+open. Independent siblings may be worked in parallel — each in its own worktree. Report
+the resolved tree and execution order before starting.
+
+## Column progression
+
+- **One column at a time.** The item advances exactly one board column per transition —
+  never skips — and only after that column's work is verified. Columns and their roles
+  (design / implement / verify / terminal) are in `factory-loop.json`.
+- **Independent subagent per column.** Each column's work is done by its own dedicated
+  subagent; one column's deliverable is the next column's input. No single subagent
+  carries the item through multiple columns.
+- Non-applicable columns are passed through with a recorded no-op justification (an issue
+  comment stating why the column does not apply).
+- On completion of the loop's scope, leave the card in `doneForNowColumn` from
+  `factory-loop.json` unless the item is genuinely Done.
+
+## Subagent rules
+
+- **One git worktree per writing subagent.** Any subagent that edits files, builds, or
+  runs tests gets its own git worktree (`isolation: "worktree"`). Parallel subagents never
+  share a checkout. Read-only search agents may use the main checkout.
+- **All subagents run on Sonnet** (`model: "sonnet"`) — no stage is downgraded to Haiku.
+
+## Build, PR, and merge gates
+
+- Branch naming: `{username}/{branch-description}` (the account that initiated the session).
+- **Private build before commit:** `pwsh -NoProfile ./privatebuild.ps1` must pass.
+- **Acceptance tests before PR:** `pwsh -NoProfile ./acceptancetests.ps1`.
+- **Merge master before PR (mandatory):** before pushing or opening/updating a PR, fetch
+  and merge `origin/master` into the branch, resolve conflicts, and re-run the private
+  build. PRs must arrive conflict-free against current master.
+- **CI is API-verified only:** after pushing, poll
+  `gh api repos/{owner}/{repo}/commits/{sha}/check-runs` and confirm EVERY job's
+  `conclusion` is `success`. Never report a PR complete on "PR created" or a local build,
+  and never infer status from a shell exit code. Fix and re-push until green.
+- **Triage every bot review finding before merge:** list all review comments from
+  static-analysis bots (`github-code-quality[bot]`, `github-advanced-security[bot]`,
+  etc.). Every finding is either fixed in the same PR or explicitly declined with a
+  one-line reply on the PR. Never merge past bot findings silently.
+- Merge method and issue-close policy come from `factory-loop.json`.
+
+## Testing policy (definition of done, non-negotiable)
+
+No functionality is added or changed without automated tests **in the same PR** at every
+applicable layer:
+
+1. **Unit tests** (`src/UnitTests` — NUnit 4.x + Shouldly, bUnit for components, AutoBogus
+   for data; test doubles prefixed `Stub`).
+2. **Integration tests** (`src/IntegrationTests`) wherever the change crosses a module
+   boundary (data store, MediatR handlers, HTTP endpoints, cross-project calls).
+3. **Full-system tests** (`src/AcceptanceTests` — Playwright, driving the real UI with
+   third-party interfaces stubbed).
+
+If a layer genuinely does not apply, state explicitly in the PR description why. UI
+features MUST have a Playwright test that actually drives that UI. Respect the Onion
+Architecture dependency rules (see repo `CLAUDE.md`) — violations are auto-rejected.
+
+## Discovered work becomes a child
+
+When working #N spawns new work — a follow-up from testing, a defect found while
+implementing, a deferred bot finding — create it as a **child sub-issue** of #N, never a
+free-floating sibling, and place it in the leftmost board column:
+
+```
+child_id=$(gh api repos/{owner}/{repo}/issues/{child} --jq .id)
+gh api repos/{owner}/{repo}/issues/{N}/sub_issues -X POST -F sub_issue_id=$child_id
+gh api repos/{owner}/{repo}/issues/{N}/sub_issues   # verify
+```
+
+Note: the POST takes the child's numeric `id`, NOT its issue number.
+
+## Parent clamp
+
+A parent's board status may never be further right than the LEAST-advanced of its open
+children. Before every parent card move, list the parent's sub-issues and clamp:
+`parent_status = min(intended_status, min(status of each open child))`. A parent cannot
+reach Done while any child is open; filing a follow-up child from a late column pulls the
+parent BACK to the child's column (reopening it if closed). Record each clamp as a comment
+on the parent naming the child that caused it. The parent advances again only as its
+children advance.
+
+## GitHub API budget
+
+The GraphQL budget is shared across all agents. Use REST (`gh issue`, `gh pr`,
+`gh api repos/...`) for reads and comments. Reserve GraphQL for board field mutations,
+using the pre-cached IDs in `factory-loop.json` `boardIds` — re-fetch them only if a
+mutation fails with an unknown-ID error. Check `gh api rate_limit` before any fan-out.
+
+Card moves use:
+
+```
+gh api graphql -f query='mutation{updateProjectV2ItemFieldValue(input:{projectId:"<projectId>",itemId:"<itemId>",fieldId:"<statusFieldId>",value:{singleSelectOptionId:"<optionId>"}}){projectV2Item{id}}}'
+```
+
+(Find `itemId` for an issue via the org project: it is the ProjectV2 item ID, not the
+issue node ID.)
+
+## Reporting
+
+Every status update states, in order: what happened, what it means for the work item, and
+what happens next — plain software-team vocabulary (work item, defect, pull request,
+build, automated tests, board status), no orchestration jargon. Finish with: final board
+column, PR number, merge commit SHA, and any children created.

--- a/.claude/skills/feature-loop/SKILL.md
+++ b/.claude/skills/feature-loop/SKILL.md
@@ -47,8 +47,8 @@ the resolved tree and execution order before starting.
 ## Build, PR, and merge gates
 
 - Branch naming: `{username}/{branch-description}` (the account that initiated the session).
-- **Private build before commit:** `pwsh -NoProfile ./privatebuild.ps1` must pass.
-- **Acceptance tests before PR:** `pwsh -NoProfile ./acceptancetests.ps1`.
+- **Private build before commit:** `pwsh -NoProfile ./PrivateBuild.ps1` must pass.
+- **Acceptance tests before PR:** `pwsh -NoProfile ./AcceptanceTests.ps1`.
 - **Merge master before PR (mandatory):** before pushing or opening/updating a PR, fetch
   and merge `origin/master` into the branch, resolve conflicts, and re-run the private
   build. PRs must arrive conflict-free against current master.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,14 @@ Format: `{username}/{branch-description}`. AI agents use the username of the acc
 | Before PR | `.\acceptancetests.ps1` |
 | Docs-only changes | Skip builds |
 
+## Feature Loop
+
+Work items live on the ClearMeasureLabs project board: https://github.com/orgs/ClearMeasureLabs/projects/1
+
+- `/feature-loop N` — drive ONE work item across the board end-to-end (design → implement → verify, one column at a time, CI-verified merge). Rules: `.claude/skills/feature-loop/SKILL.md`
+- `/feature-loop-dispatch N1 N2 ...` — orchestrate a batch: children-first tree resolution, one sub-session per item, epic clamp, stall watchdog. Rules: `.claude/skills/feature-loop-dispatch/SKILL.md`
+- Board/build configuration (columns, cached board IDs, gates): `.claude/factory-loop.json`
+
 ## Further Reference
 
 - Architecture diagrams: `arch/` (C4 PlantUML + Mermaid)


### PR DESCRIPTION
Ports the feature-loop machinery into the repository so any user who clones it gets both skills working out of the box, with no dependency on user-level files:

- `.claude/skills/feature-loop/SKILL.md` — new skill defining the single-work-item loop: children-first sub-issue resolution, one board column at a time with a dedicated subagent per column, merge-master-before-PR, API-verified green CI, bot-finding triage, parent clamp rule, and the unit/integration/full-system testing policy.
- `.claude/skills/feature-loop-dispatch/` — batch orchestrator (SKILL.md) plus the `Check-StalledLanes.ps1` stall watchdog (verbatim copy), adapted to this repo and the repo-committed feature-loop skill.
- `.claude/factory-loop.json` — board configuration for https://github.com/orgs/ClearMeasureLabs/projects/1 with pre-cached project/field/option IDs, build gates (`privatebuild.ps1`, `acceptancetests.ps1`), and merge policy.
- `CLAUDE.md` — short Feature Loop section pointing to the skills and config.

Docs/config-only change — no application code touched, so no test layers apply (no module boundary crossed, no UI change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W21h68RBRjjofNE3Y9iJRL